### PR TITLE
Update the domain from gh.biblequiz.com to biblequiz.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-gh.biblequiz.com
+biblequiz.com

--- a/_config.yml
+++ b/_config.yml
@@ -44,8 +44,8 @@ google_analytics: UA-51263872-1
 #google_analytics_ga4: G-GABC1DEFG
 
 # Used for Sitemap.xml and your RSS feed
-url: http://gh.biblequiz.com
-enforce_ssl: https://gh.biblequiz.com
+url: http://biblequiz.com
+enforce_ssl: https://biblequiz.com
 baseurl: ""
 permalink: /:year/:month/:title/
 


### PR DESCRIPTION
The `gh.biblequiz.com` domain was used during development to avoid impacting the regular web site. This change will migrate `https://biblequiz.com` from the WordPress site hosted on Azure to this GitHub pages based repo.