### PR TITLE
Add remaining JBQ Nationals from ePost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Gemfile.lock
 _site
 .sass-cache
 .jekyll-cache

--- a/_pages/jbq/2009/index.md
+++ b/_pages/jbq/2009/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2009 JBQ Season"
+permalink: /jbq/2009/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+<a href="{% link _pages/jbq/2009/nationals.md %}" class="button is-primary">National Finals</a>
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2009/nationals.md
+++ b/_pages/jbq/2009/nationals.md
@@ -1,0 +1,1179 @@
+---
+layout: page
+title: "2009 National Festival: Rockford, IL"
+permalink: /jbq/2009/nationals/
+date: "2015-06-10"
+toc_title: Results
+menubar_toc: true
+---
+
+## Friday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                        | Church            | W/L  | Total | Avg    |
+|---:|-----------------------------|-------------------|------|------:|-------:|
+| 1  | Bethlehem Church            | Richmond Hill, NY | 12/2 | 2465  | 176.07 |
+| 2  | Bible Sharks                | Austin, TX        | 11/3 | 2660  | 190.00 |
+| 3  | K.J. St. N.W.               | Renton, WA        | 10/4 | 2735  | 195.36 |
+| 4  | Gospel Gators               | Sanford, FL       | 10/4 | 2310  | 165.00 |
+| 5  | Kids For Christ             | Fergus Falls, MN  | 10/4 | 2205  | 157.50 |
+| 6  | In His Image                | Chesterfield, MO  | 8/6  | 2010  | 143.57 |
+| 7  | Angel Agents                | Brookfield, WI    | 8/6  | 1960  | 140.00 |
+| 8  | Muskogee Armored Saints     | Muskogee, OK      | 7/7  | 2025  | 144.64 |
+| 9  | Bible Cadets                | Escondido, CA     | 6/8  | 1785  | 127.50 |
+| 10 | Soaring Eagles              | Poland, OH        | 6/8  | 2045  | 146.07 |
+| 11 | Jedi Masters                | Elkhart, IN       | 5/9  | 1660  | 118.57 |
+| 12 | Word Warriors               | Mendon, MA        | 4/10 | 1620  | 115.71 |
+| 13 | Ashland 1st A/G             | Ashland, AL       | 4/10 | 1810  | 129.29 |
+| 14 | Quizzer Chicks              | Pleasanton, KS    | 3/11 | 1485  | 106.07 |
+| 15 | The Crossing Place Quizzers | Franklin, LA      | 1/13 | 1320  | 94.29  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                 | Team                        | Church            | Total | Avg    | QO |
+|---:|-------------------------|-----------------------------|-------------------|------:|-------:|---:|
+| 1  | Jason Markarian         | K.J. St. N.W.               | Renton, WA        | 1680  | 120.00 | 11 |
+| 2  | Paul Willis             | Ashland 1st A/G             | Ashland, AL       | 1265  | 90.36  | 4  |
+| 3  | Jolia Madigan           | Soaring Eagles              | Poland, OH        | 1125  | 80.36  | 2  |
+| 4  | Alexandra Ross          | Bible Cadets                | Escondido, CA     | 1125  | 80.36  |    |
+| 5  | Elizabeth Cordell       | In His Image                | Chesterfield, MO  | 1105  | 78.93  | 5  |
+| 6  | Steven Mathew           | Bible Sharks                | Austin, TX        | 1065  | 76.07  |    |
+| 7  | Vanessa Steiner         | Jedi Masters                | Elkhart, IN       | 975   | 69.64  | 4  |
+| 8  | Rebecca Ford            | Bethlehem Church            | Richmond Hill, NY | 970   | 69.29  | 2  |
+| 9  | Rachel Seidel           | Kids For Christ             | Fergus Falls, MN  | 945   | 67.50  | 1  |
+| 10 | Levi Anderson           | Gospel Gators               | Sanford, FL       | 915   | 65.36  |    |
+| 11 | Mary Meddaugh           | Muskogee Armored Saints     | Muskogee, OK      | 895   | 63.93  | 3  |
+| 12 | Elijah O\'Brien         | Angel Agents                | Brookfield, WI    | 875   | 62.50  |    |
+| 13 | Peyton Goss             | Gospel Gators               | Sanford, FL       | 845   | 60.36  | 5  |
+| 14 | Rachael Singh           | Bethlehem Church            | Richmond Hill, NY | 840   | 60.00  | 1  |
+| 15 | Paul Meddaugh           | Muskogee Armored Saints     | Muskogee, OK      | 810   | 57.86  | 4  |
+| 16 | Olivia Madigan          | Soaring Eagles              | Poland, OH        | 780   | 55.71  | 7  |
+| 17 | Joel James              | Bible Sharks                | Austin, TX        | 745   | 53.21  | 1  |
+| 18 | Kelly Fischbeck         | K.J. St. N.W.               | Renton, WA        | 735   | 52.50  | 8  |
+| 19 | Jordan Landry           | The Crossing Place Quizzers | Franklin, LA      | 720   | 51.43  |    |
+| 20 | Jonathan Eckhardt       | Kids For Christ             | Fergus Falls, MN  | 695   | 49.64  | 7  |
+| 21 | Haley Melugin           | Quizzer Chicks              | Pleasanton, KS    | 680   | 48.57  |    |
+| 22 | Kelechi Emeodi          | Bible Sharks                | Austin, TX        | 655   | 46.79  | 6  |
+| 23 | Stephanie Hamel         | Word Warriors               | Mendon, MA        | 595   | 42.50  | 1  |
+| 24 | Jonathan Gomez          | Jedi Masters                | Elkhart, IN       | 590   | 42.14  | 5  |
+| 25 | Linsie Melugin          | Quizzer Chicks              | Pleasanton, KS    | 590   | 42.14  | 2  |
+| 26 | Elizabeth O\'Brien      | Angel Agents                | Brookfield, WI    | 555   | 39.64  |    |
+| 27 | Nathan Willis           | Ashland 1st A/G             | Ashland, AL       | 540   | 38.57  | 4  |
+| 28 | Jesse Ugstad            | Kids For Christ             | Fergus Falls, MN  | 510   | 36.43  |    |
+| 29 | Beatrice=Elizabeth Ross | Bible Cadets                | Escondido, CA     | 450   | 32.14  | 3  |
+| 30 | Matthew Robinson        | Gospel Gators               | Sanford, FL       | 435   | 31.07  | 2  |
+| 31 | Nicole DeSilva          | Bethlehem Church            | Richmond Hill, NY | 395   | 28.21  | 2  |
+| 32 | Rickey Bridges          | Angel Agents                | Brookfield, WI    | 380   | 27.14  | 2  |
+| 33 | Isaac Moore             | In His Image                | Chesterfield, MO  | 350   | 25.00  | 1  |
+| 34 | Devin Morrill           | Word Warriors               | Mendon, MA        | 330   | 23.57  | 2  |
+| 35 | Jacob Morton            | Muskogee Armored Saints     | Muskogee, OK      | 320   | 22.86  |    |
+| 36 | Eliott Gathman          | In His Image                | Chesterfield, MO  | 270   | 19.29  |    |
+| 36 | Bailey Bullock          | The Crossing Place Quizzers | Franklin, LA      | 270   | 19.29  |    |
+| 37 | Jessica Vannelli        | Word Warriors               | Mendon, MA        | 265   | 18.93  |    |
+| 38 | Brendon Sturgeon        | The Crossing Place Quizzers | Franklin, LA      | 215   | 15.36  |    |
+| 39 | Rebecca Grissom         | Bible Cadets                | Escondido, CA     | 210   | 15.00  |    |
+| 40 | Mark Caughey            | Word Warriors               | Mendon, MA        | 200   | 14.29  |    |
+| 41 | Katie Burke             | Word Warriors               | Mendon, MA        | 170   | 12.14  |    |
+| 42 | Daniel Kinger           | In His Image                | Chesterfield, MO  | 165   | 11.79  | 1  |
+| 43 | Nolan Griggs            | K.J. St. N.W.               | Renton, WA        | 165   | 11.79  |    |
+| 44 | Jaret Williams          | Bethlehem Church            | Richmond Hill, NY | 160   | 11.43  |    |
+| 45 | William Ubert           | Angel Agents                | Brookfield, WI    | 150   | 10.71  |    |
+| 46 | Wesley Jacobs           | K.J. St. N.W.               | Renton, WA        | 145   | 10.36  |    |
+| 47 | Sarah Kinger            | In His Image                | Chesterfield, MO  | 120   | 8.57   |    |
+| 47 | Jana Sullins            | Quizzer Chicks              | Pleasanton, KS    | 120   | 8.57   |    |
+| 47 | Josh James              | Bible Sharks                | Austin, TX        | 120   | 8.57   |    |
+| 47 | Cory Weidner            | Gospel Gators               | Sanford, FL       | 120   | 8.57   |    |
+| 48 | Heaven Collins          | Quizzer Chicks              | Pleasanton, KS    | 105   | 7.50   |    |
+| 49 | Kati Quiggle            | Jedi Masters                | Elkhart, IN       | 100   | 7.14   |    |
+| 49 | Christon Stewart        | Bethlehem Church            | Richmond Hill, NY | 100   | 7.14   |    |
+| 50 | Owen Derouen            | The Crossing Place Quizzers | Franklin, LA      | 90    | 6.43   |    |
+| 51 | Kyle Wright             | Soaring Eagles              | Poland, OH        | 80    | 5.71   |    |
+| 52 | Samuel Birrell          | Bible Sharks                | Austin, TX        | 75    | 5.36   |    |
+| 53 | Matthew Caughey         | Word Warriors               | Mendon, MA        | 60    | 4.29   |    |
+| 54 | Audrey Dearing          | Soaring Eagles              | Poland, OH        | 55    | 3.93   |    |
+| 55 | Hannah Eckhardt         | Kids For Christ             | Fergus Falls, MN  | 35    | 2.50   |    |
+| 56 | Shane Theriot           | The Crossing Place Quizzers | Franklin, LA      | 30    | 2.14   |    |
+| 57 | Mariah Seidel           | Kids For Christ             | Fergus Falls, MN  | 20    | 1.43   |    |
+| 58 | Paul Oakes              | Soaring Eagles              | Poland, OH        | 10    | .71    |    |
+| 58 | Sami Stuefen            | K.J. St. N.W.               | Renton, WA        | 10    | .71    |    |
+| 59 | Will Jordan             | Ashland 1st A/G             | Ashland, AL       | 5     | .36    |    |
+| 59 | Grace Catchings         | Ashland 1st A/G             | Ashland, AL       | 5     | .36    |    |
+| 60 | Rebecca Ramnauth        | Bethlehem Church            | Richmond Hill, NY |       | .00    |    |
+| 60 | Sarah Weeks             | Jedi Masters                | Elkhart, IN       |       | .00    |    |
+| 60 | Christina Okafor        | Bethlehem Church            | Richmond Hill, NY |       | .00    |    |
+| 60 | Caroline Coleman        | Ashland 1st A/G             | Ashland, AL       |       | .00    |    |
+| 60 | Tony DeWitt             | K.J. St. N.W.               | Renton, WA        |       | .00    |    |
+| 60 | Sam Carter              | Muskogee Armored Saints     | Muskogee, OK      |       | .00    |    |
+| 60 | Nicholas Theriot        | The Crossing Place Quizzers | Franklin, LA      |       | .00    |    |
+| 60 | Samantha Reno           | Quizzer Chicks              | Pleasanton, KS    |       | .00    |    |
+| 61 | Meranda Lowe            | Quizzer Chicks              | Pleasanton, KS    | -10   | -0.71  |    |
+| 62 | Teddy Willis            | Ashland 1st A/G             | Ashland, AL       | -5    | -0.36  |    |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                 | Church          | W/L  | Total | Avg    |
+|---:|----------------------|-----------------|------|------:|-------:|
+| 1  | Spy Warriors         | Kent, WA        | 12/3 | 3035  | 202.33 |
+| 2  | Atomic Vortex        | Springfield, MO | 11/4 | 2665  | 177.67 |
+| 3  | International A/G #1 | Warren, MI      | 11/4 | 2550  | 170.00 |
+| 4  | Kingdom Explorers    | Dallas, TX      | 10/5 | 2490  | 166.00 |
+| 5  | Kinston              | Kinston, NC     | 10/5 | 2405  | 160.33 |
+| 6  | First Responders     | Lexington, KY   | 10/5 | 2370  | 158.00 |
+| 7  | Biblikids            | Oak Creek, WI   | 8/7  | 2265  | 151.00 |
+| 8  | Reborn Army          | Lubbock, TX     | 8/7  | 2400  | 160.00 |
+| 9  | The High Pursurers   | Omaha, NE       | 7/8  | 2215  | 147.67 |
+| 10 | Swordbearers         | Springfield, VA | 7/8  | 2005  | 133.67 |
+| 11 | Harrison Thrashers   | Harrison, AR    | 7/8  | 1995  | 133.00 |
+| 12 | Built LORD Tough     | Des Moines, IA  | 6/9  | 2130  | 142.00 |
+| 13 | Bible Surfers        | Wichita, KS     | 4/11 | 1815  | 121.00 |
+| 14 | OCCEC                | Irvine, CA      | 4/11 | 1805  | 120.33 |
+| 15 | 1 Ups                | Huntington, WV  | 3/12 | 1320  | 88.00  |
+| 16 | Geneva 1st A/G       | Geneva, AL      | 2/13 | 1175  | 78.33  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                 | Church          | Total | Avg    | QO |
+|---:|------------------------|----------------------|-----------------|------:|-------:|---:|
+| 1  | Marques Proctor        | Spy Warriors         | Kent, WA        | 1715  | 114.33 | 10 |
+| 2  | Daniel Quick           | Atomic Vortex        | Springfield, MO | 1450  | 96.67  | 8  |
+| 3  | Joshua Geisler         | Bible Surfers        | Wichita, KS     | 1325  | 88.33  | 8  |
+| 4  | Samuel Grey            | Kingdom Explorers    | Dallas, TX      | 1270  | 84.67  | 8  |
+| 5  | Brayden Laakkonen      | First Responders     | Lexington, KY   | 1190  | 79.33  | 3  |
+| 6  | Justin Dodd            | Built LORD Tough     | Des Moines, IA  | 1150  | 76.67  | 3  |
+| 7  | Sam Hyatt              | Biblikids            | Oak Creek, WI   | 1100  | 73.33  | 5  |
+| 8  | Luis Torres            | Kingdom Explorers    | Dallas, TX      | 990   | 66.00  | 5  |
+| 9  | Rob Adams              | Reborn Army          | Lubbock, TX     | 930   | 62.00  | 3  |
+| 10 | Jennise George         | International A/G #1 | Warren, MI      | 920   | 61.33  | 1  |
+| 11 | Sean Watson            | Reborn Army          | Lubbock, TX     | 915   | 61.00  | 2  |
+| 12 | Ben Palensky           | The High Pursurers   | Omaha, NE       | 915   | 61.00  | 1  |
+| 13 | Landon Powell          | Kinston              | Kinston, NC     | 895   | 59.67  |    |
+| 14 | Joshua Clark           | Atomic Vortex        | Springfield, MO | 865   | 57.67  | 12 |
+| 15 | Connor White           | Kinston              | Kinston, NC     | 860   | 57.33  | 1  |
+| 16 | Makenzie Bradshaw      | Harrison Thrashers   | Harrison, AR    | 820   | 54.67  | 1  |
+| 17 | Elijah Evers           | Biblikids            | Oak Creek, WI   | 810   | 54.00  | 2  |
+| 18 | Alex McCracken         | First Responders     | Lexington, KY   | 790   | 52.67  | 7  |
+| 19 | Jeffrey Chen           | OCCEC                | Irvine, CA      | 780   | 52.00  | 2  |
+| 20 | Seth Hensley           | 1 Ups                | Huntington, WV  | 720   | 48.00  | 1  |
+| 21 | Kiersten George        | International A/G #1 | Warren, MI      | 710   | 47.33  |    |
+| 22 | Storm Gray             | Kinston              | Kinston, NC     | 650   | 43.33  | 7  |
+| 23 | Evan Still             | Harrison Thrashers   | Harrison, AR    | 610   | 40.67  |    |
+| 24 | Steve Maobelem         | Swordbearers         | Springfield, VA | 590   | 39.33  |    |
+| 25 | David Inyangson        | Swordbearers         | Springfield, VA | 570   | 38.00  | 2  |
+| 26 | Austin Shepherd        | Spy Warriors         | Kent, WA        | 540   | 36.00  | 5  |
+| 27 | Noah Hensley           | 1 Ups                | Huntington, WV  | 540   | 36.00  | 4  |
+| 28 | Grace Xu               | OCCEC                | Irvine, CA      | 540   | 36.00  |    |
+| 29 | Ariel Watson           | Reborn Army          | Lubbock, TX     | 510   | 34.00  | 2  |
+| 30 | Noah Ridgway           | Built LORD Tough     | Des Moines, IA  | 505   | 33.67  | 5  |
+| 31 | Sherlin Chacko         | International A/G #1 | Warren, MI      | 475   | 31.67  | 3  |
+| 32 | LaDawn Burkett         | Geneva 1st A/G       | Geneva, AL      | 450   | 30.00  |    |
+| 33 | Aaron Palensky         | The High Pursurers   | Omaha, NE       | 445   | 29.67  | 1  |
+| 34 | Will Brovold           | The High Pursurers   | Omaha, NE       | 415   | 27.67  | 4  |
+| 35 | Shaun Chacko           | International A/G #1 | Warren, MI      | 405   | 27.00  | 1  |
+| 36 | Tanner Harrison        | Geneva 1st A/G       | Geneva, AL      | 400   | 26.67  | 2  |
+| 37 | Keiron Fontaine        | Swordbearers         | Springfield, VA | 400   | 26.67  |    |
+| 37 | Savannah Gutterud      | Spy Warriors         | Kent, WA        | 400   | 26.67  |    |
+| 38 | Anna Kelly             | First Responders     | Lexington, KY   | 345   | 23.00  | 1  |
+| 39 | Matthew Braham         | Spy Warriors         | Kent, WA        | 340   | 22.67  | 2  |
+| 40 | Christa Dixon          | Geneva 1st A/G       | Geneva, AL      | 320   | 21.33  |    |
+| 41 | Jeremy Wu              | OCCEC                | Irvine, CA      | 295   | 19.67  | 3  |
+| 42 | Kerigan Bradshaw       | Harrison Thrashers   | Harrison, AR    | 295   | 19.67  | 1  |
+| 43 | Rooslana Rusk          | Bible Surfers        | Wichita, KS     | 285   | 19.00  |    |
+| 44 | Amelia Dixon           | Built LORD Tough     | Des Moines, IA  | 280   | 18.67  |    |
+| 45 | Abby Bailey            | Harrison Thrashers   | Harrison, AR    | 235   | 15.67  |    |
+| 46 | Matthew Geisler        | Bible Surfers        | Wichita, KS     | 230   | 15.33  | 1  |
+| 47 | Peter Tamblyn          | Biblikids            | Oak Creek, WI   | 225   | 15.00  |    |
+| 48 | Sophie Ridgway         | Built LORD Tough     | Des Moines, IA  | 200   | 13.33  |    |
+| 49 | Mason Gore             | Atomic Vortex        | Springfield, MO | 180   | 12.00  |    |
+| 50 | Hannah Quick           | Atomic Vortex        | Springfield, MO | 170   | 11.33  |    |
+| 51 | Leah Thomas            | Swordbearers         | Springfield, VA | 165   | 11.00  | 1  |
+| 52 | Amanda Kepplin         | The High Pursurers   | Omaha, NE       | 150   | 10.00  |    |
+| 52 | Elizabeth Kaffenberger | The High Pursurers   | Omaha, NE       | 150   | 10.00  |    |
+| 53 | Matthew Hetrick        | The High Pursurers   | Omaha, NE       | 140   | 9.33   |    |
+| 54 | Glenn Kaboskey         | Biblikids            | Oak Creek, WI   | 130   | 8.67   |    |
+| 55 | Harriaon Ku            | OCCEC                | Irvine, CA      | 125   | 8.33   |    |
+| 56 | Divya Mathews          | Swordbearers         | Springfield, VA | 120   | 8.00   |    |
+| 57 | Patrick Keenan         | Kingdom Explorers    | Dallas, TX      | 90    | 6.00   |    |
+| 58 | Grandison Otchere      | Swordbearers         | Springfield, VA | 85    | 5.67   |    |
+| 59 | Matthew Keenan         | Kingdom Explorers    | Dallas, TX      | 70    | 4.67   |    |
+| 60 | Sadya Ouedraogo        | Swordbearers         | Springfield, VA | 65    | 4.33   |    |
+| 60 | Ariana Zhu             | OCCEC                | Irvine, CA      | 65    | 4.33   |    |
+| 61 | Madelyn Crowl          | Harrison Thrashers   | Harrison, AR    | 60    | 4.00   |    |
+| 62 | Makayla Lowe           | 1 Ups                | Huntington, WV  | 50    | 3.33   |    |
+| 62 | AryAnna Bennett        | Kingdom Explorers    | Dallas, TX      | 50    | 3.33   |    |
+| 63 | Tyler McCracken        | First Responders     | Lexington, KY   | 45    | 3.00   |    |
+| 64 | Abby Kornechuk         | Spy Warriors         | Kent, WA        | 40    | 2.67   |    |
+| 64 | Albert George          | International A/G #1 | Warren, MI      | 40    | 2.67   |    |
+| 65 | Mason Tidwell          | Reborn Army          | Lubbock, TX     | 30    | 2.00   |    |
+| 66 | Steven Torres          | Kingdom Explorers    | Dallas, TX      | 20    | 1.33   |    |
+| 67 | Janna Gaines           | Reborn Army          | Lubbock, TX     | 15    | 1.00   |    |
+| 68 | Anna Bell              | Geneva 1st A/G       | Geneva, AL      | 10    | .67    |    |
+| 68 | Ashley Webb            | 1 Ups                | Huntington, WV  | 10    | .67    |    |
+| 68 | Phoebe Otchere         | Swordbearers         | Springfield, VA | 10    | .67    |    |
+| 69 | Daniel Piasecki        | Biblikids            | Oak Creek, WI   |       | .00    |    |
+| 69 | Joyce Williams         | Biblikids            | Oak Creek, WI   |       | .00    |    |
+| 69 | Abigail Munoz          | Kingdom Explorers    | Dallas, TX      |       | .00    |    |
+| 69 | Abby Bennett           | Kingdom Explorers    | Dallas, TX      |       | .00    |    |
+| 69 | Jonathan Laakkonen     | First Responders     | Lexington, KY   |       | .00    |    |
+| 69 | Matthew Kelly          | First Responders     | Lexington, KY   |       | .00    |    |
+| 69 | Sarah Yates            | Geneva 1st A/G       | Geneva, AL      |       | .00    |    |
+| 70 | Aaron Geisler          | Bible Surfers        | Wichita, KS     | -20   | -1.33  |    |
+| 71 | Lauren Henderson       | Harrison Thrashers   | Harrison, AR    | -10   | -0.67  |    |
+| 71 | Hayden Ballard         | Harrison Thrashers   | Harrison, AR    | -10   | -0.67  |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                                       | Church               | W/L  | Total | Avg    |
+|---:|--------------------------------------------|----------------------|------|------:|-------:|
+| 1  | Lifeguards                                 | Dayton, OH           | 13/2 | 2670  | 178.00 |
+| 2  | Wenatchee 1st A/G                          | Wenatchee, WA        | 12/3 | 2595  | 173.00 |
+| 3  | God\'s Quad Squad                          | Branson, MO          | 11/4 | 2450  | 163.33 |
+| 4  | Quiz Kids                                  | Dripping Springs, TX | 9/6  | 2415  | 161.00 |
+| 5  | Askewville                                 | Askewville, NC       | 9/6  | 2575  | 171.67 |
+| 6  | The Fruitz                                 | Kansas City, MO      | 8/7  | 2060  | 137.33 |
+| 7  | Learners Under Discipline                  | East Lansing, MI     | 8/7  | 2225  | 148.33 |
+| 8  | The Interrupters - Pardon the Interruption | Rockford, IL         | 7/8  | 2155  | 143.67 |
+| 9  | S.O.S.                                     | Kenosha, WI          | 7/8  | 2115  | 141.00 |
+| 10 | FBI (Faithful Bible Investigators)         | Lakeville, MN        | 7/8  | 2110  | 140.67 |
+| 11 | Living Hope                                | Swedesboro, NJ       | 7/8  | 2085  | 139.00 |
+| 12 | DeLand Jesus Freaks                        | DeLand, FL           | 6/9  | 1605  | 107.00 |
+| 13 | S.P.Y. Friends                             | Leesburg, VA         | 5/10 | 1875  | 125.00 |
+| 14 | JAG                                        | Meriden, KS          | 4/11 | 1770  | 118.00 |
+| 15 | Buzz Hogs                                  | Mabelvale, AR        | 4/11 | 1455  | 97.00  |
+| 16 | An Army of Three                           | Hanford, CA          | 3/12 | 1535  | 102.33 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                                       | Church               | Total | Avg    | QO |
+|---:|---------------------|--------------------------------------------|----------------------|------:|-------:|---:|
+| 1  | Blake Isaacs        | Lifeguards                                 | Dayton, OH           | 1730  | 115.33 | 10 |
+| 2  | Joseph Pingleton    | God\'s Quad Squad                          | Branson, MO          | 1645  | 109.67 | 7  |
+| 3  | Issac Kandavalli    | Living Hope                                | Swedesboro, NJ       | 1570  | 104.67 | 8  |
+| 4  | Mikylla Davy        | Wenatchee 1st A/G                          | Wenatchee, WA        | 1510  | 100.67 | 4  |
+| 5  | Devin Ferguson      | The Fruitz                                 | Kansas City, MO      | 1290  | 86.00  | 2  |
+| 6  | Ivan Landmark       | S.O.S.                                     | Kenosha, WI          | 1240  | 82.67  | 4  |
+| 7  | Nathaniel Hanson    | The Interrupters - Pardon the Interruption | Rockford, IL         | 1115  | 74.33  | 5  |
+| 8  | Alyssa Harden       | Askewville                                 | Askewville, NC       | 1070  | 71.33  | 2  |
+| 9  | Alyssa Skinner      | Quiz Kids                                  | Dripping Springs, TX | 1060  | 70.67  | 4  |
+| 10 | Maggie Daniels      | Askewville                                 | Askewville, NC       | 850   | 56.67  |    |
+| 11 | Ethan Zambrano      | FBI (Faithful Bible Investigators)         | Lakeville, MN        | 845   | 56.33  |    |
+| 12 | Derrick Barger      | JAG                                        | Meriden, KS          | 810   | 54.00  |    |
+| 13 | Jonathan Pait       | DeLand Jesus Freaks                        | DeLand, FL           | 795   | 53.00  | 1  |
+| 14 | Jenna Klein         | Learners Under Discipline                  | East Lansing, MI     | 760   | 50.67  | 2  |
+| 15 | Jared Minick        | Buzz Hogs                                  | Mabelvale, AR        | 755   | 50.33  | 2  |
+| 16 | Robert Brock        | An Army of Three                           | Hanford, CA          | 750   | 50.00  |    |
+| 17 | Austin Harr         | Learners Under Discipline                  | East Lansing, MI     | 700   | 46.67  | 8  |
+| 18 | Will Bazemore       | Askewville                                 | Askewville, NC       | 655   | 43.67  | 7  |
+| 19 | Josiah Pait         | DeLand Jesus Freaks                        | DeLand, FL           | 620   | 41.33  | 4  |
+| 20 | Erin O\'Mara        | S.P.Y. Friends                             | Leesburg, VA         | 620   | 41.33  |    |
+| 21 | Hannah Brown        | Quiz Kids                                  | Dripping Springs, TX | 615   | 41.00  |    |
+| 22 | Madison Guzman      | The Interrupters - Pardon the Interruption | Rockford, IL         | 605   | 40.33  | 3  |
+| 23 | Kelsey Anderson     | Wenatchee 1st A/G                          | Wenatchee, WA        | 595   | 39.67  | 2  |
+| 23 | Madison Heath       | FBI (Faithful Bible Investigators)         | Lakeville, MN        | 595   | 39.67  | 2  |
+| 24 | Tia Lubinski        | FBI (Faithful Bible Investigators)         | Lakeville, MN        | 580   | 38.67  |    |
+| 25 | Eden Brock          | An Army of Three                           | Hanford, CA          | 520   | 34.67  |    |
+| 26 | Brian O\'Mara       | S.P.Y. Friends                             | Leesburg, VA         | 515   | 34.33  | 4  |
+| 27 | Caleb Jones         | Lifeguards                                 | Dayton, OH           | 515   | 34.33  | 3  |
+| 28 | Gabrielle Davy      | Wenatchee 1st A/G                          | Wenatchee, WA        | 490   | 32.67  | 2  |
+| 29 | Kayla Sowers        | S.P.Y. Friends                             | Leesburg, VA         | 480   | 32.00  |    |
+| 30 | Michael Joen        | JAG                                        | Meriden, KS          | 470   | 31.33  |    |
+| 31 | Connor Ferguson     | The Fruitz                                 | Kansas City, MO      | 465   | 31.00  | 4  |
+| 32 | James Maddox        | Buzz Hogs                                  | Mabelvale, AR        | 455   | 30.33  | 2  |
+| 33 | Luke Cooper         | God\'s Quad Squad                          | Branson, MO          | 410   | 27.33  | 2  |
+| 34 | Katrina Dowdy       | Living Hope                                | Swedesboro, NJ       | 405   | 27.00  | 1  |
+| 35 | Tino Stevens        | God\'s Quad Squad                          | Branson, MO          | 395   | 26.33  | 2  |
+| 35 | Tyler McCartney     | Learners Under Discipline                  | East Lansing, MI     | 395   | 26.33  | 2  |
+| 36 | Kirsten Andrews     | Learners Under Discipline                  | East Lansing, MI     | 355   | 23.67  | 1  |
+| 37 | Reece Skinner       | Quiz Kids                                  | Dripping Springs, TX | 335   | 22.33  | 2  |
+| 38 | Daniel Evans        | JAG                                        | Meriden, KS          | 330   | 22.00  | 2  |
+| 39 | Emily Myers         | Quiz Kids                                  | Dripping Springs, TX | 325   | 21.67  | 2  |
+| 40 | Brendan Ferguson    | The Fruitz                                 | Kansas City, MO      | 305   | 20.33  | 2  |
+| 41 | Kendra Zwonitzer    | The Interrupters - Pardon the Interruption | Rockford, IL         | 305   | 20.33  |    |
+| 42 | Natalie Isaacs      | Lifeguards                                 | Dayton, OH           | 290   | 19.33  |    |
+| 43 | Trent Stafford      | An Army of Three                           | Hanford, CA          | 275   | 18.33  | 1  |
+| 44 | Dylan Hogan         | S.O.S.                                     | Kenosha, WI          | 240   | 16.00  |    |
+| 45 | Mikayla Hammrich    | S.P.Y. Friends                             | Leesburg, VA         | 230   | 15.33  |    |
+| 46 | Dustin Hogan        | S.O.S.                                     | Kenosha, WI          | 200   | 13.33  |    |
+| 47 | Samuel Landmark     | S.O.S.                                     | Kenosha, WI          | 195   | 13.00  | 1  |
+| 48 | Cameron Calabrese   | S.O.S.                                     | Kenosha, WI          | 195   | 13.00  |    |
+| 49 | Maddy Broxterman    | JAG                                        | Meriden, KS          | 160   | 10.67  |    |
+| 50 | Craig Maynard       | DeLand Jesus Freaks                        | DeLand, FL           | 145   | 9.67   |    |
+| 51 | Danielle Alita      | The Interrupters - Pardon the Interruption | Rockford, IL         | 130   | 8.67   |    |
+| 51 | Robert Maddox       | Buzz Hogs                                  | Mabelvale, AR        | 130   | 8.67   |    |
+| 52 | Bridge Biniakewitz  | Buzz Hogs                                  | Mabelvale, AR        | 115   | 7.67   |    |
+| 53 | Dena Schaeffer      | Lifeguards                                 | Dayton, OH           | 100   | 6.67   |    |
+| 54 | Faith Myers         | Quiz Kids                                  | Dripping Springs, TX | 80    | 5.33   |    |
+| 55 | Dylan Lovick        | FBI (Faithful Bible Investigators)         | Lakeville, MN        | 60    | 4.00   |    |
+| 56 | Shaun Dowdy         | Living Hope                                | Swedesboro, NJ       | 50    | 3.33   |    |
+| 57 | Courtney Andexler   | DeLand Jesus Freaks                        | DeLand, FL           | 45    | 3.00   |    |
+| 57 | Jessica Watson      | Living Hope                                | Swedesboro, NJ       | 45    | 3.00   |    |
+| 58 | Tyrone Lovick       | FBI (Faithful Bible Investigators)         | Lakeville, MN        | 30    | 2.00   |    |
+| 58 | Sarah Judd          | S.P.Y. Friends                             | Leesburg, VA         | 30    | 2.00   |    |
+| 59 | Sean Jones          | Lifeguards                                 | Dayton, OH           | 20    | 1.33   |    |
+| 59 | Audrey Petravich    | S.O.S.                                     | Kenosha, WI          | 20    | 1.33   |    |
+| 60 | Joey Jones          | Lifeguards                                 | Dayton, OH           | 15    | 1.00   |    |
+| 60 | John Schafer        | Learners Under Discipline                  | East Lansing, MI     | 15    | 1.00   |    |
+| 61 | Erin Zak            | Living Hope                                | Swedesboro, NJ       | 10    | .67    |    |
+| 62 | Hannah Hill         | Living Hope                                | Swedesboro, NJ       | 5     | .33    |    |
+| 63 | Savanah Biniakewitz | Buzz Hogs                                  | Mabelvale, AR        |       | .00    |    |
+| 63 | Trenton Page        | Buzz Hogs                                  | Mabelvale, AR        |       | .00    |    |
+| 63 | Ashley Carder       | God\'s Quad Squad                          | Branson, MO          |       | .00    |    |
+| 63 | Krystal Stotts      | The Fruitz                                 | Kansas City, MO      |       | .00    |    |
+| 63 | Hannah Alita        | The Interrupters - Pardon the Interruption | Rockford, IL         |       | .00    |    |
+| 63 | Sarah Harrison      | Askewville                                 | Askewville, NC       |       | .00    |    |
+| 63 | Maggie Smith        | Lifeguards                                 | Dayton, OH           |       | .00    |    |
+| 63 | Ben Beeson          | Lifeguards                                 | Dayton, OH           |       | .00    |    |
+| 63 | Mason Seals         | JAG                                        | Meriden, KS          |       | .00    |    |
+
+
+### Purple
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                      | Church               | W/L  | Total | Avg    |
+|---:|---------------------------|----------------------|------|------:|-------:|
+| 1  | Grace                     | New Whiteland, IN    | 11/3 | 2930  | 209.29 |
+| 2  | Goldsboro Gladius         | Goldsboro, NC        | 11/3 | 2565  | 183.21 |
+| 3  | Storm                     | Bonifay, FL          | 11/3 | 2365  | 168.93 |
+| 4  | Spy All Stars             | Kent, WA             | 10/4 | 2410  | 172.14 |
+| 5  | Normal 1st A/G            | Normal, IL           | 9/5  | 1895  | 135.36 |
+| 6  | Laffy Taffies             | Baxter, MN           | 8/6  | 2300  | 164.29 |
+| 7  | The Olympians             | Cedar Hill, TX       | 8/6  | 2210  | 157.86 |
+| 8  | Bethesda Christian Church | Sterling Heights, MI | 7/7  | 2020  | 144.29 |
+| 9  | James River Bullseye      | Ozark, MO            | 6/8  | 1720  | 122.86 |
+| 10 | Braeswood                 | Houston, TX          | 6/8  | 1600  | 114.29 |
+| 11 | JBR in da JBQ             | Bismarck, ND         | 6/8  | 1590  | 113.57 |
+| 12 | Paradise Hills Vipers     | Phoenix, AZ          | 5/9  | 1860  | 132.86 |
+| 13 | MCC Son Burst Yellow      | Mechanicsville, VA   | 4/10 | 1665  | 118.93 |
+| 14 | Calvary Church (Dunwoody) | Dunwoody, GA         | 2/12 | 1290  | 92.14  |
+| 15 | Dodson Assembly           | Dodson, LA           | 1/13 | 765   | 54.64  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                      | Church               | Total | Avg    | QO |
+|---:|---------------------|---------------------------|----------------------|------:|-------:|---:|
+| 1  | Braden Murray       | Grace                     | New Whiteland, IN    | 1630  | 116.43 | 8  |
+| 2  | Aliyah Fashaw       | Spy All Stars             | Kent, WA             | 1405  | 100.36 | 6  |
+| 3  | Bridget Farris      | Bethesda Christian Church | Sterling Heights, MI | 1340  | 95.71  | 7  |
+| 4  | Joshua Sipes        | JBR in da JBQ             | Bismarck, ND         | 1105  | 78.93  | 4  |
+| 5  | McKenzie Shepherd   | Normal 1st A/G            | Normal, IL           | 1055  | 75.36  | 3  |
+| 6  | Sabrina Justice     | Storm                     | Bonifay, FL          | 1050  | 75.00  | 3  |
+| 6  | Brianna Ruiz        | Laffy Taffies             | Baxter, MN           | 1050  | 75.00  | 3  |
+| 7  | Benjamin Ofomata    | Braeswood                 | Houston, TX          | 940   | 67.14  | 4  |
+| 8  | Kelsey Stewart      | Storm                     | Bonifay, FL          | 875   | 62.50  | 3  |
+| 9  | Chad Stogner        | Paradise Hills Vipers     | Phoenix, AZ          | 860   | 61.43  | 3  |
+| 10 | Charlie Jones       | Goldsboro Gladius         | Goldsboro, NC        | 850   | 60.71  | 6  |
+| 11 | Susanna Ferguson    | The Olympians             | Cedar Hill, TX       | 835   | 59.64  |    |
+| 12 | Jaron Klassen       | James River Bullseye      | Ozark, MO            | 830   | 59.29  | 2  |
+| 13 | Samuel Wilkerson    | Goldsboro Gladius         | Goldsboro, NC        | 800   | 57.14  | 1  |
+| 14 | Chandler Click      | The Olympians             | Cedar Hill, TX       | 795   | 56.79  | 7  |
+| 15 | Alissa Garrett      | Grace                     | New Whiteland, IN    | 685   | 48.93  | 6  |
+| 16 | Jillian Griffith    | James River Bullseye      | Ozark, MO            | 590   | 42.14  |    |
+| 17 | Samuel Borwicz      | Laffy Taffies             | Baxter, MN           | 570   | 40.71  | 1  |
+| 18 | Joshua Kukuvka      | MCC Son Burst Yellow      | Mechanicsville, VA   | 565   | 40.36  |    |
+| 19 | Koty Wojeski        | Goldsboro Gladius         | Goldsboro, NC        | 535   | 38.21  |    |
+| 20 | Elle Miller         | The Olympians             | Cedar Hill, TX       | 530   | 37.86  | 3  |
+| 21 | Josiah Duka         | Paradise Hills Vipers     | Phoenix, AZ          | 530   | 37.86  | 1  |
+| 22 | Lacon Walsh         | Normal 1st A/G            | Normal, IL           | 510   | 36.43  | 1  |
+| 23 | David Osunkwo       | Calvary Church (Dunwoody) | Dunwoody, GA         | 455   | 32.50  | 3  |
+| 24 | Lynne Borowicz      | Laffy Taffies             | Baxter, MN           | 445   | 31.79  | 5  |
+| 25 | Emily Ott           | Grace                     | New Whiteland, IN    | 440   | 31.43  |    |
+| 25 | Chi Chi Osunkwo     | Calvary Church (Dunwoody) | Dunwoody, GA         | 440   | 31.43  |    |
+| 26 | Alyssa Walker       | MCC Son Burst Yellow      | Mechanicsville, VA   | 435   | 31.07  |    |
+| 27 | Michaela Toole      | Spy All Stars             | Kent, WA             | 415   | 29.64  | 4  |
+| 28 | Raleigh Zook        | MCC Son Burst Yellow      | Mechanicsville, VA   | 415   | 29.64  | 1  |
+| 29 | Joseph Duka         | Paradise Hills Vipers     | Phoenix, AZ          | 410   | 29.29  | 3  |
+| 30 | Daniel Gallegos     | Spy All Stars             | Kent, WA             | 405   | 28.93  | 3  |
+| 31 | Brianna Sipes       | JBR in da JBQ             | Bismarck, ND         | 400   | 28.57  | 1  |
+| 32 | Travis Williams     | Dodson Assembly           | Dodson, LA           | 395   | 28.21  |    |
+| 33 | Jojo Wood           | Storm                     | Bonifay, FL          | 385   | 27.50  | 1  |
+| 34 | Derick Nwokorie     | Braeswood                 | Houston, TX          | 335   | 23.93  | 1  |
+| 35 | Randy Jones         | Goldsboro Gladius         | Goldsboro, NC        | 290   | 20.71  |    |
+| 36 | Nathan Lavender     | Normal 1st A/G            | Normal, IL           | 285   | 20.36  | 1  |
+| 37 | Kaylen Williams     | Dodson Assembly           | Dodson, LA           | 270   | 19.29  |    |
+| 38 | Alexandra Buhl      | Calvary Church (Dunwoody) | Dunwoody, GA         | 255   | 18.21  |    |
+| 39 | Moriah Tecsom       | Bethesda Christian Church | Sterling Heights, MI | 245   | 17.50  |    |
+| 40 | Michael Ragap       | Bethesda Christian Church | Sterling Heights, MI | 220   | 15.71  |    |
+| 41 | Kelise Braithwaite  | James River Bullseye      | Ozark, MO            | 200   | 14.29  | 1  |
+| 42 | Sarah Toole         | Spy All Stars             | Kent, WA             | 190   | 13.57  |    |
+| 43 | Parker Sanders      | Grace                     | New Whiteland, IN    | 175   | 12.50  |    |
+| 44 | Megan Etzweiler     | Braeswood                 | Houston, TX          | 165   | 11.79  |    |
+| 45 | Jeremy Mgbeike      | Braeswood                 | Houston, TX          | 160   | 11.43  |    |
+| 46 | Ben Stevens         | Laffy Taffies             | Baxter, MN           | 120   | 8.57   |    |
+| 46 | Jordan Hasse        | Bethesda Christian Church | Sterling Heights, MI | 120   | 8.57   |    |
+| 47 | My\'Randa Tolar     | Dodson Assembly           | Dodson, LA           | 110   | 7.86   |    |
+| 48 | Austin Barclay      | Bethesda Christian Church | Sterling Heights, MI | 95    | 6.79   | 1  |
+| 49 | Mariah Cowan        | Calvary Church (Dunwoody) | Dunwoody, GA         | 90    | 6.43   |    |
+| 49 | Robyn Patch         | JBR in da JBQ             | Bismarck, ND         | 90    | 6.43   |    |
+| 49 | Erykah Betterson    | Goldsboro Gladius         | Goldsboro, NC        | 90    | 6.43   |    |
+| 50 | Aili Dabill         | Laffy Taffies             | Baxter, MN           | 80    | 5.71   |    |
+| 51 | Abby O\'Connell     | James River Bullseye      | Ozark, MO            | 70    | 5.00   |    |
+| 51 | Amber Walker        | MCC Son Burst Yellow      | Mechanicsville, VA   | 70    | 5.00   |    |
+| 51 | Nathan Isner        | MCC Son Burst Yellow      | Mechanicsville, VA   | 70    | 5.00   |    |
+| 52 | Nathaniel Walker    | MCC Son Burst Yellow      | Mechanicsville, VA   | 60    | 4.29   |    |
+| 53 | Rebecca Yates       | Paradise Hills Vipers     | Phoenix, AZ          | 55    | 3.93   |    |
+| 54 | Noah Zook           | MCC Son Burst Yellow      | Mechanicsville, VA   | 50    | 3.57   |    |
+| 54 | Christopher Calvery | The Olympians             | Cedar Hill, TX       | 50    | 3.57   |    |
+| 54 | Chad Buurman        | Calvary Church (Dunwoody) | Dunwoody, GA         | 50    | 3.57   |    |
+| 55 | Nick Stewart        | Storm                     | Bonifay, FL          | 45    | 3.21   |    |
+| 55 | Drew Garvin         | Normal 1st A/G            | Normal, IL           | 45    | 3.21   |    |
+| 56 | Travis Griessel     | James River Bullseye      | Ozark, MO            | 30    | 2.14   |    |
+| 57 | Eva Dabill          | Laffy Taffies             | Baxter, MN           | 20    | 1.43   |    |
+| 57 | Grace Rivedl        | Laffy Taffies             | Baxter, MN           | 20    | 1.43   |    |
+| 58 | Cason Moore         | Storm                     | Bonifay, FL          | 10    | .71    |    |
+| 59 | Heidi Rasmussen     | Paradise Hills Vipers     | Phoenix, AZ          | 5     | .36    |    |
+| 60 | Dustin May          | Dodson Assembly           | Dodson, LA           |       | .00    |    |
+| 60 | Jacob Hansel        | Normal 1st A/G            | Normal, IL           |       | .00    |    |
+| 60 | Nathanael Heide     | James River Bullseye      | Ozark, MO            |       | .00    |    |
+| 60 | Devon Morris        | Calvary Church (Dunwoody) | Dunwoody, GA         |       | .00    |    |
+| 61 | Amber May           | Dodson Assembly           | Dodson, LA           | -10   | -0.71  |    |
+| 62 | Casey Macauley      | Spy All Stars             | Kent, WA             | -5    | -0.36  |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                        | Church            | W/L  | Total | Avg    |
+|---:|-----------------------------|-------------------|------|------:|-------:|
+| 1  | Sword Masters               | Zephyrhills, FL   | 13/2 | 2790  | 186.00 |
+| 2  | Power Possums               | Princeton, MN     | 9/6  | 2665  | 177.67 |
+| 3  | Master\'s Mavericks         | Grapevine, TX     | 9/6  | 2475  | 165.00 |
+| 4  | Calvary Church (Naperville) | Naperville, IL    | 9/6  | 2465  | 164.33 |
+| 5  | S.P.Y. Kids 007             | Leesburg, VA      | 9/6  | 2310  | 154.00 |
+| 6  | God\'s C.R.E.W.             | Oklahoma City, OK | 8/7  | 2200  | 146.67 |
+| 7  | Racin\' for God             | Racine, WI        | 8/7  | 2050  | 136.67 |
+| 8  | Freedom Church              | Tallahassee, FL   | 8/7  | 1990  | 132.67 |
+| 9  | Word Warriors               | Grass Lake, MI    | 7/8  | 2135  | 142.33 |
+| 10 | Smyrna River Rapids         | Smyrna, TN        | 7/8  | 2235  | 149.00 |
+| 11 | Matrix                      | Mesa, AZ          | 6/9  | 2060  | 137.33 |
+| 12 | Soul Survivors              | Lawson, MO        | 6/9  | 2030  | 135.33 |
+| 13 | Seed Sowers for Christ      | Georgetown, KY    | 6/9  | 1960  | 130.67 |
+| 14 | Evangel Eagles              | Scotch Plains, NJ | 6/9  | 1870  | 124.67 |
+| 15 | FLCC                        | Federal Way, WA   | 5/10 | 1885  | 125.67 |
+| 16 | Tru God                     | Jacksonville, AR  | 4/11 | 1880  | 125.33 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                        | Church            | Total | Avg    | QO |
+|---:|---------------------|-----------------------------|-------------------|------:|-------:|---:|
+| 1  | Abby Rogers         | Sword Masters               | Zephyrhills, FL   | 2055  | 137.00 | 12 |
+| 2  | Thomas Stewart      | Power Possums               | Princeton, MN     | 1590  | 106.00 | 6  |
+| 3  | Benjamin Smith      | Smyrna River Rapids         | Smyrna, TN        | 1520  | 101.33 | 6  |
+| 4  | Zachary Cook        | Soul Survivors              | Lawson, MO        | 1420  | 94.67  | 7  |
+| 5  | Grace Geesey        | Matrix                      | Mesa, AZ          | 1410  | 94.00  | 2  |
+| 6  | Tim Lester          | Word Warriors               | Grass Lake, MI    | 1380  | 92.00  | 4  |
+| 7  | Christopher Turner  | Seed Sowers for Christ      | Georgetown, KY    | 1320  | 88.00  | 5  |
+| 8  | David Brauchler     | Master\'s Mavericks         | Grapevine, TX     | 1310  | 87.33  | 5  |
+| 9  | Patrick Kilgallon   | Calvary Church (Naperville) | Naperville, IL    | 1190  | 79.33  | 10 |
+| 10 | Sean Daniels        | Racin\' for God             | Racine, WI        | 1005  | 67.00  | 8  |
+| 11 | Josh Rozelle        | S.P.Y. Kids 007             | Leesburg, VA      | 995   | 66.33  | 2  |
+| 12 | Benjamin Judd       | S.P.Y. Kids 007             | Leesburg, VA      | 930   | 62.00  | 9  |
+| 13 | Shreanna Powell     | Calvary Church (Naperville) | Naperville, IL    | 925   | 61.67  | 2  |
+| 14 | Damon Comfort       | God\'s C.R.E.W.             | Oklahoma City, OK | 890   | 59.33  | 2  |
+| 15 | Samantha Anderson   | Tru God                     | Jacksonville, AR  | 850   | 56.67  | 1  |
+| 16 | Hannah Stephens     | Freedom Church              | Tallahassee, FL   | 825   | 55.00  | 3  |
+| 17 | Christina Baxter    | God\'s C.R.E.W.             | Oklahoma City, OK | 820   | 54.67  | 1  |
+| 18 | Anshel Bright       | Evangel Eagles              | Scotch Plains, NJ | 800   | 53.33  | 1  |
+| 19 | Jacob Jeter         | Master\'s Mavericks         | Grapevine, TX     | 665   | 44.33  | 4  |
+| 20 | Ruth Anne Sanderson | Evangel Eagles              | Scotch Plains, NJ | 640   | 42.67  | 7  |
+| 21 | Cassidy Boyce       | FLCC                        | Federal Way, WA   | 635   | 42.33  | 6  |
+| 22 | Jonathan Larson     | FLCC                        | Federal Way, WA   | 610   | 40.67  | 1  |
+| 23 | Marina Tinney       | Seed Sowers for Christ      | Georgetown, KY    | 590   | 39.33  | 4  |
+| 24 | Nicolas Boyce       | FLCC                        | Federal Way, WA   | 560   | 37.33  |    |
+| 25 | Micah Roelofs       | Power Possums               | Princeton, MN     | 555   | 37.00  | 3  |
+| 26 | Lyndsey Sykes       | Freedom Church              | Tallahassee, FL   | 500   | 33.33  | 3  |
+| 27 | Johnny Trail        | God\'s C.R.E.W.             | Oklahoma City, OK | 490   | 32.67  | 3  |
+| 28 | Jaden Werley        | Master\'s Mavericks         | Grapevine, TX     | 475   | 31.67  | 2  |
+| 28 | Matthew Lester      | Word Warriors               | Grass Lake, MI    | 475   | 31.67  | 2  |
+| 29 | Laura Cardenas      | Racin\' for God             | Racine, WI        | 475   | 31.67  |    |
+| 30 | Stephen Thomas      | Evangel Eagles              | Scotch Plains, NJ | 425   | 28.33  | 1  |
+| 31 | Lilly Seigrist      | Tru God                     | Jacksonville, AR  | 410   | 27.33  | 2  |
+| 32 | Breanna Cole        | Soul Survivors              | Lawson, MO        | 370   | 24.67  | 2  |
+| 33 | Taylor Rich         | Tru God                     | Jacksonville, AR  | 370   | 24.67  |    |
+| 34 | Rachael Meley       | Matrix                      | Mesa, AZ          | 360   | 24.00  |    |
+| 35 | Nicholas Wolbert    | Power Possums               | Princeton, MN     | 355   | 23.67  |    |
+| 36 | Zachary McClellan   | Sword Masters               | Zephyrhills, FL   | 350   | 23.33  | 1  |
+| 37 | Abigail DeGraff     | Calvary Church (Naperville) | Naperville, IL    | 340   | 22.67  | 3  |
+| 38 | Reanna Toeller      | Racin\' for God             | Racine, WI        | 305   | 20.33  |    |
+| 39 | Connell Donoghue    | Freedom Church              | Tallahassee, FL   | 280   | 18.67  |    |
+| 39 | Joshua Wilcox       | Sword Masters               | Zephyrhills, FL   | 280   | 18.67  |    |
+| 40 | Robyn Sharp         | Smyrna River Rapids         | Smyrna, TN        | 270   | 18.00  |    |
+| 41 | Dillon Matherne     | Smyrna River Rapids         | Smyrna, TN        | 265   | 17.67  |    |
+| 42 | Caleb Stephens      | Freedom Church              | Tallahassee, FL   | 260   | 17.33  |    |
+| 43 | Kyra Hintz          | Matrix                      | Mesa, AZ          | 250   | 16.67  |    |
+| 44 | Matthew Bozzay      | S.P.Y. Kids 007             | Leesburg, VA      | 245   | 16.33  |    |
+| 45 | Halie Miller        | Tru God                     | Jacksonville, AR  | 220   | 14.67  | 1  |
+| 46 | Alexander Smith     | Smyrna River Rapids         | Smyrna, TN        | 180   | 12.00  | 1  |
+| 47 | Jonathan Archer     | Soul Survivors              | Lawson, MO        | 175   | 11.67  |    |
+| 48 | Montana Sager       | Word Warriors               | Grass Lake, MI    | 160   | 10.67  |    |
+| 49 | Caleb Daniels       | Power Possums               | Princeton, MN     | 155   | 10.33  |    |
+| 50 | Christina Belmares  | Racin\' for God             | Racine, WI        | 145   | 9.67   |    |
+| 51 | Isabella Frazier    | Freedom Church              | Tallahassee, FL   | 125   | 8.33   |    |
+| 52 | Liz Ashley          | Racin\' for God             | Racine, WI        | 120   | 8.00   |    |
+| 53 | Riley McClellan     | Sword Masters               | Zephyrhills, FL   | 105   | 7.00   |    |
+| 54 | Alex Roth           | Word Warriors               | Grass Lake, MI    | 95    | 6.33   |    |
+| 55 | Luke Yoder          | S.P.Y. Kids 007             | Leesburg, VA      | 90    | 6.00   |    |
+| 56 | Maddie Hawkes       | FLCC                        | Federal Way, WA   | 80    | 5.33   |    |
+| 57 | Shane Emry          | Soul Survivors              | Lawson, MO        | 70    | 4.67   |    |
+| 58 | Sarah Steinbach     | Seed Sowers for Christ      | Georgetown, KY    | 60    | 4.00   |    |
+| 59 | Daniel Bozzay       | S.P.Y. Kids 007             | Leesburg, VA      | 50    | 3.33   |    |
+| 60 | Alexis Wilcox       | Matrix                      | Mesa, AZ          | 40    | 2.67   |    |
+| 61 | Ciara Cruz          | Master\'s Mavericks         | Grapevine, TX     | 30    | 2.00   |    |
+| 61 | Brianne Durham      | Tru God                     | Jacksonville, AR  | 30    | 2.00   |    |
+| 61 | Logan Wimbish       | Word Warriors               | Grass Lake, MI    | 30    | 2.00   |    |
+| 62 | Robert Laboy        | Calvary Church (Naperville) | Naperville, IL    | 20    | 1.33   |    |
+| 63 | Shannon Tinney      | Seed Sowers for Christ      | Georgetown, KY    | 10    | .67    |    |
+| 63 | Samantha Roth       | Word Warriors               | Grass Lake, MI    | 10    | .67    |    |
+| 63 | Gabe Kolhoff        | Power Possums               | Princeton, MN     | 10    | .67    |    |
+| 64 | Daniel Persaud      | Evangel Eagles              | Scotch Plains, NJ | 5     | .33    |    |
+| 65 | Shannon Lojeski     | Racin\' for God             | Racine, WI        |       | .00    |    |
+| 65 | Kaden               | Matrix                      | Mesa, AZ          |       | .00    |    |
+| 65 | Katherine Bozzay    | S.P.Y. Kids 007             | Leesburg, VA      |       | .00    |    |
+| 65 | Brianna Haufman     | Evangel Eagles              | Scotch Plains, NJ |       | .00    |    |
+| 65 | Catherine Baxter    | God\'s C.R.E.W.             | Oklahoma City, OK |       | .00    |    |
+| 65 | Rachel Sharp        | Smyrna River Rapids         | Smyrna, TN        |       | .00    |    |
+| 65 | Autumn Pettit       | Seed Sowers for Christ      | Georgetown, KY    |       | .00    |    |
+| 65 | Elijah Pettit       | Seed Sowers for Christ      | Georgetown, KY    |       | .00    |    |
+| 66 | Elizabeth Steinbach | Seed Sowers for Christ      | Georgetown, KY    | -20   | -1.33  |    |
+| 67 | Gavin Wimbish       | Word Warriors               | Grass Lake, MI    | -5    | -0.33  |    |
+
+
+## Saturday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                               | Church          | W/L | Total | Avg    |
+|---:|------------------------------------|-----------------|-----|------:|-------:|
+| 1  | The High Pursurers                 | Omaha, NE       | 6/3 | 1515  | 168.33 |
+| 2  | Swordbearers                       | Springfield, VA | 6/3 | 1395  | 155.00 |
+| 3  | Soaring Eagles                     | Poland, OH      | 6/3 | 1305  | 145.00 |
+| 4  | Braeswood                          | Houston, TX     | 5/4 | 1040  | 115.56 |
+| 5  | James River Bullseye               | Ozark, MO       | 5/4 | 1490  | 165.56 |
+| 6  | FBI (Faithful Bible Investigators) | Lakeville, MN   | 4/5 | 1330  | 147.78 |
+| 7  | S.O.S.                             | Kenosha, WI     | 4/5 | 1300  | 144.44 |
+| 8  | Smyrna River Rapids                | Smyrna, TN      | 4/5 | 1280  | 142.22 |
+| 9  | Word Warriors                      | Grass Lake, MI  | 4/5 | 1230  | 136.67 |
+| 10 | Bible Cadets                       | Escondido, CA   | 1/8 | 920   | 102.22 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                 | Team                               | Church          | Total | Avg   | QO |
+|---:|-------------------------|------------------------------------|-----------------|------:|------:|---:|
+| 1  | Benjamin Smith          | Smyrna River Rapids                | Smyrna, TN      | 870   | 96.67 | 3  |
+| 2  | Benjamin Ofomata        | Braeswood                          | Houston, TX     | 805   | 89.44 | 5  |
+| 3  | Jolia Madigan           | Soaring Eagles                     | Poland, OH      | 805   | 89.44 |    |
+| 4  | Tim Lester              | Word Warriors                      | Grass Lake, MI  | 755   | 83.89 | 1  |
+| 5  | Ethan Zambrano          | FBI (Faithful Bible Investigators) | Lakeville, MN   | 710   | 78.89 | 1  |
+| 6  | Ivan Landmark           | S.O.S.                             | Kenosha, WI     | 685   | 76.11 | 2  |
+| 7  | Ben Palensky            | The High Pursurers                 | Omaha, NE       | 655   | 72.78 | 1  |
+| 8  | Jaron Klassen           | James River Bullseye               | Ozark, MO       | 650   | 72.22 | 1  |
+| 9  | Jillian Griffith        | James River Bullseye               | Ozark, MO       | 575   | 63.89 | 1  |
+| 10 | Alexandra Ross          | Bible Cadets                       | Escondido, CA   | 540   | 60.00 |    |
+| 11 | Steve Maobelem          | Swordbearers                       | Springfield, VA | 405   | 45.00 | 1  |
+| 12 | Aaron Palensky          | The High Pursurers                 | Omaha, NE       | 385   | 42.78 | 2  |
+| 13 | Keiron Fontaine         | Swordbearers                       | Springfield, VA | 380   | 42.22 |    |
+| 14 | Olivia Madigan          | Soaring Eagles                     | Poland, OH      | 330   | 36.67 | 1  |
+| 15 | Matthew Lester          | Word Warriors                      | Grass Lake, MI  | 325   | 36.11 | 2  |
+| 16 | Will Brovold            | The High Pursurers                 | Omaha, NE       | 290   | 32.22 | 1  |
+| 17 | Madison Heath           | FBI (Faithful Bible Investigators) | Lakeville, MN   | 280   | 31.11 | 2  |
+| 18 | Tia Lubinski            | FBI (Faithful Bible Investigators) | Lakeville, MN   | 280   | 31.11 |    |
+| 19 | Beatrice=Elizabeth Ross | Bible Cadets                       | Escondido, CA   | 245   | 27.22 |    |
+| 20 | David Inyangson         | Swordbearers                       | Springfield, VA | 240   | 26.67 |    |
+| 21 | Dylan Hogan             | S.O.S.                             | Kenosha, WI     | 175   | 19.44 | 1  |
+| 22 | Kelise Braithwaite      | James River Bullseye               | Ozark, MO       | 160   | 17.78 | 1  |
+| 23 | Robyn Sharp             | Smyrna River Rapids                | Smyrna, TN      | 160   | 17.78 |    |
+| 24 | Dustin Hogan            | S.O.S.                             | Kenosha, WI     | 150   | 16.67 | 1  |
+| 25 | Dillon Matherne         | Smyrna River Rapids                | Smyrna, TN      | 145   | 16.11 |    |
+| 25 | Elizabeth Kaffenberger  | The High Pursurers                 | Omaha, NE       | 145   | 16.11 |    |
+| 26 | Rebecca Grissom         | Bible Cadets                       | Escondido, CA   | 135   | 15.00 |    |
+| 27 | Grandison Otchere       | Swordbearers                       | Springfield, VA | 125   | 13.89 | 1  |
+| 28 | Megan Etzweiler         | Braeswood                          | Houston, TX     | 120   | 13.33 |    |
+| 29 | Kyle Wright             | Soaring Eagles                     | Poland, OH      | 110   | 12.22 |    |
+| 30 | Alexander Smith         | Smyrna River Rapids                | Smyrna, TN      | 105   | 11.67 |    |
+| 31 | Divya Mathews           | Swordbearers                       | Springfield, VA | 100   | 11.11 | 1  |
+| 32 | Leah Thomas             | Swordbearers                       | Springfield, VA | 100   | 11.11 |    |
+| 33 | Samuel Landmark         | S.O.S.                             | Kenosha, WI     | 90    | 10.00 | 1  |
+| 34 | Abby O\'Connell         | James River Bullseye               | Ozark, MO       | 85    | 9.44  |    |
+| 35 | Audrey Petravich        | S.O.S.                             | Kenosha, WI     | 80    | 8.89  |    |
+| 36 | Alex Roth               | Word Warriors                      | Grass Lake, MI  | 70    | 7.78  |    |
+| 37 | Cameron Calabrese       | S.O.S.                             | Kenosha, WI     | 60    | 6.67  |    |
+| 37 | Derick Nwokorie         | Braeswood                          | Houston, TX     | 60    | 6.67  |    |
+| 38 | Jeremy Mgbeike          | Braeswood                          | Houston, TX     | 55    | 6.11  |    |
+| 39 | Montana Sager           | Word Warriors                      | Grass Lake, MI  | 50    | 5.56  |    |
+| 40 | Dylan Lovick            | FBI (Faithful Bible Investigators) | Lakeville, MN   | 45    | 5.00  |    |
+| 41 | Audrey Dearing          | Soaring Eagles                     | Poland, OH      | 40    | 4.44  |    |
+| 42 | Matthew Hetrick         | The High Pursurers                 | Omaha, NE       | 30    | 3.33  |    |
+| 43 | Logan Wimbish           | Word Warriors                      | Grass Lake, MI  | 25    | 2.78  |    |
+| 43 | Sadya Ouedraogo         | Swordbearers                       | Springfield, VA | 25    | 2.78  |    |
+| 44 | Paul Oakes              | Soaring Eagles                     | Poland, OH      | 20    | 2.22  |    |
+| 44 | Phoebe Otchere          | Swordbearers                       | Springfield, VA | 20    | 2.22  |    |
+| 45 | Tyrone Lovick           | FBI (Faithful Bible Investigators) | Lakeville, MN   | 15    | 1.67  |    |
+| 46 | Samantha Roth           | Word Warriors                      | Grass Lake, MI  | 10    | 1.11  |    |
+| 46 | Nathanael Heide         | James River Bullseye               | Ozark, MO       | 10    | 1.11  |    |
+| 46 | Amanda Kepplin          | The High Pursurers                 | Omaha, NE       | 10    | 1.11  |    |
+| 46 | Travis Griessel         | James River Bullseye               | Ozark, MO       | 10    | 1.11  |    |
+| 47 | Rachel Sharp            | Smyrna River Rapids                | Smyrna, TN      |       | .00   |    |
+| 47 | Gavin Wimbish           | Word Warriors                      | Grass Lake, MI  |       | .00   |    |
+
+
+### Gray
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                        | Church           | W/L | Total | Avg    |
+|--:|-----------------------------|------------------|-----|------:|-------:|
+| 1 | Tru God                     | Jacksonville, AR | 7/1 | 1240  | 155.00 |
+| 2 | FLCC                        | Federal Way, WA  | 6/2 | 1540  | 192.50 |
+| 3 | Buzz Hogs                   | Mabelvale, AR    | 6/2 | 1265  | 158.13 |
+| 4 | Calvary Church (Dunwoody)   | Dunwoody, GA     | 5/3 | 1115  | 139.38 |
+| 5 | An Army of Three            | Hanford, CA      | 4/4 | 995   | 124.38 |
+| 6 | Geneva 1st A/G              | Geneva, AL       | 3/5 | 1000  | 125.00 |
+| 7 | The Crossing Place Quizzers | Franklin, LA     | 3/5 | 1065  | 133.13 |
+| 8 | 1 Ups                       | Huntington, WV   | 2/6 | 760   | 95.00  |
+| 9 | Dodson Assembly             | Dodson, LA       | 0/8 | 530   | 66.25  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                        | Church           | Total | Avg   | QO |
+|---:|---------------------|-----------------------------|------------------|------:|------:|---:|
+| 1  | Jared Minick        | Buzz Hogs                   | Mabelvale, AR    | 725   | 90.63 | 4  |
+| 2  | Jordan Landry       | The Crossing Place Quizzers | Franklin, LA     | 700   | 87.50 | 3  |
+| 3  | Samantha Anderson   | Tru God                     | Jacksonville, AR | 550   | 68.75 | 1  |
+| 4  | Jonathan Larson     | FLCC                        | Federal Way, WA  | 530   | 66.25 | 1  |
+| 5  | Nicolas Boyce       | FLCC                        | Federal Way, WA  | 530   | 66.25 |    |
+| 6  | Eden Brock          | An Army of Three            | Hanford, CA      | 475   | 59.38 | 2  |
+| 7  | Seth Hensley        | 1 Ups                       | Huntington, WV   | 450   | 56.25 | 2  |
+| 8  | Cassidy Boyce       | FLCC                        | Federal Way, WA  | 440   | 55.00 | 5  |
+| 9  | Alexandra Buhl      | Calvary Church (Dunwoody)   | Dunwoody, GA     | 415   | 51.88 |    |
+| 10 | James Maddox        | Buzz Hogs                   | Mabelvale, AR    | 400   | 50.00 | 6  |
+| 11 | Chi Chi Osunkwo     | Calvary Church (Dunwoody)   | Dunwoody, GA     | 375   | 46.88 | 1  |
+| 12 | Taylor Rich         | Tru God                     | Jacksonville, AR | 375   | 46.88 |    |
+| 13 | Christa Dixon       | Geneva 1st A/G              | Geneva, AL       | 345   | 43.13 |    |
+| 14 | Robert Brock        | An Army of Three            | Hanford, CA      | 340   | 42.50 | 1  |
+| 15 | Tanner Harrison     | Geneva 1st A/G              | Geneva, AL       | 325   | 40.63 | 3  |
+| 16 | LaDawn Burkett      | Geneva 1st A/G              | Geneva, AL       | 310   | 38.75 |    |
+| 17 | Noah Hensley        | 1 Ups                       | Huntington, WV   | 285   | 35.63 | 3  |
+| 18 | Travis Williams     | Dodson Assembly             | Dodson, LA       | 250   | 31.25 |    |
+| 19 | Lilly Seigrist      | Tru God                     | Jacksonville, AR | 235   | 29.38 | 2  |
+| 20 | David Osunkwo       | Calvary Church (Dunwoody)   | Dunwoody, GA     | 195   | 24.38 | 2  |
+| 21 | Trent Stafford      | An Army of Three            | Hanford, CA      | 185   | 23.13 | 2  |
+| 22 | Brendon Sturgeon    | The Crossing Place Quizzers | Franklin, LA     | 175   | 21.88 | 1  |
+| 23 | My\'Randa Tolar     | Dodson Assembly             | Dodson, LA       | 130   | 16.25 |    |
+| 24 | Bridge Biniakewitz  | Buzz Hogs                   | Mabelvale, AR    | 105   | 13.13 |    |
+| 25 | Owen Derouen        | The Crossing Place Quizzers | Franklin, LA     | 100   | 12.50 |    |
+| 26 | Kaylen Williams     | Dodson Assembly             | Dodson, LA       | 90    | 11.25 |    |
+| 26 | Mariah Cowan        | Calvary Church (Dunwoody)   | Dunwoody, GA     | 90    | 11.25 |    |
+| 27 | Bailey Bullock      | The Crossing Place Quizzers | Franklin, LA     | 80    | 10.00 |    |
+| 27 | Halie Miller        | Tru God                     | Jacksonville, AR | 80    | 10.00 |    |
+| 28 | Amber May           | Dodson Assembly             | Dodson, LA       | 60    | 7.50  |    |
+| 29 | Chad Buurman        | Calvary Church (Dunwoody)   | Dunwoody, GA     | 40    | 5.00  |    |
+| 29 | Maddie Hawkes       | FLCC                        | Federal Way, WA  | 40    | 5.00  |    |
+| 30 | Robert Maddox       | Buzz Hogs                   | Mabelvale, AR    | 35    | 4.38  |    |
+| 31 | Makayla Lowe        | 1 Ups                       | Huntington, WV   | 30    | 3.75  |    |
+| 32 | Sarah Yates         | Geneva 1st A/G              | Geneva, AL       | 20    | 2.50  |    |
+| 33 | Shane Theriot       | The Crossing Place Quizzers | Franklin, LA     | 10    | 1.25  |    |
+| 34 | Trenton Page        | Buzz Hogs                   | Mabelvale, AR    |       | .00   |    |
+| 34 | Savanah Biniakewitz | Buzz Hogs                   | Mabelvale, AR    |       | .00   |    |
+| 34 | Anna Bell           | Geneva 1st A/G              | Geneva, AL       |       | .00   |    |
+| 34 | Dustin May          | Dodson Assembly             | Dodson, LA       |       | .00   |    |
+| 34 | Nicholas Theriot    | The Crossing Place Quizzers | Franklin, LA     |       | .00   |    |
+| 34 | Brianne Durham      | Tru God                     | Jacksonville, AR |       | .00   |    |
+| 34 | Devon Morris        | Calvary Church (Dunwoody)   | Dunwoody, GA     |       | .00   |    |
+| 35 | Ashley Webb         | 1 Ups                       | Huntington, WV   | -5    | -0.63 |    |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                   | Church             | W/L | Total | Avg    |
+|--:|------------------------|--------------------|-----|------:|-------:|
+| 1 | Evangel Eagles         | Scotch Plains, NJ  | 8/0 | 1635  | 204.38 |
+| 2 | JAG                    | Meriden, KS        | 6/2 | 1235  | 154.38 |
+| 3 | S.P.Y. Friends         | Leesburg, VA       | 5/3 | 1170  | 146.25 |
+| 4 | MCC Son Burst Yellow   | Mechanicsville, VA | 4/4 | 1260  | 157.50 |
+| 5 | Quizzer Chicks         | Pleasanton, KS     | 3/5 | 1035  | 129.38 |
+| 6 | Seed Sowers for Christ | Georgetown, KY     | 3/5 | 1010  | 126.25 |
+| 7 | Bible Surfers          | Wichita, KS        | 3/5 | 1005  | 125.63 |
+| 8 | OCCEC                  | Irvine, CA         | 2/6 | 960   | 120.00 |
+| 9 | Ashland 1st A/G        | Ashland, AL        | 2/6 | 895   | 111.88 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                   | Church             | Total | Avg    | QO |
+|---:|---------------------|------------------------|--------------------|------:|-------:|---:|
+| 1  | Anshel Bright       | Evangel Eagles         | Scotch Plains, NJ  | 860   | 107.50 | 4  |
+| 2  | Joshua Geisler      | Bible Surfers          | Wichita, KS        | 725   | 90.63  | 4  |
+| 3  | Christopher Turner  | Seed Sowers for Christ | Georgetown, KY     | 700   | 87.50  | 3  |
+| 4  | Joshua Kukuvka      | MCC Son Burst Yellow   | Mechanicsville, VA | 630   | 78.75  | 3  |
+| 5  | Derrick Barger      | JAG                    | Meriden, KS        | 605   | 75.63  | 2  |
+| 6  | Linsie Melugin      | Quizzer Chicks         | Pleasanton, KS     | 570   | 71.25  | 2  |
+| 7  | Erin O\'Mara        | S.P.Y. Friends         | Leesburg, VA       | 555   | 69.38  |    |
+| 8  | Paul Willis         | Ashland 1st A/G        | Ashland, AL        | 530   | 66.25  | 2  |
+| 9  | Jeffrey Chen        | OCCEC                  | Irvine, CA         | 480   | 60.00  |    |
+| 10 | Ruth Anne Sanderson | Evangel Eagles         | Scotch Plains, NJ  | 435   | 54.38  | 5  |
+| 11 | Nathan Willis       | Ashland 1st A/G        | Ashland, AL        | 355   | 44.38  | 3  |
+| 12 | Michael Joen        | JAG                    | Meriden, KS        | 345   | 43.13  |    |
+| 13 | Brian O\'Mara       | S.P.Y. Friends         | Leesburg, VA       | 330   | 41.25  | 3  |
+| 14 | Stephen Thomas      | Evangel Eagles         | Scotch Plains, NJ  | 315   | 39.38  |    |
+| 15 | Marina Tinney       | Seed Sowers for Christ | Georgetown, KY     | 290   | 36.25  | 2  |
+| 16 | Haley Melugin       | Quizzer Chicks         | Pleasanton, KS     | 290   | 36.25  |    |
+| 17 | Rooslana Rusk       | Bible Surfers          | Wichita, KS        | 235   | 29.38  | 1  |
+| 18 | Grace Xu            | OCCEC                  | Irvine, CA         | 190   | 23.75  |    |
+| 18 | Kayla Sowers        | S.P.Y. Friends         | Leesburg, VA       | 190   | 23.75  |    |
+| 19 | Raleigh Zook        | MCC Son Burst Yellow   | Mechanicsville, VA | 160   | 20.00  | 1  |
+| 20 | Alyssa Walker       | MCC Son Burst Yellow   | Mechanicsville, VA | 160   | 20.00  |    |
+| 21 | Maddy Broxterman    | JAG                    | Meriden, KS        | 155   | 19.38  |    |
+| 22 | Daniel Evans        | JAG                    | Meriden, KS        | 130   | 16.25  |    |
+| 23 | Jeremy Wu           | OCCEC                  | Irvine, CA         | 125   | 15.63  | 1  |
+| 24 | Harriaon Ku         | OCCEC                  | Irvine, CA         | 110   | 13.75  |    |
+| 25 | Heaven Collins      | Quizzer Chicks         | Pleasanton, KS     | 105   | 13.13  |    |
+| 26 | Amber Walker        | MCC Son Burst Yellow   | Mechanicsville, VA | 100   | 12.50  |    |
+| 27 | Mikayla Hammrich    | S.P.Y. Friends         | Leesburg, VA       | 95    | 11.88  |    |
+| 28 | Noah Zook           | MCC Son Burst Yellow   | Mechanicsville, VA | 85    | 10.63  | 1  |
+| 29 | Nathaniel Walker    | MCC Son Burst Yellow   | Mechanicsville, VA | 65    | 8.13   |    |
+| 30 | Nathan Isner        | MCC Son Burst Yellow   | Mechanicsville, VA | 60    | 7.50   |    |
+| 31 | Ariana Zhu          | OCCEC                  | Irvine, CA         | 55    | 6.88   |    |
+| 32 | Matthew Geisler     | Bible Surfers          | Wichita, KS        | 45    | 5.63   |    |
+| 33 | Sarah Steinbach     | Seed Sowers for Christ | Georgetown, KY     | 35    | 4.38   |    |
+| 34 | Meranda Lowe        | Quizzer Chicks         | Pleasanton, KS     | 30    | 3.75   |    |
+| 34 | Daniel Persaud      | Evangel Eagles         | Scotch Plains, NJ  | 30    | 3.75   |    |
+| 35 | Jana Sullins        | Quizzer Chicks         | Pleasanton, KS     | 20    | 2.50   |    |
+| 35 | Samantha Reno       | Quizzer Chicks         | Pleasanton, KS     | 20    | 2.50   |    |
+| 36 | Grace Catchings     | Ashland 1st A/G        | Ashland, AL        | 10    | 1.25   |    |
+| 37 | Will Jordan         | Ashland 1st A/G        | Ashland, AL        | 5     | .63    |    |
+| 38 | Brianna Haufman     | Evangel Eagles         | Scotch Plains, NJ  |       | .00    |    |
+| 38 | Sarah Judd          | S.P.Y. Friends         | Leesburg, VA       |       | .00    |    |
+| 38 | Mason Seals         | JAG                    | Meriden, KS        |       | .00    |    |
+| 38 | Aaron Geisler       | Bible Surfers          | Wichita, KS        |       | .00    |    |
+| 38 | Autumn Pettit       | Seed Sowers for Christ | Georgetown, KY     |       | .00    |    |
+| 38 | Elijah Pettit       | Seed Sowers for Christ | Georgetown, KY     |       | .00    |    |
+| 38 | Teddy Willis        | Ashland 1st A/G        | Ashland, AL        |       | .00    |    |
+| 39 | Shannon Tinney      | Seed Sowers for Christ | Georgetown, KY     | -10   | -1.25  |    |
+| 40 | Caroline Coleman    | Ashland 1st A/G        | Ashland, AL        | -5    | -0.63  |    |
+| 40 | Elizabeth Steinbach | Seed Sowers for Christ | Georgetown, KY     | -5    | -0.63  |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team             | Church            | W/L | Total | Avg    |
+|--:|------------------|-------------------|-----|------:|-------:|
+| 1 | S.P.Y. Kids 007  | Leesburg, VA      | 7/2 | 1465  | 162.78 |
+| 2 | Kinston          | Kinston, NC       | 6/3 | 1435  | 159.44 |
+| 3 | In His Image     | Chesterfield, MO  | 6/3 | 1355  | 150.56 |
+| 4 | First Responders | Lexington, KY     | 5/4 | 1475  | 163.89 |
+| 5 | Normal 1st A/G   | Normal, IL        | 5/4 | 1370  | 152.22 |
+| 5 | God\'s C.R.E.W.  | Oklahoma City, OK | 5/4 | 1370  | 152.22 |
+| 6 | The Fruitz       | Kansas City, MO   | 4/5 | 985   | 109.44 |
+| 7 | Askewville       | Askewville, NC    | 4/5 | 1270  | 141.11 |
+| 8 | Laffy Taffies    | Baxter, MN        | 2/7 | 1150  | 127.78 |
+| 9 | Kids For Christ  | Fergus Falls, MN  | 1/8 | 1110  | 123.33 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team             | Church            | Total | Avg   | QO |
+|---:|--------------------|------------------|-------------------|------:|------:|---:|
+| 1  | Josh Rozelle       | S.P.Y. Kids 007  | Leesburg, VA      | 800   | 88.89 | 3  |
+| 2  | McKenzie Shepherd  | Normal 1st A/G   | Normal, IL        | 790   | 87.78 | 3  |
+| 3  | Elizabeth Cordell  | In His Image     | Chesterfield, MO  | 755   | 83.89 | 3  |
+| 4  | Brianna Ruiz       | Laffy Taffies    | Baxter, MN        | 705   | 78.33 | 1  |
+| 5  | Brayden Laakkonen  | First Responders | Lexington, KY     | 680   | 75.56 | 2  |
+| 6  | Devin Ferguson     | The Fruitz       | Kansas City, MO   | 670   | 74.44 | 1  |
+| 7  | Landon Powell      | Kinston          | Kinston, NC       | 615   | 68.33 |    |
+| 8  | Alyssa Harden      | Askewville       | Askewville, NC    | 570   | 63.33 | 1  |
+| 9  | Alex McCracken     | First Responders | Lexington, KY     | 525   | 58.33 | 2  |
+| 10 | Damon Comfort      | God\'s C.R.E.W.  | Oklahoma City, OK | 525   | 58.33 | 1  |
+| 11 | Storm Gray         | Kinston          | Kinston, NC       | 500   | 55.56 | 5  |
+| 12 | Christina Baxter   | God\'s C.R.E.W.  | Oklahoma City, OK | 475   | 52.78 |    |
+| 13 | Benjamin Judd      | S.P.Y. Kids 007  | Leesburg, VA      | 455   | 50.56 | 3  |
+| 14 | Maggie Daniels     | Askewville       | Askewville, NC    | 450   | 50.00 | 3  |
+| 15 | Jonathan Eckhardt  | Kids For Christ  | Fergus Falls, MN  | 390   | 43.33 | 3  |
+| 16 | Johnny Trail       | God\'s C.R.E.W.  | Oklahoma City, OK | 380   | 42.22 | 3  |
+| 17 | Lacon Walsh        | Normal 1st A/G   | Normal, IL        | 380   | 42.22 | 2  |
+| 18 | Connor White       | Kinston          | Kinston, NC       | 320   | 35.56 |    |
+| 18 | Rachel Seidel      | Kids For Christ  | Fergus Falls, MN  | 320   | 35.56 |    |
+| 19 | Will Bazemore      | Askewville       | Askewville, NC    | 250   | 27.78 | 2  |
+| 20 | Anna Kelly         | First Responders | Lexington, KY     | 250   | 27.78 | 1  |
+| 21 | Jesse Ugstad       | Kids For Christ  | Fergus Falls, MN  | 225   | 25.00 |    |
+| 22 | Connor Ferguson    | The Fruitz       | Kansas City, MO   | 215   | 23.89 | 3  |
+| 23 | Daniel Kinger      | In His Image     | Chesterfield, MO  | 210   | 23.33 | 1  |
+| 24 | Nathan Lavender    | Normal 1st A/G   | Normal, IL        | 205   | 22.78 |    |
+| 25 | Samuel Borwicz     | Laffy Taffies    | Baxter, MN        | 190   | 21.11 |    |
+| 26 | Eliott Gathman     | In His Image     | Chesterfield, MO  | 160   | 17.78 |    |
+| 27 | Matthew Bozzay     | S.P.Y. Kids 007  | Leesburg, VA      | 135   | 15.00 |    |
+| 28 | Isaac Moore        | In His Image     | Chesterfield, MO  | 125   | 13.89 |    |
+| 29 | Lynne Borowicz     | Laffy Taffies    | Baxter, MN        | 115   | 12.78 |    |
+| 30 | Hannah Eckhardt    | Kids For Christ  | Fergus Falls, MN  | 110   | 12.22 |    |
+| 31 | Sarah Kinger       | In His Image     | Chesterfield, MO  | 105   | 11.67 |    |
+| 32 | Brendan Ferguson   | The Fruitz       | Kansas City, MO   | 100   | 11.11 |    |
+| 32 | Ben Stevens        | Laffy Taffies    | Baxter, MN        | 100   | 11.11 |    |
+| 33 | Daniel Bozzay      | S.P.Y. Kids 007  | Leesburg, VA      | 80    | 8.89  |    |
+| 34 | Mariah Seidel      | Kids For Christ  | Fergus Falls, MN  | 65    | 7.22  |    |
+| 35 | Aili Dabill        | Laffy Taffies    | Baxter, MN        | 20    | 2.22  |    |
+| 35 | Eva Dabill         | Laffy Taffies    | Baxter, MN        | 20    | 2.22  |    |
+| 36 | Matthew Kelly      | First Responders | Lexington, KY     | 10    | 1.11  |    |
+| 36 | Jonathan Laakkonen | First Responders | Lexington, KY     | 10    | 1.11  |    |
+| 37 | Jacob Hansel       | Normal 1st A/G   | Normal, IL        |       | .00   |    |
+| 37 | Krystal Stotts     | The Fruitz       | Kansas City, MO   |       | .00   |    |
+| 37 | Tyler McCracken    | First Responders | Lexington, KY     |       | .00   |    |
+| 37 | Catherine Baxter   | God\'s C.R.E.W.  | Oklahoma City, OK |       | .00   |    |
+| 37 | Grace Rivedl       | Laffy Taffies    | Baxter, MN        |       | .00   |    |
+| 37 | Katherine Bozzay   | S.P.Y. Kids 007  | Leesburg, VA      |       | .00   |    |
+| 37 | Sarah Harrison     | Askewville       | Askewville, NC    |       | .00   |    |
+| 38 | Drew Garvin        | Normal 1st A/G   | Normal, IL        | -5    | -0.56 |    |
+| 38 | Luke Yoder         | S.P.Y. Kids 007  | Leesburg, VA      | -5    | -0.56 |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                  | Church         | W/L | Total | Avg    |
+|---:|-----------------------|----------------|-----|------:|-------:|
+| 1  | Soul Survivors        | Lawson, MO     | 7/2 | 1475  | 163.89 |
+| 2  | Paradise Hills Vipers | Phoenix, AZ    | 6/3 | 1430  | 158.89 |
+| 3  | Word Warriors         | Mendon, MA     | 6/3 | 1275  | 141.67 |
+| 4  | Living Hope           | Swedesboro, NJ | 6/3 | 1250  | 138.89 |
+| 5  | JBR in da JBQ         | Bismarck, ND   | 5/4 | 1370  | 152.22 |
+| 6  | Jedi Masters          | Elkhart, IN    | 4/5 | 1355  | 150.56 |
+| 7  | Harrison Thrashers    | Harrison, AR   | 4/5 | 1450  | 161.11 |
+| 8  | DeLand Jesus Freaks   | DeLand, FL     | 3/6 | 1145  | 127.22 |
+| 9  | Built LORD Tough      | Des Moines, IA | 3/6 | 1115  | 123.89 |
+| 10 | Matrix                | Mesa, AZ       | 1/8 | 885   | 98.33  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                  | Church         | Total | Avg    | QO |
+|---:|-------------------|-----------------------|----------------|------:|-------:|---:|
+| 1  | Issac Kandavalli  | Living Hope           | Swedesboro, NJ | 1045  | 116.11 | 8  |
+| 2  | Zachary Cook      | Soul Survivors        | Lawson, MO     | 1020  | 113.33 | 5  |
+| 3  | Joshua Sipes      | JBR in da JBQ         | Bismarck, ND   | 935   | 103.89 | 5  |
+| 4  | Vanessa Steiner   | Jedi Masters          | Elkhart, IN    | 870   | 96.67  | 3  |
+| 5  | Chad Stogner      | Paradise Hills Vipers | Phoenix, AZ    | 650   | 72.22  | 2  |
+| 6  | Grace Geesey      | Matrix                | Mesa, AZ       | 640   | 71.11  | 2  |
+| 7  | Makenzie Bradshaw | Harrison Thrashers    | Harrison, AR   | 625   | 69.44  | 1  |
+| 8  | Josiah Pait       | DeLand Jesus Freaks   | DeLand, FL     | 515   | 57.22  | 5  |
+| 9  | Jonathan Pait     | DeLand Jesus Freaks   | DeLand, FL     | 510   | 56.67  | 1  |
+| 10 | Stephanie Hamel   | Word Warriors         | Mendon, MA     | 460   | 51.11  |    |
+| 11 | Justin Dodd       | Built LORD Tough      | Des Moines, IA | 450   | 50.00  |    |
+| 12 | Noah Ridgway      | Built LORD Tough      | Des Moines, IA | 440   | 48.89  | 5  |
+| 13 | Jonathan Gomez    | Jedi Masters          | Elkhart, IN    | 405   | 45.00  | 2  |
+| 14 | Evan Still        | Harrison Thrashers    | Harrison, AR   | 395   | 43.89  |    |
+| 15 | Josiah Duka       | Paradise Hills Vipers | Phoenix, AZ    | 390   | 43.33  |    |
+| 16 | Devin Morrill     | Word Warriors         | Mendon, MA     | 355   | 39.44  | 4  |
+| 17 | Joseph Duka       | Paradise Hills Vipers | Phoenix, AZ    | 355   | 39.44  | 3  |
+| 18 | Brianna Sipes     | JBR in da JBQ         | Bismarck, ND   | 335   | 37.22  | 1  |
+| 19 | Kerigan Bradshaw  | Harrison Thrashers    | Harrison, AR   | 290   | 32.22  | 2  |
+| 20 | Breanna Cole      | Soul Survivors        | Lawson, MO     | 215   | 23.89  |    |
+| 21 | Sophie Ridgway    | Built LORD Tough      | Des Moines, IA | 190   | 21.11  |    |
+| 21 | Jessica Vannelli  | Word Warriors         | Mendon, MA     | 190   | 21.11  |    |
+| 22 | Katrina Dowdy     | Living Hope           | Swedesboro, NJ | 165   | 18.33  |    |
+| 23 | Alexis Wilcox     | Matrix                | Mesa, AZ       | 145   | 16.11  |    |
+| 24 | Katie Burke       | Word Warriors         | Mendon, MA     | 135   | 15.00  |    |
+| 24 | Jonathan Archer   | Soul Survivors        | Lawson, MO     | 135   | 15.00  |    |
+| 24 | Abby Bailey       | Harrison Thrashers    | Harrison, AR   | 135   | 15.00  |    |
+| 25 | Shane Emry        | Soul Survivors        | Lawson, MO     | 110   | 12.22  |    |
+| 26 | Robyn Patch       | JBR in da JBQ         | Bismarck, ND   | 100   | 11.11  |    |
+| 27 | Craig Maynard     | DeLand Jesus Freaks   | DeLand, FL     | 95    | 10.56  |    |
+| 28 | Kati Quiggle      | Jedi Masters          | Elkhart, IN    | 80    | 8.89   |    |
+| 28 | Kyra Hintz        | Matrix                | Mesa, AZ       | 80    | 8.89   |    |
+| 28 | Mark Caughey      | Word Warriors         | Mendon, MA     | 80    | 8.89   |    |
+| 29 | Matthew Caughey   | Word Warriors         | Mendon, MA     | 60    | 6.67   |    |
+| 30 | Amelia Dixon      | Built LORD Tough      | Des Moines, IA | 40    | 4.44   |    |
+| 30 | Heidi Rasmussen   | Paradise Hills Vipers | Phoenix, AZ    | 40    | 4.44   |    |
+| 31 | Courtney Andexler | DeLand Jesus Freaks   | DeLand, FL     | 30    | 3.33   |    |
+| 32 | Rachael Meley     | Matrix                | Mesa, AZ       | 20    | 2.22   |    |
+| 32 | Jessica Watson    | Living Hope           | Swedesboro, NJ | 20    | 2.22   |    |
+| 33 | Hayden Ballard    | Harrison Thrashers    | Harrison, AR   | 10    | 1.11   |    |
+| 33 | Hannah Hill       | Living Hope           | Swedesboro, NJ | 10    | 1.11   |    |
+| 33 | Erin Zak          | Living Hope           | Swedesboro, NJ | 10    | 1.11   |    |
+| 34 | Madelyn Crowl     | Harrison Thrashers    | Harrison, AR   |       | .00    |    |
+| 34 | Lauren Henderson  | Harrison Thrashers    | Harrison, AR   |       | .00    |    |
+| 34 | Sarah Weeks       | Jedi Masters          | Elkhart, IN    |       | .00    |    |
+| 34 | Rebecca Yates     | Paradise Hills Vipers | Phoenix, AZ    |       | .00    |    |
+| 34 | Shaun Dowdy       | Living Hope           | Swedesboro, NJ |       | .00    |    |
+| 34 | Kaden             | Matrix                | Mesa, AZ       |       | .00    |    |
+
+
+### Purple
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                        | Church               | W/L | Total | Avg    |
+|--:|-----------------------------|----------------------|-----|------:|-------:|
+| 1 | International A/G #1        | Warren, MI           | 7/2 | 1405  | 156.11 |
+| 2 | God\'s Quad Squad           | Branson, MO          | 6/3 | 1320  | 146.67 |
+| 3 | Calvary Church (Naperville) | Naperville, IL       | 5/4 | 1520  | 168.89 |
+| 4 | Master\'s Mavericks         | Grapevine, TX        | 5/4 | 1320  | 146.67 |
+| 5 | Quiz Kids                   | Dripping Springs, TX | 5/4 | 1200  | 133.33 |
+| 5 | K.J. St. N.W.               | Renton, WA           | 5/4 | 1200  | 133.33 |
+| 6 | Kingdom Explorers           | Dallas, TX           | 4/5 | 1300  | 144.44 |
+| 7 | Gospel Gators               | Sanford, FL          | 3/6 | 1195  | 132.78 |
+| 8 | Spy All Stars               | Kent, WA             | 3/6 | 1295  | 143.89 |
+| 9 | Storm                       | Bonifay, FL          | 2/7 | 1140  | 126.67 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                        | Church               | Total | Avg    | QO |
+|---:|-------------------|-----------------------------|----------------------|------:|-------:|---:|
+| 1  | Aliyah Fashaw     | Spy All Stars               | Kent, WA             | 940   | 104.44 | 4  |
+| 2  | Patrick Kilgallon | Calvary Church (Naperville) | Naperville, IL       | 930   | 103.33 | 8  |
+| 3  | Joseph Pingleton  | God\'s Quad Squad           | Branson, MO          | 865   | 96.11  | 4  |
+| 4  | Jason Markarian   | K.J. St. N.W.               | Renton, WA           | 860   | 95.56  | 5  |
+| 5  | Samuel Grey       | Kingdom Explorers           | Dallas, TX           | 720   | 80.00  | 4  |
+| 6  | Jacob Jeter       | Master\'s Mavericks         | Grapevine, TX        | 615   | 68.33  | 4  |
+| 7  | Alyssa Skinner    | Quiz Kids                   | Dripping Springs, TX | 570   | 63.33  |    |
+| 8  | Kelsey Stewart    | Storm                       | Bonifay, FL          | 525   | 58.33  | 2  |
+| 9  | David Brauchler   | Master\'s Mavericks         | Grapevine, TX        | 495   | 55.00  |    |
+| 10 | Shreanna Powell   | Calvary Church (Naperville) | Naperville, IL       | 475   | 52.78  |    |
+| 11 | Jennise George    | International A/G #1        | Warren, MI           | 470   | 52.22  | 1  |
+| 12 | Sabrina Justice   | Storm                       | Bonifay, FL          | 460   | 51.11  |    |
+| 13 | Matthew Robinson  | Gospel Gators               | Sanford, FL          | 450   | 50.00  | 3  |
+| 14 | Luis Torres       | Kingdom Explorers           | Dallas, TX           | 430   | 47.78  | 1  |
+| 15 | Levi Anderson     | Gospel Gators               | Sanford, FL          | 430   | 47.78  |    |
+| 16 | Shaun Chacko      | International A/G #1        | Warren, MI           | 390   | 43.33  | 2  |
+| 17 | Kiersten George   | International A/G #1        | Warren, MI           | 340   | 37.78  |    |
+| 18 | Kelly Fischbeck   | K.J. St. N.W.               | Renton, WA           | 305   | 33.89  | 3  |
+| 19 | Peyton Goss       | Gospel Gators               | Sanford, FL          | 280   | 31.11  | 1  |
+| 20 | Tino Stevens      | God\'s Quad Squad           | Branson, MO          | 235   | 26.11  | 1  |
+| 21 | Reece Skinner     | Quiz Kids                   | Dripping Springs, TX | 220   | 24.44  | 2  |
+| 22 | Jaden Werley      | Master\'s Mavericks         | Grapevine, TX        | 215   | 23.89  |    |
+| 23 | Luke Cooper       | God\'s Quad Squad           | Branson, MO          | 210   | 23.33  | 2  |
+| 24 | Hannah Brown      | Quiz Kids                   | Dripping Springs, TX | 210   | 23.33  |    |
+| 25 | Emily Myers       | Quiz Kids                   | Dripping Springs, TX | 200   | 22.22  | 1  |
+| 26 | Michaela Toole    | Spy All Stars               | Kent, WA             | 180   | 20.00  |    |
+| 27 | Sherlin Chacko    | International A/G #1        | Warren, MI           | 165   | 18.33  | 1  |
+| 28 | Jojo Wood         | Storm                       | Bonifay, FL          | 125   | 13.89  |    |
+| 29 | Daniel Gallegos   | Spy All Stars               | Kent, WA             | 75    | 8.33   |    |
+| 30 | Sarah Toole       | Spy All Stars               | Kent, WA             | 70    | 7.78   |    |
+| 31 | Robert Laboy      | Calvary Church (Naperville) | Naperville, IL       | 65    | 7.22   |    |
+| 32 | Abigail DeGraff   | Calvary Church (Naperville) | Naperville, IL       | 55    | 6.11   |    |
+| 33 | Abigail Munoz     | Kingdom Explorers           | Dallas, TX           | 50    | 5.56   |    |
+| 34 | Albert George     | International A/G #1        | Warren, MI           | 40    | 4.44   |    |
+| 35 | Cory Weidner      | Gospel Gators               | Sanford, FL          | 35    | 3.89   |    |
+| 36 | Casey Macauley    | Spy All Stars               | Kent, WA             | 30    | 3.33   |    |
+| 36 | Matthew Keenan    | Kingdom Explorers           | Dallas, TX           | 30    | 3.33   |    |
+| 37 | Patrick Keenan    | Kingdom Explorers           | Dallas, TX           | 25    | 2.78   |    |
+| 38 | Abby Bennett      | Kingdom Explorers           | Dallas, TX           | 20    | 2.22   |    |
+| 38 | AryAnna Bennett   | Kingdom Explorers           | Dallas, TX           | 20    | 2.22   |    |
+| 38 | Nick Stewart      | Storm                       | Bonifay, FL          | 20    | 2.22   |    |
+| 38 | Wesley Jacobs     | K.J. St. N.W.               | Renton, WA           | 20    | 2.22   |    |
+| 39 | Nolan Griggs      | K.J. St. N.W.               | Renton, WA           | 15    | 1.67   |    |
+| 40 | Cason Moore       | Storm                       | Bonifay, FL          | 10    | 1.11   |    |
+| 40 | Ashley Carder     | God\'s Quad Squad           | Branson, MO          | 10    | 1.11   |    |
+| 41 | Steven Torres     | Kingdom Explorers           | Dallas, TX           | 5     | .56    |    |
+| 42 | Sami Stuefen      | K.J. St. N.W.               | Renton, WA           |       | .00    |    |
+| 42 | Faith Myers       | Quiz Kids                   | Dripping Springs, TX |       | .00    |    |
+| 42 | Tony DeWitt       | K.J. St. N.W.               | Renton, WA           |       | .00    |    |
+| 43 | Ciara Cruz        | Master\'s Mavericks         | Grapevine, TX        | -5    | -0.56  |    |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team              | Church            | W/L | Total | Avg    |
+|---:|-------------------|-------------------|-----|------:|-------:|
+| 1  | Atomic Vortex     | Springfield, MO   | 7/2 | 1500  | 166.67 |
+| 2  | Grace             | New Whiteland, IN | 7/2 | 1470  | 163.33 |
+| 3  | Bible Sharks      | Austin, TX        | 6/3 | 1320  | 146.67 |
+| 4  | Spy Warriors      | Kent, WA          | 6/3 | 1245  | 138.33 |
+| 5  | Sword Masters     | Zephyrhills, FL   | 5/4 | 1435  | 159.44 |
+| 6  | Lifeguards        | Dayton, OH        | 4/5 | 1280  | 142.22 |
+| 7  | Power Possums     | Princeton, MN     | 4/5 | 1245  | 138.33 |
+| 8  | Bethlehem Church  | Richmond Hill, NY | 2/7 | 1165  | 129.44 |
+| 9  | Wenatchee 1st A/G | Wenatchee, WA     | 2/7 | 1025  | 113.89 |
+| 10 | Goldsboro Gladius | Goldsboro, NC     | 2/7 | 1015  | 112.78 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team              | Church            | Total | Avg    | QO |
+|---:|-------------------|-------------------|-------------------|------:|-------:|---:|
+| 1  | Abby Rogers       | Sword Masters     | Zephyrhills, FL   | 1175  | 130.56 | 7  |
+| 2  | Braden Murray     | Grace             | New Whiteland, IN | 905   | 100.56 | 3  |
+| 3  | Blake Isaacs      | Lifeguards        | Dayton, OH        | 860   | 95.56  | 5  |
+| 4  | Marques Proctor   | Spy Warriors      | Kent, WA          | 765   | 85.00  | 3  |
+| 5  | Daniel Quick      | Atomic Vortex     | Springfield, MO   | 710   | 78.89  | 1  |
+| 6  | Mikylla Davy      | Wenatchee 1st A/G | Wenatchee, WA     | 630   | 70.00  | 2  |
+| 7  | Steven Mathew     | Bible Sharks      | Austin, TX        | 545   | 60.56  | 1  |
+| 8  | Thomas Stewart    | Power Possums     | Princeton, MN     | 520   | 57.78  | 1  |
+| 9  | Joshua Clark      | Atomic Vortex     | Springfield, MO   | 495   | 55.00  | 4  |
+| 10 | Joel James        | Bible Sharks      | Austin, TX        | 435   | 48.33  |    |
+| 11 | Rebecca Ford      | Bethlehem Church  | Richmond Hill, NY | 430   | 47.78  |    |
+| 12 | Nicholas Wolbert  | Power Possums     | Princeton, MN     | 400   | 44.44  | 1  |
+| 13 | Samuel Wilkerson  | Goldsboro Gladius | Goldsboro, NC     | 340   | 37.78  |    |
+| 14 | Rachael Singh     | Bethlehem Church  | Richmond Hill, NY | 325   | 36.11  |    |
+| 15 | Koty Wojeski      | Goldsboro Gladius | Goldsboro, NC     | 305   | 33.89  |    |
+| 16 | Kelsey Anderson   | Wenatchee 1st A/G | Wenatchee, WA     | 300   | 33.33  | 1  |
+| 17 | Alissa Garrett    | Grace             | New Whiteland, IN | 295   | 32.78  | 1  |
+| 18 | Nicole DeSilva    | Bethlehem Church  | Richmond Hill, NY | 270   | 30.00  | 2  |
+| 19 | Savannah Gutterud | Spy Warriors      | Kent, WA          | 265   | 29.44  |    |
+| 20 | Kelechi Emeodi    | Bible Sharks      | Austin, TX        | 255   | 28.33  | 1  |
+| 21 | Charlie Jones     | Goldsboro Gladius | Goldsboro, NC     | 250   | 27.78  |    |
+| 22 | Emily Ott         | Grace             | New Whiteland, IN | 190   | 21.11  |    |
+| 23 | Caleb Daniels     | Power Possums     | Princeton, MN     | 185   | 20.56  | 1  |
+| 24 | Dena Schaeffer    | Lifeguards        | Dayton, OH        | 165   | 18.33  |    |
+| 24 | Mason Gore        | Atomic Vortex     | Springfield, MO   | 165   | 18.33  |    |
+| 25 | Zachary McClellan | Sword Masters     | Zephyrhills, FL   | 160   | 17.78  |    |
+| 26 | Matthew Braham    | Spy Warriors      | Kent, WA          | 140   | 15.56  |    |
+| 27 | Caleb Jones       | Lifeguards        | Dayton, OH        | 130   | 14.44  | 1  |
+| 28 | Hannah Quick      | Atomic Vortex     | Springfield, MO   | 130   | 14.44  |    |
+| 29 | Micah Roelofs     | Power Possums     | Princeton, MN     | 120   | 13.33  |    |
+| 30 | Jaret Williams    | Bethlehem Church  | Richmond Hill, NY | 95    | 10.56  |    |
+| 30 | Gabrielle Davy    | Wenatchee 1st A/G | Wenatchee, WA     | 95    | 10.56  |    |
+| 31 | Parker Sanders    | Grace             | New Whiteland, IN | 80    | 8.89   |    |
+| 32 | Josh James        | Bible Sharks      | Austin, TX        | 70    | 7.78   |    |
+| 32 | Randy Jones       | Goldsboro Gladius | Goldsboro, NC     | 70    | 7.78   |    |
+| 33 | Natalie Isaacs    | Lifeguards        | Dayton, OH        | 60    | 6.67   |    |
+| 34 | Austin Shepherd   | Spy Warriors      | Kent, WA          | 55    | 6.11   | 1  |
+| 35 | Erykah Betterson  | Goldsboro Gladius | Goldsboro, NC     | 55    | 6.11   |    |
+| 35 | Joshua Wilcox     | Sword Masters     | Zephyrhills, FL   | 55    | 6.11   |    |
+| 36 | Riley McClellan   | Sword Masters     | Zephyrhills, FL   | 45    | 5.00   |    |
+| 36 | Christon Stewart  | Bethlehem Church  | Richmond Hill, NY | 45    | 5.00   |    |
+| 37 | Ben Beeson        | Lifeguards        | Dayton, OH        | 30    | 3.33   |    |
+| 37 | Sean Jones        | Lifeguards        | Dayton, OH        | 30    | 3.33   |    |
+| 38 | Gabe Kolhoff      | Power Possums     | Princeton, MN     | 20    | 2.22   |    |
+| 38 | Abby Kornechuk    | Spy Warriors      | Kent, WA          | 20    | 2.22   |    |
+| 39 | Samuel Birrell    | Bible Sharks      | Austin, TX        | 15    | 1.67   |    |
+| 40 | Joey Jones        | Lifeguards        | Dayton, OH        | 10    | 1.11   |    |
+| 41 | Christina Okafor  | Bethlehem Church  | Richmond Hill, NY |       | .00    |    |
+| 41 | Rebecca Ramnauth  | Bethlehem Church  | Richmond Hill, NY |       | .00    |    |
+| 41 | Maggie Smith      | Lifeguards        | Dayton, OH        |       | .00    |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                                       | Church               | W/L | Total | Avg    |
+|--:|--------------------------------------------|----------------------|-----|------:|-------:|
+| 1 | The Olympians                              | Cedar Hill, TX       | 7/2 | 1580  | 175.56 |
+| 2 | Reborn Army                                | Lubbock, TX          | 7/2 | 1480  | 164.44 |
+| 3 | Biblikids                                  | Oak Creek, WI        | 5/4 | 1455  | 161.67 |
+| 3 | Muskogee Armored Saints                    | Muskogee, OK         | 5/4 | 1455  | 161.67 |
+| 4 | The Interrupters - Pardon the Interruption | Rockford, IL         | 5/4 | 1440  | 160.00 |
+| 5 | Bethesda Christian Church                  | Sterling Heights, MI | 5/4 | 1305  | 145.00 |
+| 6 | Learners Under Discipline                  | East Lansing, MI     | 5/4 | 1270  | 141.11 |
+| 7 | Freedom Church                             | Tallahassee, FL      | 4/5 | 1415  | 157.22 |
+| 8 | Angel Agents                               | Brookfield, WI       | 1/8 | 765   | 85.00  |
+| 9 | Racin\' for God                            | Racine, WI           | 1/8 | 1005  | 111.67 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                                       | Church               | Total | Avg    | QO |
+|---:|---------------------|--------------------------------------------|----------------------|------:|-------:|---:|
+| 1  | Bridget Farris      | Bethesda Christian Church                  | Sterling Heights, MI | 1035  | 115.00 | 4  |
+| 2  | Susanna Ferguson    | The Olympians                              | Cedar Hill, TX       | 810   | 90.00  | 1  |
+| 3  | Sam Hyatt           | Biblikids                                  | Oak Creek, WI        | 780   | 86.67  | 3  |
+| 4  | Paul Meddaugh       | Muskogee Armored Saints                    | Muskogee, OK         | 695   | 77.22  | 2  |
+| 5  | Mary Meddaugh       | Muskogee Armored Saints                    | Muskogee, OK         | 690   | 76.67  | 2  |
+| 6  | Jenna Klein         | Learners Under Discipline                  | East Lansing, MI     | 675   | 75.00  | 2  |
+| 7  | Rob Adams           | Reborn Army                                | Lubbock, TX          | 590   | 65.56  | 2  |
+| 8  | Nathaniel Hanson    | The Interrupters - Pardon the Interruption | Rockford, IL         | 590   | 65.56  | 1  |
+| 9  | Elijah Evers        | Biblikids                                  | Oak Creek, WI        | 520   | 57.78  | 4  |
+| 10 | Chandler Click      | The Olympians                              | Cedar Hill, TX       | 510   | 56.67  | 5  |
+| 11 | Hannah Stephens     | Freedom Church                             | Tallahassee, FL      | 510   | 56.67  | 2  |
+| 12 | Madison Guzman      | The Interrupters - Pardon the Interruption | Rockford, IL         | 495   | 55.00  | 5  |
+| 13 | Ariel Watson        | Reborn Army                                | Lubbock, TX          | 465   | 51.67  | 4  |
+| 14 | Sean Daniels        | Racin\' for God                            | Racine, WI           | 430   | 47.78  | 3  |
+| 15 | Sean Watson         | Reborn Army                                | Lubbock, TX          | 420   | 46.67  |    |
+| 16 | Lyndsey Sykes       | Freedom Church                             | Tallahassee, FL      | 410   | 45.56  | 2  |
+| 17 | Elijah O\'Brien     | Angel Agents                               | Brookfield, WI       | 380   | 42.22  |    |
+| 18 | Austin Harr         | Learners Under Discipline                  | East Lansing, MI     | 300   | 33.33  | 2  |
+| 19 | Laura Cardenas      | Racin\' for God                            | Racine, WI           | 290   | 32.22  |    |
+| 20 | Caleb Stephens      | Freedom Church                             | Tallahassee, FL      | 270   | 30.00  |    |
+| 21 | Elle Miller         | The Olympians                              | Cedar Hill, TX       | 260   | 28.89  |    |
+| 22 | Kendra Zwonitzer    | The Interrupters - Pardon the Interruption | Rockford, IL         | 250   | 27.78  |    |
+| 23 | Connell Donoghue    | Freedom Church                             | Tallahassee, FL      | 200   | 22.22  |    |
+| 24 | Kirsten Andrews     | Learners Under Discipline                  | East Lansing, MI     | 160   | 17.78  |    |
+| 24 | Elizabeth O\'Brien  | Angel Agents                               | Brookfield, WI       | 160   | 17.78  |    |
+| 25 | Reanna Toeller      | Racin\' for God                            | Racine, WI           | 155   | 17.22  |    |
+| 25 | Rickey Bridges      | Angel Agents                               | Brookfield, WI       | 155   | 17.22  |    |
+| 26 | Moriah Tecsom       | Bethesda Christian Church                  | Sterling Heights, MI | 130   | 14.44  |    |
+| 27 | Danielle Alita      | The Interrupters - Pardon the Interruption | Rockford, IL         | 105   | 11.67  |    |
+| 28 | Tyler McCartney     | Learners Under Discipline                  | East Lansing, MI     | 85    | 9.44   |    |
+| 28 | Michael Ragap       | Bethesda Christian Church                  | Sterling Heights, MI | 85    | 9.44   |    |
+| 29 | Christina Belmares  | Racin\' for God                            | Racine, WI           | 70    | 7.78   |    |
+| 29 | William Ubert       | Angel Agents                               | Brookfield, WI       | 70    | 7.78   |    |
+| 30 | Glenn Kaboskey      | Biblikids                                  | Oak Creek, WI        | 65    | 7.22   |    |
+| 30 | Jacob Morton        | Muskogee Armored Saints                    | Muskogee, OK         | 65    | 7.22   |    |
+| 31 | Liz Ashley          | Racin\' for God                            | Racine, WI           | 60    | 6.67   |    |
+| 31 | Peter Tamblyn       | Biblikids                                  | Oak Creek, WI        | 60    | 6.67   |    |
+| 32 | John Schafer        | Learners Under Discipline                  | East Lansing, MI     | 50    | 5.56   |    |
+| 33 | Jordan Hasse        | Bethesda Christian Church                  | Sterling Heights, MI | 30    | 3.33   |    |
+| 33 | Joyce Williams      | Biblikids                                  | Oak Creek, WI        | 30    | 3.33   |    |
+| 34 | Isabella Frazier    | Freedom Church                             | Tallahassee, FL      | 25    | 2.78   |    |
+| 34 | Austin Barclay      | Bethesda Christian Church                  | Sterling Heights, MI | 25    | 2.78   |    |
+| 35 | Sam Carter          | Muskogee Armored Saints                    | Muskogee, OK         | 10    | 1.11   |    |
+| 36 | Janna Gaines        | Reborn Army                                | Lubbock, TX          | 5     | .56    |    |
+| 37 | Daniel Piasecki     | Biblikids                                  | Oak Creek, WI        |       | .00    |    |
+| 37 | Shannon Lojeski     | Racin\' for God                            | Racine, WI           |       | .00    |    |
+| 37 | Mason Tidwell       | Reborn Army                                | Lubbock, TX          |       | .00    |    |
+| 37 | Hannah Alita        | The Interrupters - Pardon the Interruption | Rockford, IL         |       | .00    |    |
+| 37 | Christopher Calvery | The Olympians                              | Cedar Hill, TX       |       | .00    |    |
+

--- a/_pages/jbq/2010/index.md
+++ b/_pages/jbq/2010/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2010 JBQ Season"
+permalink: /jbq/2010/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+<a href="{% link _pages/jbq/2010/nationals.md %}" class="button is-primary">National Finals</a>
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2010/nationals.md
+++ b/_pages/jbq/2010/nationals.md
@@ -1,0 +1,1714 @@
+---
+layout: page
+title: "2010 National Festival: Red Oak, TX"
+permalink: /jbq/2010/nationals/
+date: "2015-06-10"
+toc_title: Results
+menubar_toc: true
+---
+
+## Friday (AM)
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church                              | W/L | Total | Avg    |
+|--:|---------------------------|-------------------------------------|-----|------:|-------:|
+| 1 | SPY Warriors              | River of Life Fellowship (Kent, WA) | 6/1 | 1520  | 217.14 |
+| 2 | Supernova                 | Central Assembly (Springfield, MO)  | 5/2 | 1285  | 183.57 |
+| 3 | Seed Sowers               | Trinity A/G (Georgetown, KY)        | 5/2 | 1255  | 179.29 |
+| 4 | Skittles                  | Evangel A/G (Bismarck, ND)          | 5/2 | 1100  | 157.14 |
+| 5 | Quiz CREW                 | Trinity Tabernacle (Crossville, TN) | 3/4 | 950   | 135.71 |
+| 6 | Tallahassee Freedom       | Freedom Church (Tallahassee, FL)    | 2/5 | 940   | 134.29 |
+| 7 | Swordsmen                 | Vailsburg Assembly (Newark, NJ)     | 2/5 | 740   | 105.71 |
+| 8 | Awesome Bible Competitors | Victory A/G (Universal City, TX)    | 0/7 | 530   | 75.71  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                      | Church                              | Total | Avg    | QO |
+|---:|---------------------|---------------------------|-------------------------------------|------:|-------:|---:|
+| 1  | Savannah Gutterud   | SPY Warriors              | River of Life Fellowship (Kent, WA) | 910   | 130.00 | 6  |
+| 2  | Lily Johnson        | Seed Sowers               | Trinity A/G (Georgetown, KY)        | 770   | 110.00 | 5  |
+| 3  | Joshua Sipes        | Skittles                  | Evangel A/G (Bismarck, ND)          | 655   | 93.57  | 2  |
+| 4  | Hannah Quick        | Supernova                 | Central Assembly (Springfield, MO)  | 615   | 87.86  | 2  |
+| 5  | Hannah Stephens     | Tallahassee Freedom       | Freedom Church (Tallahassee, FL)    | 610   | 87.14  | 3  |
+| 6  | Buddy Guenther      | Quiz CREW                 | Trinity Tabernacle (Crossville, TN) | 490   | 70.00  | 2  |
+| 7  | Bridgett Guenther   | Quiz CREW                 | Trinity Tabernacle (Crossville, TN) | 435   | 62.14  | 3  |
+| 8  | Luke Slater         | Supernova                 | Central Assembly (Springfield, MO)  | 340   | 48.57  | 4  |
+| 9  | Mary Frances Harris | Awesome Bible Competitors | Victory A/G (Universal City, TX)    | 300   | 42.86  |    |
+| 10 | Natalie Slater      | Supernova                 | Central Assembly (Springfield, MO)  | 290   | 41.43  |    |
+| 11 | Christopher Turner  | Seed Sowers               | Trinity A/G (Georgetown, KY)        | 280   | 40.00  |    |
+| 12 | Daniel Gallegos     | SPY Warriors              | River of Life Fellowship (Kent, WA) | 245   | 35.00  | 3  |
+| 13 | Daniel Green        | Swordsmen                 | Vailsburg Assembly (Newark, NJ)     | 245   | 35.00  | 2  |
+| 14 | Brooklyne Sederwall | Swordsmen                 | Vailsburg Assembly (Newark, NJ)     | 220   | 31.43  |    |
+| 15 | Sarah Toole         | SPY Warriors              | River of Life Fellowship (Kent, WA) | 210   | 30.00  |    |
+| 16 | Jayden Freyer       | Skittles                  | Evangel A/G (Bismarck, ND)          | 190   | 27.14  | 1  |
+| 17 | Sarah Steinbach     | Seed Sowers               | Trinity A/G (Georgetown, KY)        | 185   | 26.43  | 1  |
+| 18 | Connell Donoghue    | Tallahassee Freedom       | Freedom Church (Tallahassee, FL)    | 175   | 25.00  | 1  |
+| 19 | Matthew Braham      | SPY Warriors              | River of Life Fellowship (Kent, WA) | 155   | 22.14  | 1  |
+| 20 | Chad Sederwall      | Swordsmen                 | Vailsburg Assembly (Newark, NJ)     | 150   | 21.43  |    |
+| 21 | Brianna Sipes       | Skittles                  | Evangel A/G (Bismarck, ND)          | 140   | 20.00  |    |
+| 22 | Brittany Steinberg  | Awesome Bible Competitors | Victory A/G (Universal City, TX)    | 130   | 18.57  |    |
+| 23 | Elijah Sauer        | Skittles                  | Evangel A/G (Bismarck, ND)          | 115   | 16.43  |    |
+| 24 | Cody Goodwyn        | Awesome Bible Competitors | Victory A/G (Universal City, TX)    | 80    | 11.43  |    |
+| 25 | Noble Frazier       | Tallahassee Freedom       | Freedom Church (Tallahassee, FL)    | 75    | 10.71  |    |
+| 26 | Hope Richards       | Tallahassee Freedom       | Freedom Church (Tallahassee, FL)    | 60    | 8.57   |    |
+| 27 | Lucas Clark         | Supernova                 | Central Assembly (Springfield, MO)  | 50    | 7.14   |    |
+| 27 | Fran-jec Makoule    | Swordsmen                 | Vailsburg Assembly (Newark, NJ)     | 50    | 7.14   |    |
+| 28 | George Austin       | Swordsmen                 | Vailsburg Assembly (Newark, NJ)     | 30    | 4.29   |    |
+| 29 | Acacia Todd         | Swordsmen                 | Vailsburg Assembly (Newark, NJ)     | 20    | 2.86   |    |
+| 29 | Joy Richards        | Tallahassee Freedom       | Freedom Church (Tallahassee, FL)    | 20    | 2.86   |    |
+| 29 | Rudy Narvaez        | Awesome Bible Competitors | Victory A/G (Universal City, TX)    | 20    | 2.86   |    |
+| 29 | Jasmine Nazaire     | Swordsmen                 | Vailsburg Assembly (Newark, NJ)     | 20    | 2.86   |    |
+| 29 | Elizabeth Steinbach | Seed Sowers               | Trinity A/G (Georgetown, KY)        | 20    | 2.86   |    |
+| 29 | Makayla Olsen       | Quiz CREW                 | Trinity Tabernacle (Crossville, TN) | 20    | 2.86   |    |
+| 30 | Katie Van Nuck      | Swordsmen                 | Vailsburg Assembly (Newark, NJ)     | 5     | .71    |    |
+| 30 | John Guenther       | Quiz CREW                 | Trinity Tabernacle (Crossville, TN) | 5     | .71    |    |
+| 31 | Elijah Pettit       | Seed Sowers               | Trinity A/G (Georgetown, KY)        |       | .00    |    |
+| 31 | Jeremiah Olsen      | Quiz CREW                 | Trinity Tabernacle (Crossville, TN) |       | .00    |    |
+| 31 | Maddi Evans         | Seed Sowers               | Trinity A/G (Georgetown, KY)        |       | .00    |    |
+| 31 | Micah Rodriguez     | Awesome Bible Competitors | Victory A/G (Universal City, TX)    |       | .00    |    |
+| 31 | Autumn Pettit       | Seed Sowers               | Trinity A/G (Georgetown, KY)        |       | .00    |    |
+| 31 | Abbye Evans         | Seed Sowers               | Trinity A/G (Georgetown, KY)        |       | .00    |    |
+| 31 | Abigail Olsen       | Quiz CREW                 | Trinity Tabernacle (Crossville, TN) |       | .00    |    |
+| 31 | Ethan Collins       | Quiz CREW                 | Trinity Tabernacle (Crossville, TN) |       | .00    |    |
+| 31 | Lily Slater         | Supernova                 | Central Assembly (Springfield, MO)  |       | .00    |    |
+| 31 | Ashlyn Sipes        | Skittles                  | Evangel A/G (Bismarck, ND)          |       | .00    |    |
+
+
+### Cream
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                        | Church                                 | W/L | Total | Avg    |
+|--:|-----------------------------|----------------------------------------|-----|------:|-------:|
+| 1 | SPY All Stars               | River of Life Fellowship (Kent, WA)    | 6/1 | 1385  | 197.86 |
+| 2 | Jedi Knights                | Calvary A/G (Elkhart, IN)              | 6/1 | 1290  | 184.29 |
+| 3 | Alien Ambassadors           | River of Life (Minot, ND)              | 5/2 | 945   | 135.00 |
+| 4 | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX) | 4/3 | 1220  | 174.29 |
+| 5 | Powerful Praying Platypuses | 1st A/G (Phoenix, AZ)                  | 3/4 | 880   | 125.71 |
+| 6 | Ashland                     | 1st A/G (Ashland, AL)                  | 2/5 | 640   | 91.43  |
+| 7 | Sonburst Alpha              | MCC (Mechanicsville, VA)               | 1/6 | 755   | 107.86 |
+| 8 | Cordova                     | 1st A/G (Cordova, TN)                  | 1/6 | 690   | 98.57  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                        | Church                                 | Total | Avg    | QO |
+|---:|----------------------|-----------------------------|----------------------------------------|------:|-------:|---:|
+| 1  | Vanessa Steiner      | Jedi Knights                | Calvary A/G (Elkhart, IN)              | 815   | 116.43 | 3  |
+| 2  | Aliyah Fashaw        | SPY All Stars               | River of Life Fellowship (Kent, WA)    | 800   | 114.29 | 4  |
+| 3  | Caleb Hoverson       | Alien Ambassadors           | River of Life (Minot, ND)              | 620   | 88.57  | 2  |
+| 4  | Jessica Rutland      | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX) | 605   | 86.43  | 1  |
+| 5  | Daniel Deppe         | Cordova                     | 1st A/G (Cordova, TN)                  | 380   | 54.29  |    |
+| 6  | Jonathan Gomez       | Jedi Knights                | Calvary A/G (Elkhart, IN)              | 370   | 52.86  | 5  |
+| 7  | Austin Shepherd      | SPY All Stars               | River of Life Fellowship (Kent, WA)    | 340   | 48.57  | 4  |
+| 8  | Paul Willis          | Ashland                     | 1st A/G (Ashland, AL)                  | 335   | 47.86  | 1  |
+| 9  | Teddy Willis         | Ashland                     | 1st A/G (Ashland, AL)                  | 275   | 39.29  | 2  |
+| 10 | Jordan Raum          | Powerful Praying Platypuses | 1st A/G (Phoenix, AZ)                  | 260   | 37.14  |    |
+| 11 | Alex Rawlings        | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX) | 255   | 36.43  | 2  |
+| 12 | Cassidy Neal         | Powerful Praying Platypuses | 1st A/G (Phoenix, AZ)                  | 250   | 35.71  | 2  |
+| 13 | Jared Deppe          | Cordova                     | 1st A/G (Cordova, TN)                  | 250   | 35.71  | 1  |
+| 14 | Alyssa Walker        | Sonburst Alpha              | MCC (Mechanicsville, VA)               | 250   | 35.71  |    |
+| 15 | Joshua Kukuvka       | Sonburst Alpha              | MCC (Mechanicsville, VA)               | 240   | 34.29  |    |
+| 16 | Elijah Vanderhule    | Powerful Praying Platypuses | 1st A/G (Phoenix, AZ)                  | 230   | 32.86  |    |
+| 17 | Tucker Paulson       | Alien Ambassadors           | River of Life (Minot, ND)              | 225   | 32.14  | 1  |
+| 18 | Kaitlyn Ballard      | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX) | 200   | 28.57  |    |
+| 19 | Madie Rawlings       | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX) | 165   | 23.57  | 1  |
+| 20 | Michaela Toole       | SPY All Stars               | River of Life Fellowship (Kent, WA)    | 165   | 23.57  |    |
+| 21 | Katherine Preudhomme | Powerful Praying Platypuses | 1st A/G (Phoenix, AZ)                  | 140   | 20.00  |    |
+| 22 | Nathan Isner         | Sonburst Alpha              | MCC (Mechanicsville, VA)               | 130   | 18.57  | 1  |
+| 23 | Kristian Hoverson    | Alien Ambassadors           | River of Life (Minot, ND)              | 100   | 14.29  |    |
+| 24 | Lauren Randolph      | Jedi Knights                | Calvary A/G (Elkhart, IN)              | 90    | 12.86  |    |
+| 24 | Nathaniel Walker     | Sonburst Alpha              | MCC (Mechanicsville, VA)               | 90    | 12.86  |    |
+| 25 | Teddy Gutterud       | SPY All Stars               | River of Life Fellowship (Kent, WA)    | 80    | 11.43  |    |
+| 26 | Abbigail Vaughan     | Cordova                     | 1st A/G (Cordova, TN)                  | 40    | 5.71   |    |
+| 27 | Noah Zook            | Sonburst Alpha              | MCC (Mechanicsville, VA)               | 35    | 5.00   |    |
+| 28 | Nicole Bradberry     | Cordova                     | 1st A/G (Cordova, TN)                  | 20    | 2.86   |    |
+| 28 | Grace Catchings      | Ashland                     | 1st A/G (Ashland, AL)                  | 20    | 2.86   |    |
+| 29 | Caroline Coleman     | Ashland                     | 1st A/G (Ashland, AL)                  | 10    | 1.43   |    |
+| 29 | Lance Lewis          | Jedi Knights                | Calvary A/G (Elkhart, IN)              | 10    | 1.43   |    |
+| 29 | Anthony Webster      | Sonburst Alpha              | MCC (Mechanicsville, VA)               | 10    | 1.43   |    |
+| 30 | Dylan Quiggle        | Jedi Knights                | Calvary A/G (Elkhart, IN)              | 5     | .71    |    |
+| 31 | Madison Doise        | Sonburst Alpha              | MCC (Mechanicsville, VA)               |       | .00    |    |
+| 31 | Sara Gaither         | Ashland                     | 1st A/G (Ashland, AL)                  |       | .00    |    |
+| 32 | Zeke Rashid          | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX) | -5    | -0.71  |    |
+
+
+### Gray
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team              | Church                                         | W/L | Total | Avg    |
+|--:|-------------------|------------------------------------------------|-----|------:|-------:|
+| 1 | Fearsome Foursome | Trinity Church (Cedar Hill, TX)                | 6/1 | 1405  | 200.71 |
+| 2 | Christ\'s Crew    | Dayspring A/G (Bowling Green, OH)              | 5/2 | 1215  | 173.57 |
+| 3 | CRK Almighty      | Church of the Risen King (Gloucester City, NJ) | 5/2 | 1100  | 157.14 |
+| 4 | Blazing Swords    | West County (Chesterfield, MO)                 | 4/3 | 1035  | 147.86 |
+| 5 | Silver Spurs      | Bethel A/G (Askewville, NC)                    | 4/3 | 1150  | 164.29 |
+| 6 | Scottsdale Free   | 1st A/G (Scottsdale, AZ)                       | 3/4 | 1070  | 152.86 |
+| 7 | God Squad         | 1st A/G (Bernalillo, NM)                       | 1/6 | 575   | 82.14  |
+| 8 | Get Smart         | 1st A/G (Des Moines, IA)                       | 0/7 | 695   | 99.29  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer         | Team              | Church                                         | Total | Avg    | QO |
+|---:|-----------------|-------------------|------------------------------------------------|------:|-------:|---:|
+| 1  | Elle Miller     | Fearsome Foursome | Trinity Church (Cedar Hill, TX)                | 880   | 125.71 | 4  |
+| 2  | Alyssa Harden   | Silver Spurs      | Bethel A/G (Askewville, NC)                    | 650   | 92.86  | 2  |
+| 3  | Jared Jordan    | CRK Almighty      | Church of the Risen King (Gloucester City, NJ) | 605   | 86.43  | 3  |
+| 4  | Stephen Moses   | Scottsdale Free   | 1st A/G (Scottsdale, AZ)                       | 570   | 81.43  | 1  |
+| 5  | Aaron Smith     | Christ\'s Crew    | Dayspring A/G (Bowling Green, OH)              | 470   | 67.14  | 1  |
+| 6  | Daniel Kinger   | Blazing Swords    | West County (Chesterfield, MO)                 | 435   | 62.14  | 5  |
+| 7  | Evan Kobylski   | Christ\'s Crew    | Dayspring A/G (Bowling Green, OH)              | 410   | 58.57  |    |
+| 8  | Sarah Kinger    | Blazing Swords    | West County (Chesterfield, MO)                 | 390   | 55.71  | 1  |
+| 9  | Aaron Hardinge  | God Squad         | 1st A/G (Bernalillo, NM)                       | 390   | 55.71  |    |
+| 10 | Noah Ridgway    | Get Smart         | 1st A/G (Des Moines, IA)                       | 380   | 54.29  |    |
+| 11 | Coby Calvery    | Fearsome Foursome | Trinity Church (Cedar Hill, TX)                | 370   | 52.86  | 5  |
+| 12 | Will Bazemore   | Silver Spurs      | Bethel A/G (Askewville, NC)                    | 345   | 49.29  | 3  |
+| 13 | Lilly Schmitz   | Christ\'s Crew    | Dayspring A/G (Bowling Green, OH)              | 320   | 45.71  | 3  |
+| 14 | Russell Flores  | CRK Almighty      | Church of the Risen King (Gloucester City, NJ) | 290   | 41.43  | 2  |
+| 15 | Elijah Abad     | CRK Almighty      | Church of the Risen King (Gloucester City, NJ) | 205   | 29.29  |    |
+| 16 | Sophia Ridgway  | Get Smart         | 1st A/G (Des Moines, IA)                       | 190   | 27.14  |    |
+| 17 | Eliott Gathman  | Blazing Swords    | West County (Chesterfield, MO)                 | 170   | 24.29  | 1  |
+| 18 | Joanna Moses    | Scottsdale Free   | 1st A/G (Scottsdale, AZ)                       | 165   | 23.57  | 1  |
+| 19 | David Moses     | Scottsdale Free   | 1st A/G (Scottsdale, AZ)                       | 160   | 22.86  | 1  |
+| 20 | Peter Moses     | Scottsdale Free   | 1st A/G (Scottsdale, AZ)                       | 150   | 21.43  |    |
+| 21 | Daniel Castello | Silver Spurs      | Bethel A/G (Askewville, NC)                    | 120   | 17.14  |    |
+| 22 | Emma Tercero    | God Squad         | 1st A/G (Bernalillo, NM)                       | 115   | 16.43  |    |
+| 23 | Amelia Dixon    | Get Smart         | 1st A/G (Des Moines, IA)                       | 95    | 13.57  |    |
+| 24 | Rachel Rimmer   | Fearsome Foursome | Trinity Church (Cedar Hill, TX)                | 90    | 12.86  |    |
+| 25 | Ben Manoli      | Fearsome Foursome | Trinity Church (Cedar Hill, TX)                | 65    | 9.29   |    |
+| 26 | Hans Beker      | God Squad         | 1st A/G (Bernalillo, NM)                       | 50    | 7.14   |    |
+| 27 | Kaleb Smith     | Blazing Swords    | West County (Chesterfield, MO)                 | 40    | 5.71   |    |
+| 28 | Colton Hoggard  | Silver Spurs      | Bethel A/G (Askewville, NC)                    | 35    | 5.00   |    |
+| 29 | Lola Phillips   | Get Smart         | 1st A/G (Des Moines, IA)                       | 30    | 4.29   |    |
+| 29 | JD Welter       | God Squad         | 1st A/G (Bernalillo, NM)                       | 30    | 4.29   |    |
+| 30 | Holly Garrett   | Scottsdale Free   | 1st A/G (Scottsdale, AZ)                       | 25    | 3.57   |    |
+| 31 | Danielle Borja  | CRK Almighty      | Church of the Risen King (Gloucester City, NJ) | 20    | 2.86   |    |
+| 32 | Seth Estep      | Christ\'s Crew    | Dayspring A/G (Bowling Green, OH)              | 15    | 2.14   |    |
+| 33 | Sofia Beker     | God Squad         | 1st A/G (Bernalillo, NM)                       |       | .00    |    |
+| 33 | Yasmine Barlow  | God Squad         | 1st A/G (Bernalillo, NM)                       |       | .00    |    |
+| 33 | Leslie Flores   | God Squad         | 1st A/G (Bernalillo, NM)                       |       | .00    |    |
+| 33 | Elle Leebrick   | Scottsdale Free   | 1st A/G (Scottsdale, AZ)                       |       | .00    |    |
+| 33 | Kristiana Ramos | CRK Almighty      | Church of the Risen King (Gloucester City, NJ) |       | .00    |    |
+| 34 | Jillian Angeles | CRK Almighty      | Church of the Risen King (Gloucester City, NJ) | -15   | -2.14  |    |
+| 35 | Emily Beker     | God Squad         | 1st A/G (Bernalillo, NM)                       | -10   | -1.43  |    |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church                                  | W/L | Total | Avg    |
+|--:|---------------------------|-----------------------------------------|-----|------:|-------:|
+| 1 | Super Sonic Sailfish      | New Life Church (Princeton, MN)         | 6/1 | 1380  | 197.14 |
+| 2 | Lifeguards                | Destiny Christian Ctr. (Dayton, OH)     | 6/1 | 1325  | 189.29 |
+| 3 | Stone Quizzers            | Stone Church (Palos Heights, IL)        | 5/2 | 1300  | 185.71 |
+| 4 | S.P.Y. Kids 007           | The Worship Center (Leesburg, VA)       | 4/3 | 1375  | 196.43 |
+| 5 | Fizz Up                   | James River Assembly (Ozark, MO)        | 3/4 | 1065  | 152.14 |
+| 6 | Lightning                 | Carmel A/G (Bonifay, FL)                | 2/5 | 795   | 113.57 |
+| 7 | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 2/5 | 850   | 121.43 |
+| 8 | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)           | 0/7 | 105   | 15.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                      | Church                                  | Total | Avg    | QO |
+|---:|--------------------|---------------------------|-----------------------------------------|------:|-------:|---:|
+| 1  | Thomas Stewart     | Super Sonic Sailfish      | New Life Church (Princeton, MN)         | 765   | 109.29 | 2  |
+| 2  | Josh Rozelle       | S.P.Y. Kids 007           | The Worship Center (Leesburg, VA)       | 720   | 102.86 | 3  |
+| 3  | Caleb Jones        | Lifeguards                | Destiny Christian Ctr. (Dayton, OH)     | 540   | 77.14  | 5  |
+| 4  | Caleb Czaja        | Stone Quizzers            | Stone Church (Palos Heights, IL)        | 535   | 76.43  |    |
+| 5  | Weslee Kate Green  | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 515   | 73.57  | 2  |
+| 6  | Sean Jones         | Lifeguards                | Destiny Christian Ctr. (Dayton, OH)     | 510   | 72.86  | 1  |
+| 7  | Kelise Braithwaite | Fizz Up                   | James River Assembly (Ozark, MO)        | 455   | 65.00  | 2  |
+| 8  | Travis Griessel    | Fizz Up                   | James River Assembly (Ozark, MO)        | 420   | 60.00  | 2  |
+| 9  | Casey Walin        | Stone Quizzers            | Stone Church (Palos Heights, IL)        | 385   | 55.00  | 4  |
+| 10 | Micah Roelofs      | Super Sonic Sailfish      | New Life Church (Princeton, MN)         | 355   | 50.71  | 3  |
+| 11 | Luke Yoder         | S.P.Y. Kids 007           | The Worship Center (Leesburg, VA)       | 340   | 48.57  | 4  |
+| 12 | Brady Powell       | Lightning                 | Carmel A/G (Bonifay, FL)                | 340   | 48.57  | 1  |
+| 13 | Benjamin Judd      | S.P.Y. Kids 007           | The Worship Center (Leesburg, VA)       | 275   | 39.29  |    |
+| 14 | Will Zepp          | Lightning                 | Carmel A/G (Bonifay, FL)                | 270   | 38.57  |    |
+| 15 | Josiah Stewart     | Super Sonic Sailfish      | New Life Church (Princeton, MN)         | 240   | 34.29  | 1  |
+| 16 | Sopulu Anidobu     | Stone Quizzers            | Stone Church (Palos Heights, IL)        | 230   | 32.86  |    |
+| 17 | Joey Jones         | Lifeguards                | Destiny Christian Ctr. (Dayton, OH)     | 195   | 27.86  |    |
+| 18 | Nathan Green       | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 185   | 26.43  |    |
+| 19 | Reagan Griessel    | Fizz Up                   | James River Assembly (Ozark, MO)        | 150   | 21.43  | 1  |
+| 19 | Dayna Burns        | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 150   | 21.43  | 1  |
+| 20 | Naomi Czaja        | Stone Quizzers            | Stone Church (Palos Heights, IL)        | 130   | 18.57  |    |
+| 21 | Nick Stewart       | Lightning                 | Carmel A/G (Bonifay, FL)                | 85    | 12.14  |    |
+| 22 | JJ Paul            | Lightning                 | Carmel A/G (Bonifay, FL)                | 80    | 11.43  |    |
+| 23 | Jonah Gomes        | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)           | 50    | 7.14   |    |
+| 24 | Sarah Judd         | S.P.Y. Kids 007           | The Worship Center (Leesburg, VA)       | 40    | 5.71   |    |
+| 24 | Nathanael Heide    | Fizz Up                   | James River Assembly (Ozark, MO)        | 40    | 5.71   |    |
+| 24 | Jeannah Jones      | Lifeguards                | Destiny Christian Ctr. (Dayton, OH)     | 40    | 5.71   |    |
+| 24 | Jason Root         | Lifeguards                | Destiny Christian Ctr. (Dayton, OH)     | 40    | 5.71   |    |
+| 25 | Ayzhia-Marie Tadeo | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)           | 30    | 4.29   |    |
+| 26 | Isaiah Gomes       | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)           | 25    | 3.57   |    |
+| 27 | Kyler Stephan      | Stone Quizzers            | Stone Church (Palos Heights, IL)        | 20    | 2.86   |    |
+| 27 | Cameron Moore      | Lightning                 | Carmel A/G (Bonifay, FL)                | 20    | 2.86   |    |
+| 27 | Montana Lawrence   | Super Sonic Sailfish      | New Life Church (Princeton, MN)         | 20    | 2.86   |    |
+| 28 | Chasity Stalcup    | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)           | 5     | .71    |    |
+| 29 | Caleb Daniels      | Super Sonic Sailfish      | New Life Church (Princeton, MN)         |       | .00    |    |
+| 29 | Dena Schaeffer     | Lifeguards                | Destiny Christian Ctr. (Dayton, OH)     |       | .00    |    |
+| 29 | Katie Stalcup      | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)           |       | .00    |    |
+| 29 | Shanzie Tiqui      | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)           |       | .00    |    |
+| 29 | Ben Beeson         | Lifeguards                | Destiny Christian Ctr. (Dayton, OH)     |       | .00    |    |
+| 29 | Ryan Moos          | Super Sonic Sailfish      | New Life Church (Princeton, MN)         |       | .00    |    |
+| 29 | Udo Anidobu        | Stone Quizzers            | Stone Church (Palos Heights, IL)        |       | .00    |    |
+| 29 | Natalie Isaacs     | Lifeguards                | Destiny Christian Ctr. (Dayton, OH)     |       | .00    |    |
+| 29 | Tristyn Celestino  | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)           |       | .00    |    |
+| 30 | Isaac Stalcup      | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)           | -5    | -0.71  |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                    | Church                                   | W/L | Total | Avg    |
+|--:|-------------------------|------------------------------------------|-----|------:|-------:|
+| 1 | Soul Survivors          | Lawson A/G (Lawson, MO)                  | 6/1 | 1145  | 163.57 |
+| 2 | Naperville              | Calvary Church (Naperville, IL)          | 6/1 | 1745  | 249.29 |
+| 3 | God\'s C.R.E.W.         | Capitol Hill A/G (OKC, OK)               | 4/3 | 1075  | 153.57 |
+| 4 | Bible Cadets            | Ross Prep. Academy (Fallbrook, CA)       | 4/3 | 905   | 129.29 |
+| 5 | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) | 2/5 | 1050  | 150.00 |
+| 6 | Word Warriors           | Bethany Comm. Church (Mendon, MA)        | 2/5 | 835   | 119.29 |
+| 7 | Light                   | World Harvest (Roswell, GA)              | 2/5 | 820   | 117.14 |
+| 8 | Westgate Chapel A Team  | Westgate Chapel (Edmonds, WA)            | 2/5 | 780   | 111.43 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                       | Team                    | Church                                   | Total | Avg    | QO |
+|---:|-------------------------------|-------------------------|------------------------------------------|------:|-------:|---:|
+| 1  | Shreanna Powell               | Naperville              | Calvary Church (Naperville, IL)          | 945   | 135.00 | 6  |
+| 2  | Zachary Cook                  | Soul Survivors          | Lawson A/G (Lawson, MO)                  | 855   | 122.14 | 4  |
+| 3  | Alexandra E. E. Ross          | Bible Cadets            | Ross Prep. Academy (Fallbrook, CA)       | 650   | 92.86  | 3  |
+| 4  | Jordan Landry                 | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) | 615   | 87.86  | 2  |
+| 5  | Christina Baxter              | God\'s C.R.E.W.         | Capitol Hill A/G (OKC, OK)               | 560   | 80.00  | 1  |
+| 6  | Robert Laboy                  | Naperville              | Calvary Church (Naperville, IL)          | 505   | 72.14  | 7  |
+| 7  | Katie Burke                   | Word Warriors           | Bethany Comm. Church (Mendon, MA)        | 375   | 53.57  |    |
+| 8  | Garrett Miyaoka               | Westgate Chapel A Team  | Westgate Chapel (Edmonds, WA)            | 340   | 48.57  |    |
+| 9  | Grace Artis                   | Light                   | World Harvest (Roswell, GA)              | 325   | 46.43  | 1  |
+| 10 | Daniel Ferreira               | Light                   | World Harvest (Roswell, GA)              | 315   | 45.00  |    |
+| 11 | Catherine Baxter              | God\'s C.R.E.W.         | Capitol Hill A/G (OKC, OK)               | 290   | 41.43  | 2  |
+| 12 | Lauren Huseman                | Naperville              | Calvary Church (Naperville, IL)          | 285   | 40.71  | 1  |
+| 13 | Beatrice-Elizabeth A. C. Ross | Bible Cadets            | Ross Prep. Academy (Fallbrook, CA)       | 255   | 36.43  | 3  |
+| 14 | Brendon Sturgeon              | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) | 240   | 34.29  | 2  |
+| 15 | Breanna Cole                  | Soul Survivors          | Lawson A/G (Lawson, MO)                  | 240   | 34.29  | 1  |
+| 16 | Filip DaSilva                 | Word Warriors           | Bethany Comm. Church (Mendon, MA)        | 225   | 32.14  | 1  |
+| 17 | Trent Hashimoto               | Westgate Chapel A Team  | Westgate Chapel (Edmonds, WA)            | 220   | 31.43  | 1  |
+| 18 | Nicholas Tveit                | Westgate Chapel A Team  | Westgate Chapel (Edmonds, WA)            | 195   | 27.86  | 2  |
+| 19 | Bailey Bullock                | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) | 195   | 27.86  | 1  |
+| 20 | Kaelyn Comfort                | God\'s C.R.E.W.         | Capitol Hill A/G (OKC, OK)               | 190   | 27.14  |    |
+| 21 | Cristian Huix                 | Light                   | World Harvest (Roswell, GA)              | 180   | 25.71  | 2  |
+| 22 | Grace Caughey                 | Word Warriors           | Bethany Comm. Church (Mendon, MA)        | 120   | 17.14  |    |
+| 23 | John Fugere                   | Word Warriors           | Bethany Comm. Church (Mendon, MA)        | 75    | 10.71  |    |
+| 24 | Jonathan Archer               | Soul Survivors          | Lawson A/G (Lawson, MO)                  | 50    | 7.14   |    |
+| 25 | Isabelle Smith                | Westgate Chapel A Team  | Westgate Chapel (Edmonds, WA)            | 25    | 3.57   |    |
+| 26 | Jonathan Burke                | God\'s C.R.E.W.         | Capitol Hill A/G (OKC, OK)               | 20    | 2.86   |    |
+| 26 | Tayla Vannelli                | Word Warriors           | Bethany Comm. Church (Mendon, MA)        | 20    | 2.86   |    |
+| 26 | Bethany Perry                 | Word Warriors           | Bethany Comm. Church (Mendon, MA)        | 20    | 2.86   |    |
+| 27 | Miken Melvin                  | God\'s C.R.E.W.         | Capitol Hill A/G (OKC, OK)               | 15    | 2.14   |    |
+| 28 | Julia DeGraff                 | Naperville              | Calvary Church (Naperville, IL)          | 10    | 1.43   |    |
+| 29 | Abigail Bullock               | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) |       | .00    |    |
+| 29 | Nathan Burke                  | God\'s C.R.E.W.         | Capitol Hill A/G (OKC, OK)               |       | .00    |    |
+| 29 | Jessica McElwee               | Naperville              | Calvary Church (Naperville, IL)          |       | .00    |    |
+| 29 | Nicholas Theriot              | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) |       | .00    |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                        | Church                                       | W/L | Total | Avg    |
+|--:|-----------------------------|----------------------------------------------|-----|------:|-------:|
+| 1 | Kingdom Explorers           | Mt. Creek Comm. Church (Dallas, TX)          | 6/1 | 1660  | 237.14 |
+| 2 | Greeneway Gospel Warriors   | Greeneway Church (Orlando, FL)               | 6/1 | 1260  | 180.00 |
+| 3 | Oak Creek Biblikids         | Oak Creek A/G (Oak Creek, WI)                | 4/3 | 1190  | 170.00 |
+| 4 | JUMP Kids                   | Family Life Christian Ctr. (Federal Way, WA) | 4/3 | 965   | 137.86 |
+| 5 | Greater Lansing             | 1st A/G (East Lansing, MI)                   | 4/3 | 930   | 132.86 |
+| 6 | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)         | 3/4 | 735   | 105.00 |
+| 7 | Justified Gems              | Evangel (Columbus, MS)                       | 1/6 | 680   | 97.14  |
+| 8 | Wild Things                 | Glad Tidings Church (Hanford, CA)            | 0/7 | 415   | 59.29  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                        | Church                                       | Total | Avg    | QO |
+|---:|--------------------|-----------------------------|----------------------------------------------|------:|-------:|---:|
+| 1  | Elijah Evers       | Oak Creek Biblikids         | Oak Creek A/G (Oak Creek, WI)                | 860   | 122.86 | 5  |
+| 2  | Samuel Grey        | Kingdom Explorers           | Mt. Creek Comm. Church (Dallas, TX)          | 795   | 113.57 | 6  |
+| 3  | Zachary Barlow     | Greeneway Gospel Warriors   | Greeneway Church (Orlando, FL)               | 715   | 102.14 | 4  |
+| 4  | Luis Torres        | Kingdom Explorers           | Mt. Creek Comm. Church (Dallas, TX)          | 580   | 82.86  | 4  |
+| 5  | Kirsten Andrews    | Greater Lansing             | 1st A/G (East Lansing, MI)                   | 515   | 73.57  | 3  |
+| 6  | McKenzie Barlow    | Greeneway Gospel Warriors   | Greeneway Church (Orlando, FL)               | 420   | 60.00  | 2  |
+| 7  | Nicholas Boyce     | JUMP Kids                   | Family Life Christian Ctr. (Federal Way, WA) | 365   | 52.14  | 1  |
+| 8  | Jonathan Larson    | JUMP Kids                   | Family Life Christian Ctr. (Federal Way, WA) | 345   | 49.29  | 2  |
+| 9  | Robert Brock       | Wild Things                 | Glad Tidings Church (Hanford, CA)            | 340   | 48.57  |    |
+| 10 | Joy Okafor         | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)         | 315   | 45.00  | 3  |
+| 11 | Jaret Williams     | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)         | 295   | 42.14  | 1  |
+| 12 | Glenn Kaboskey     | Oak Creek Biblikids         | Oak Creek A/G (Oak Creek, WI)                | 290   | 41.43  | 3  |
+| 13 | Tyler McCartney    | Greater Lansing             | 1st A/G (East Lansing, MI)                   | 255   | 36.43  |    |
+| 14 | Kathryn Mackey     | Justified Gems              | Evangel (Columbus, MS)                       | 210   | 30.00  |    |
+| 15 | Patrick Keenan     | Kingdom Explorers           | Mt. Creek Comm. Church (Dallas, TX)          | 200   | 28.57  | 2  |
+| 16 | Billy Brewer       | Justified Gems              | Evangel (Columbus, MS)                       | 200   | 28.57  | 1  |
+| 17 | Maddie Hawkes      | JUMP Kids                   | Family Life Christian Ctr. (Federal Way, WA) | 195   | 27.86  | 1  |
+| 18 | Jeanette Surajbali | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)         | 175   | 25.00  |    |
+| 19 | Cameron Wilcox     | Justified Gems              | Evangel (Columbus, MS)                       | 130   | 18.57  |    |
+| 20 | John Schafer       | Greater Lansing             | 1st A/G (East Lansing, MI)                   | 120   | 17.14  |    |
+| 20 | Emilee Wilcox      | Justified Gems              | Evangel (Columbus, MS)                       | 120   | 17.14  |    |
+| 21 | Kyle Ritter        | Greeneway Gospel Warriors   | Greeneway Church (Orlando, FL)               | 90    | 12.86  |    |
+| 22 | Trent Stafford     | Wild Things                 | Glad Tidings Church (Hanford, CA)            | 75    | 10.71  |    |
+| 23 | Lizzie Dambacher   | JUMP Kids                   | Family Life Christian Ctr. (Federal Way, WA) | 60    | 8.57   |    |
+| 24 | Matthew Keenan     | Kingdom Explorers           | Mt. Creek Comm. Church (Dallas, TX)          | 50    | 7.14   |    |
+| 25 | Katie Tamblyn      | Oak Creek Biblikids         | Oak Creek A/G (Oak Creek, WI)                | 40    | 5.71   |    |
+| 25 | Claire Convis      | Greater Lansing             | 1st A/G (East Lansing, MI)                   | 40    | 5.71   |    |
+| 25 | AryAnna Bennett    | Kingdom Explorers           | Mt. Creek Comm. Church (Dallas, TX)          | 40    | 5.71   |    |
+| 26 | Caleb Barlow       | Greeneway Gospel Warriors   | Greeneway Church (Orlando, FL)               | 35    | 5.00   |    |
+| 27 | Shashendri DeSilva | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)         | 25    | 3.57   |    |
+| 28 | Caleb Brewer       | Justified Gems              | Evangel (Columbus, MS)                       | 20    | 2.86   |    |
+| 29 | Esji Johnson       | Oak Creek Biblikids         | Oak Creek A/G (Oak Creek, WI)                |       | .00    |    |
+| 29 | Christon Stewart   | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)         |       | .00    |    |
+| 29 | Celah Convis       | Greater Lansing             | 1st A/G (East Lansing, MI)                   |       | .00    |    |
+| 29 | Alyssa Sachs       | Oak Creek Biblikids         | Oak Creek A/G (Oak Creek, WI)                |       | .00    |    |
+| 29 | Darcie Harr        | Greater Lansing             | 1st A/G (East Lansing, MI)                   |       | .00    |    |
+| 30 | Nicole DeSilva     | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)         | -65   | -9.29  |    |
+| 31 | Rebecca Ramnauth   | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)         | -5    | -0.71  |    |
+| 31 | Jeremiah Umali     | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)         | -5    | -0.71  |    |
+
+
+### Purple
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                  | Church                                        | W/L | Total | Avg    |
+|--:|-----------------------|-----------------------------------------------|-----|------:|-------:|
+| 1 | Master\'s Mavericks   | Abundant Life Church (Grapevine, TX)          | 6/1 | 1275  | 182.14 |
+| 2 | Buzz Hogs             | River of Life (Mabelvale, AR)                 | 5/2 | 1005  | 143.57 |
+| 3 | FCA - Cincinnati      | First Christian A/G (Cincinnati, OH)          | 5/2 | 1050  | 150.00 |
+| 4 | Los Chicos            | City Church (Sanford, FL)                     | 4/3 | 940   | 134.29 |
+| 5 | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 3/4 | 915   | 130.71 |
+| 6 | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)      | 2/5 | 820   | 117.14 |
+| 7 | God\'s Victory Kids   | Victory A/G (Universal City, TX)              | 2/5 | 825   | 117.86 |
+| 8 | Quiztastic Four       | Tiffany Fellowship (KC, MO)                   | 1/6 | 550   | 78.57  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                  | Church                                        | Total | Avg   | QO |
+|---:|---------------------|-----------------------|-----------------------------------------------|------:|------:|---:|
+| 1  | Jared Minick        | Buzz Hogs             | River of Life (Mabelvale, AR)                 | 575   | 82.14 | 1  |
+| 2  | David Brauchler     | Master\'s Mavericks   | Abundant Life Church (Grapevine, TX)          | 570   | 81.43 | 2  |
+| 3  | Tyler Cardiel       | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)      | 560   | 80.00 | 2  |
+| 4  | Brennan Dodds       | FCA - Cincinnati      | First Christian A/G (Cincinnati, OH)          | 430   | 61.43 |    |
+| 5  | Peyton Goss         | Los Chicos            | City Church (Sanford, FL)                     | 400   | 57.14 |    |
+| 6  | Zach Wylie          | God\'s Victory Kids   | Victory A/G (Universal City, TX)              | 390   | 55.71 |    |
+| 7  | Jaden Werley        | Master\'s Mavericks   | Abundant Life Church (Grapevine, TX)          | 380   | 54.29 | 4  |
+| 8  | Jacob Jeter         | Master\'s Mavericks   | Abundant Life Church (Grapevine, TX)          | 325   | 46.43 |    |
+| 9  | Carmel Lee          | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 320   | 45.71 |    |
+| 10 | Trenton Page        | Buzz Hogs             | River of Life (Mabelvale, AR)                 | 310   | 44.29 | 4  |
+| 11 | Matthew Robinson    | Los Chicos            | City Church (Sanford, FL)                     | 305   | 43.57 | 2  |
+| 12 | Brendan Ferguson    | Quiztastic Four       | Tiffany Fellowship (KC, MO)                   | 305   | 43.57 |    |
+| 13 | Jared Kleinhenz     | FCA - Cincinnati      | First Christian A/G (Cincinnati, OH)          | 280   | 40.00 |    |
+| 14 | Jeremy Wu           | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 270   | 38.57 | 2  |
+| 15 | Ariana Zhu          | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 220   | 31.43 |    |
+| 16 | Paul Russell, Jr.   | God\'s Victory Kids   | Victory A/G (Universal City, TX)              | 210   | 30.00 |    |
+| 17 | Noah Harris         | God\'s Victory Kids   | Victory A/G (Universal City, TX)              | 195   | 27.86 |    |
+| 18 | Toby Robinson       | Los Chicos            | City Church (Sanford, FL)                     | 180   | 25.71 | 1  |
+| 19 | Bekah Ray           | FCA - Cincinnati      | First Christian A/G (Cincinnati, OH)          | 160   | 22.86 | 1  |
+| 20 | Ethan Smith         | FCA - Cincinnati      | First Christian A/G (Cincinnati, OH)          | 160   | 22.86 |    |
+| 21 | Maggie Akinleye     | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)      | 110   | 15.71 |    |
+| 22 | Bridge Biniakewitz  | Buzz Hogs             | River of Life (Mabelvale, AR)                 | 100   | 14.29 |    |
+| 23 | Harrison Ku         | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 95    | 13.57 |    |
+| 24 | Connor Ferguson     | Quiztastic Four       | Tiffany Fellowship (KC, MO)                   | 90    | 12.86 |    |
+| 24 | Tyler Bernheisel    | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)      | 90    | 12.86 |    |
+| 24 | Tyler Lake          | Quiztastic Four       | Tiffany Fellowship (KC, MO)                   | 90    | 12.86 |    |
+| 25 | Jordan Birmingham   | Quiztastic Four       | Tiffany Fellowship (KC, MO)                   | 65    | 9.29  |    |
+| 26 | Braden Pennington   | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)      | 60    | 8.57  |    |
+| 27 | Aubrey Goss         | Los Chicos            | City Church (Sanford, FL)                     | 40    | 5.71  |    |
+| 28 | Jakob Schweizerhoff | God\'s Victory Kids   | Victory A/G (Universal City, TX)              | 30    | 4.29  |    |
+| 29 | Gunnar Smart        | FCA - Cincinnati      | First Christian A/G (Cincinnati, OH)          | 20    | 2.86  |    |
+| 29 | Jonathan Huber      | Los Chicos            | City Church (Sanford, FL)                     | 20    | 2.86  |    |
+| 29 | Savanah Biniakewitz | Buzz Hogs             | River of Life (Mabelvale, AR)                 | 20    | 2.86  |    |
+| 30 | Calvin Lee          | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 10    | 1.43  |    |
+| 31 | Julie Huber         | Los Chicos            | City Church (Sanford, FL)                     |       | .00   |    |
+| 31 | Kasie Narvaez       | God\'s Victory Kids   | Victory A/G (Universal City, TX)              |       | .00   |    |
+| 31 | Janet Li            | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) |       | .00   |    |
+| 31 | Levi Biniakewitz    | Buzz Hogs             | River of Life (Mabelvale, AR)                 |       | .00   |    |
+| 31 | Jack Titkemeyer     | FCA - Cincinnati      | First Christian A/G (Cincinnati, OH)          |       | .00   |    |
+| 32 | Jonathan Robinson   | Los Chicos            | City Church (Sanford, FL)                     | -5    | -0.71 |    |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                                | Church                            | W/L | Total | Avg    |
+|--:|-------------------------------------|-----------------------------------|-----|------:|-------:|
+| 1 | S.P.Y. Kids 006                     | The Worship Center (Leesburg, VA) | 6/1 | 1190  | 170.00 |
+| 2 | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)       | 6/1 | 1070  | 152.86 |
+| 3 | 3-n-1                               | 1st A/G (Goldsboro, NC)           | 5/2 | 1105  | 157.86 |
+| 4 | Harrison Thrashers                  | Faith A/G (Harrison, AR)          | 4/3 | 1060  | 151.43 |
+| 5 | Grace Assembly of God               | Grace A/G (New Whiteland, IN)     | 4/3 | 1125  | 160.71 |
+| 6 | G.R.I.P.                            | The Bridge (Mustang, OK)          | 2/5 | 860   | 122.86 |
+| 7 | Status Update                       | 1st A/G (Fargo, ND)               | 1/6 | 815   | 116.43 |
+| 8 | Phoenix First Frogs                 | 1st A/G (Phoenix, AZ)             | 0/7 | 720   | 102.86 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                                | Church                            | Total | Avg   | QO |
+|---:|-------------------|-------------------------------------|-----------------------------------|------:|------:|---:|
+| 1  | Deyja Middleton   | 3-n-1                               | 1st A/G (Goldsboro, NC)           | 560   | 80.00 | 4  |
+| 2  | Makenzie Bradshaw | Harrison Thrashers                  | Faith A/G (Harrison, AR)          | 490   | 70.00 | 1  |
+| 3  | Alissa Garrett    | Grace Assembly of God               | Grace A/G (New Whiteland, IN)     | 480   | 68.57 |    |
+| 4  | Tyler Howard      | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)       | 475   | 67.86 | 2  |
+| 5  | Erika Fox         | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)       | 465   | 66.43 | 3  |
+| 6  | Matthew Bozzay    | S.P.Y. Kids 006                     | The Worship Center (Leesburg, VA) | 460   | 65.71 | 1  |
+| 7  | Erin O\'Mara      | S.P.Y. Kids 006                     | The Worship Center (Leesburg, VA) | 415   | 59.29 |    |
+| 8  | Samuel Wilkerson  | 3-n-1                               | 1st A/G (Goldsboro, NC)           | 410   | 58.57 |    |
+| 9  | Sarah Lane        | Phoenix First Frogs                 | 1st A/G (Phoenix, AZ)             | 400   | 57.14 |    |
+| 10 | Carson Nix        | Status Update                       | 1st A/G (Fargo, ND)               | 395   | 56.43 |    |
+| 11 | Luke Richardson   | Grace Assembly of God               | Grace A/G (New Whiteland, IN)     | 380   | 54.29 | 1  |
+| 12 | Luke Grisham      | G.R.I.P.                            | The Bridge (Mustang, OK)          | 320   | 45.71 |    |
+| 13 | Alex Shell        | G.R.I.P.                            | The Bridge (Mustang, OK)          | 305   | 43.57 | 1  |
+| 14 | Aaron Marchand    | Status Update                       | 1st A/G (Fargo, ND)               | 255   | 36.43 | 2  |
+| 15 | Evan Still        | Harrison Thrashers                  | Faith A/G (Harrison, AR)          | 245   | 35.00 |    |
+| 16 | Aidan Strain      | Grace Assembly of God               | Grace A/G (New Whiteland, IN)     | 230   | 32.86 | 2  |
+| 17 | James Lane        | Phoenix First Frogs                 | 1st A/G (Phoenix, AZ)             | 205   | 29.29 |    |
+| 18 | Alyssa Campbell   | G.R.I.P.                            | The Bridge (Mustang, OK)          | 195   | 27.86 |    |
+| 19 | Ben Rozelle       | S.P.Y. Kids 006                     | The Worship Center (Leesburg, VA) | 180   | 25.71 | 1  |
+| 20 | Kerigan Bradshaw  | Harrison Thrashers                  | Faith A/G (Harrison, AR)          | 180   | 25.71 |    |
+| 21 | Micah Marchand    | Status Update                       | 1st A/G (Fargo, ND)               | 165   | 23.57 |    |
+| 22 | Renee Betterson   | 3-n-1                               | 1st A/G (Goldsboro, NC)           | 135   | 19.29 | 1  |
+| 23 | Abby Bailey       | Harrison Thrashers                  | Faith A/G (Harrison, AR)          | 125   | 17.86 |    |
+| 24 | Brian O\'Mara     | S.P.Y. Kids 006                     | The Worship Center (Leesburg, VA) | 115   | 16.43 | 1  |
+| 25 | Bethany Lane      | Phoenix First Frogs                 | 1st A/G (Phoenix, AZ)             | 115   | 16.43 |    |
+| 26 | Tirzah Brookbank  | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)       | 110   | 15.71 |    |
+| 27 | Evan Gray         | G.R.I.P.                            | The Bridge (Mustang, OK)          | 45    | 6.43  |    |
+| 28 | Claire Richardson | Grace Assembly of God               | Grace A/G (New Whiteland, IN)     | 30    | 4.29  |    |
+| 29 | Duncan Connors    | S.P.Y. Kids 006                     | The Worship Center (Leesburg, VA) | 25    | 3.57  |    |
+| 30 | Laura Henderson   | Harrison Thrashers                  | Faith A/G (Harrison, AR)          | 20    | 2.86  |    |
+| 30 | Hannah Merrell    | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)       | 20    | 2.86  |    |
+| 31 | Andrea Little     | Grace Assembly of God               | Grace A/G (New Whiteland, IN)     | 5     | .71   |    |
+| 32 | Jed Brookbank     | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)       |       | .00   |    |
+| 32 | Landon Grisham    | G.R.I.P.                            | The Bridge (Mustang, OK)          |       | .00   |    |
+| 32 | Lauren Grisham    | G.R.I.P.                            | The Bridge (Mustang, OK)          |       | .00   |    |
+| 32 | Katherine Bozzay  | S.P.Y. Kids 006                     | The Worship Center (Leesburg, VA) |       | .00   |    |
+| 32 | Kailan Weidner    | G.R.I.P.                            | The Bridge (Mustang, OK)          |       | .00   |    |
+| 33 | Caleb Horn        | G.R.I.P.                            | The Bridge (Mustang, OK)          | -5    | -0.71 |    |
+
+
+### White
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                          | Church                             | W/L | Total | Avg    |
+|--:|-------------------------------|------------------------------------|-----|------:|-------:|
+| 1 | International Assembly of God | International A/G (Warren, MI)     | 6/1 | 1235  | 176.43 |
+| 2 | Fizz Over                     | James River Assembly (Ozark, MO)   | 5/2 | 1160  | 165.71 |
+| 3 | God Worshippers               | Glad Tidings (Omaha, NE)           | 4/3 | 1015  | 145.00 |
+| 4 | Ocala First                   | 1st A/G (Ocala, FL)                | 4/3 | 1170  | 167.14 |
+| 5 | The Giant Smarties            | Bethel Temple A/G (Huntington, WV) | 3/4 | 655   | 93.57  |
+| 6 | Evangel Qwizzlers             | Evangel Church (Scotch Plains, NJ) | 3/4 | 1125  | 160.71 |
+| 7 | Bible Worms                   | 1st A/G (Dumas,TX)                 | 2/5 | 805   | 115.00 |
+| 8 | IAG Seals                     | International A/G (Mesa, AZ)       | 1/6 | 530   | 75.71  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                          | Church                             | Total | Avg    | QO |
+|---:|------------------------|-------------------------------|------------------------------------|------:|-------:|---:|
+| 1  | Chase Petry            | Ocala First                   | 1st A/G (Ocala, FL)                | 740   | 105.71 | 3  |
+| 2  | Stephen Thomas         | Evangel Qwizzlers             | Evangel Church (Scotch Plains, NJ) | 615   | 87.86  | 2  |
+| 3  | Jillian Griffith       | Fizz Over                     | James River Assembly (Ozark, MO)   | 560   | 80.00  | 3  |
+| 4  | Sherlin Chacko         | International Assembly of God | International A/G (Warren, MI)     | 535   | 76.43  | 1  |
+| 5  | Jaron Klassen          | Fizz Over                     | James River Assembly (Ozark, MO)   | 470   | 67.14  | 2  |
+| 6  | Elizabeth Kaffenberger | God Worshippers               | Glad Tidings (Omaha, NE)           | 380   | 54.29  | 2  |
+| 7  | Amanda Kepplin         | God Worshippers               | Glad Tidings (Omaha, NE)           | 370   | 52.86  |    |
+| 8  | Seth Hensley           | The Giant Smarties            | Bethel Temple A/G (Huntington, WV) | 330   | 47.14  | 1  |
+| 9  | Ashley Theesfeld       | IAG Seals                     | International A/G (Mesa, AZ)       | 330   | 47.14  |    |
+| 10 | Emma Alfey             | Ocala First                   | 1st A/G (Ocala, FL)                | 325   | 46.43  | 4  |
+| 11 | Ruth Anne Sanderson    | Evangel Qwizzlers             | Evangel Church (Scotch Plains, NJ) | 295   | 42.14  | 3  |
+| 12 | Jerrin George          | International Assembly of God | International A/G (Warren, MI)     | 285   | 40.71  |    |
+| 13 | Nicholas Clemens       | Bible Worms                   | 1st A/G (Dumas,TX)                 | 280   | 40.00  | 4  |
+| 14 | Albert George          | International Assembly of God | International A/G (Warren, MI)     | 260   | 37.14  | 3  |
+| 15 | Dugan Akins            | Bible Worms                   | 1st A/G (Dumas,TX)                 | 235   | 33.57  |    |
+| 16 | Maggie Akins           | Bible Worms                   | 1st A/G (Dumas,TX)                 | 215   | 30.71  |    |
+| 17 | Madyson Theesfeld      | IAG Seals                     | International A/G (Mesa, AZ)       | 200   | 28.57  | 1  |
+| 18 | Laura Hetrick          | God Worshippers               | Glad Tidings (Omaha, NE)           | 170   | 24.29  |    |
+| 19 | Noah Hensley           | The Giant Smarties            | Bethel Temple A/G (Huntington, WV) | 160   | 22.86  | 1  |
+| 20 | Sarah Jacob            | International Assembly of God | International A/G (Warren, MI)     | 155   | 22.14  |    |
+| 21 | Abby O\'Connell        | Fizz Over                     | James River Assembly (Ozark, MO)   | 100   | 14.29  |    |
+| 21 | Stanley Thomas         | Evangel Qwizzlers             | Evangel Church (Scotch Plains, NJ) | 100   | 14.29  |    |
+| 22 | Philip Greenaway       | Ocala First                   | 1st A/G (Ocala, FL)                | 95    | 13.57  |    |
+| 23 | Makayla Lowe           | The Giant Smarties            | Bethel Temple A/G (Huntington, WV) | 80    | 11.43  |    |
+| 24 | Ashli Sauer            | Bible Worms                   | 1st A/G (Dumas,TX)                 | 75    | 10.71  | 1  |
+| 25 | Brianna Haufman        | Evangel Qwizzlers             | Evangel Church (Scotch Plains, NJ) | 70    | 10.00  |    |
+| 26 | Ashley Webb            | The Giant Smarties            | Bethel Temple A/G (Huntington, WV) | 60    | 8.57   |    |
+| 26 | Will Brovold           | God Worshippers               | Glad Tidings (Omaha, NE)           | 60    | 8.57   |    |
+| 27 | Benshel Bright         | Evangel Qwizzlers             | Evangel Church (Scotch Plains, NJ) | 45    | 6.43   |    |
+| 28 | Catherine Hetrick      | God Worshippers               | Glad Tidings (Omaha, NE)           | 35    | 5.00   |    |
+| 29 | Leisl Janesen          | Fizz Over                     | James River Assembly (Ozark, MO)   | 30    | 4.29   |    |
+| 30 | Mark Ziegler           | The Giant Smarties            | Bethel Temple A/G (Huntington, WV) | 25    | 3.57   |    |
+| 31 | Joel Alfrey            | Ocala First                   | 1st A/G (Ocala, FL)                | 10    | 1.43   |    |
+| 32 | Justin Cheriyan        | IAG Seals                     | International A/G (Mesa, AZ)       |       | .00    |    |
+| 32 | Gavin Griffith         | Fizz Over                     | James River Assembly (Ozark, MO)   |       | .00    |    |
+| 32 | Michael Webb           | The Giant Smarties            | Bethel Temple A/G (Huntington, WV) |       | .00    |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church                                   | W/L | Total | Avg    |
+|--:|---------------------------|------------------------------------------|-----|------:|-------:|
+| 1 | Tribulation Force         | The Oaks Fellowship (Red Oak, TX)        | 6/1 | 1285  | 183.57 |
+| 2 | Word of Life Swordbearers | Word of Life (Springfield, VA)           | 6/1 | 1210  | 172.86 |
+| 3 | Army of God               | Calvary Church (Greensboro, NC)          | 6/1 | 1135  | 162.14 |
+| 4 | FBI                       | Celebration Church (Lakeville, MN)       | 3/4 | 990   | 141.43 |
+| 5 | New Life C.L.A.Y.         | New Life Church (Billings, MT)           | 2/5 | 890   | 127.14 |
+| 6 | Tazmanian Truth Seekers   | 1st A/G (Ft. Wayne, IN)                  | 2/5 | 820   | 117.14 |
+| 7 | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                    | 2/5 | 705   | 100.71 |
+| 8 | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 1/6 | 840   | 120.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                      | Church                                   | Total | Avg   | QO |
+|---:|----------------------|---------------------------|------------------------------------------|------:|------:|---:|
+| 1  | Alecia Rajesh        | Army of God               | Calvary Church (Greensboro, NC)          | 645   | 92.14 | 2  |
+| 2  | David Inyangson      | Word of Life Swordbearers | Word of Life (Springfield, VA)           | 500   | 71.43 |    |
+| 3  | David Saunders       | Tribulation Force         | The Oaks Fellowship (Red Oak, TX)        | 480   | 68.57 |    |
+| 4  | Tia Lubinski         | FBI                       | Celebration Church (Lakeville, MN)       | 475   | 67.86 |    |
+| 5  | Elijah O\'Brien      | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 470   | 67.14 |    |
+| 6  | Parker Frankiewicz   | Tribulation Force         | The Oaks Fellowship (Red Oak, TX)        | 460   | 65.71 |    |
+| 7  | Chris Collins        | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                    | 440   | 62.86 |    |
+| 8  | Danika Houde         | New Life C.L.A.Y.         | New Life Church (Billings, MT)           | 370   | 52.86 |    |
+| 9  | Ethan Storms         | Tazmanian Truth Seekers   | 1st A/G (Ft. Wayne, IN)                  | 340   | 48.57 | 1  |
+| 10 | Emilia Chavez        | New Life C.L.A.Y.         | New Life Church (Billings, MT)           | 305   | 43.57 | 3  |
+| 11 | William Ubert        | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 240   | 34.29 | 2  |
+| 12 | Landin Jacquay       | Tazmanian Truth Seekers   | 1st A/G (Ft. Wayne, IN)                  | 235   | 33.57 | 2  |
+| 13 | Leah Thomas          | Word of Life Swordbearers | Word of Life (Springfield, VA)           | 225   | 32.14 | 1  |
+| 14 | Matthew Hipshire     | Tribulation Force         | The Oaks Fellowship (Red Oak, TX)        | 215   | 30.71 | 1  |
+| 15 | Madison Heath        | FBI                       | Celebration Church (Lakeville, MN)       | 210   | 30.00 |    |
+| 16 | Rohan George         | Army of God               | Calvary Church (Greensboro, NC)          | 190   | 27.14 | 1  |
+| 17 | Eva Clark            | FBI                       | Celebration Church (Lakeville, MN)       | 185   | 26.43 |    |
+| 18 | Jerrell Sydney       | Word of Life Swordbearers | Word of Life (Springfield, VA)           | 175   | 25.00 | 1  |
+| 19 | Aleah Robinson       | New Life C.L.A.Y.         | New Life Church (Billings, MT)           | 175   | 25.00 |    |
+| 20 | Keiron Fontaine      | Word of Life Swordbearers | Word of Life (Springfield, VA)           | 170   | 24.29 |    |
+| 21 | Samuel King          | Tazmanian Truth Seekers   | 1st A/G (Ft. Wayne, IN)                  | 165   | 23.57 |    |
+| 22 | Cody Collins         | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                    | 135   | 19.29 |    |
+| 23 | Cameron Berta        | Tribulation Force         | The Oaks Fellowship (Red Oak, TX)        | 130   | 18.57 |    |
+| 24 | Taylor Bridges       | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 125   | 17.86 |    |
+| 25 | Dylan Lovick         | FBI                       | Celebration Church (Lakeville, MN)       | 120   | 17.14 |    |
+| 25 | Aaron CyrilJohn      | Army of God               | Calvary Church (Greensboro, NC)          | 120   | 17.14 |    |
+| 26 | Divya Mathews        | Word of Life Swordbearers | Word of Life (Springfield, VA)           | 90    | 12.86 |    |
+| 26 | Abigail Prejean      | Army of God               | Calvary Church (Greensboro, NC)          | 90    | 12.86 |    |
+| 26 | Faith Davis          | Army of God               | Calvary Church (Greensboro, NC)          | 90    | 12.86 |    |
+| 27 | Isaac Reading        | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                    | 80    | 11.43 |    |
+| 28 | David Boller         | Tazmanian Truth Seekers   | 1st A/G (Ft. Wayne, IN)                  | 60    | 8.57  |    |
+| 29 | Gerald Koon          | Word of Life Swordbearers | Word of Life (Springfield, VA)           | 50    | 7.14  |    |
+| 30 | Vincent Hall-Shipley | New Life C.L.A.Y.         | New Life Church (Billings, MT)           | 40    | 5.71  |    |
+| 30 | Emily Rogers         | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                    | 40    | 5.71  |    |
+| 31 | Seth King            | Tazmanian Truth Seekers   | 1st A/G (Ft. Wayne, IN)                  | 20    | 2.86  |    |
+| 32 | Alisa Rosen          | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                    | 10    | 1.43  |    |
+| 33 | Anthony Mikolajewski | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 5     | .71   |    |
+| 33 | Keenan Messmer       | New Life C.L.A.Y.         | New Life Church (Billings, MT)           | 5     | .71   |    |
+| 34 | Harrison Hoggard     | Tribulation Force         | The Oaks Fellowship (Red Oak, TX)        |       | .00   |    |
+| 34 | Heather Erickson     | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) |       | .00   |    |
+| 34 | Isabella Burt        | Word of Life Swordbearers | Word of Life (Springfield, VA)           |       | .00   |    |
+| 34 | Ashton Heath         | FBI                       | Celebration Church (Lakeville, MN)       |       | .00   |    |
+| 34 | Grayson Vestergaard  | Tazmanian Truth Seekers   | 1st A/G (Ft. Wayne, IN)                  |       | .00   |    |
+| 35 | Tessa Houde          | New Life C.L.A.Y.         | New Life Church (Billings, MT)           | -5    | -0.71 |    |
+
+
+## Friday (PM)
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                  | Church                                       | W/L | Total | Avg    |
+|--:|-----------------------|----------------------------------------------|-----|------:|-------:|
+| 1 | JUMP Kids             | Family Life Christian Ctr. (Federal Way, WA) | 5/0 | 800   | 160.00 |
+| 2 | New Life C.L.A.Y.     | New Life Church (Billings, MT)               | 4/1 | 910   | 182.00 |
+| 3 | S.P.Y. Kids 007       | The Worship Center (Leesburg, VA)            | 3/2 | 815   | 163.00 |
+| 4 | Grace Assembly of God | Grace A/G (New Whiteland, IN)                | 1/4 | 780   | 156.00 |
+| 5 | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                     | 1/4 | 625   | 125.00 |
+| 6 | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)     | 1/4 | 485   | 97.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                  | Church                                       | Total | Avg   | QO |
+|---:|----------------------|-----------------------|----------------------------------------------|------:|------:|---:|
+| 1  | Josh Rozelle         | S.P.Y. Kids 007       | The Worship Center (Leesburg, VA)            | 475   | 95.00 | 1  |
+| 2  | Nicholas Boyce       | JUMP Kids             | Family Life Christian Ctr. (Federal Way, WA) | 400   | 80.00 | 3  |
+| 3  | Aleah Robinson       | New Life C.L.A.Y.     | New Life Church (Billings, MT)               | 380   | 76.00 |    |
+| 4  | Luke Richardson      | Grace Assembly of God | Grace A/G (New Whiteland, IN)                | 350   | 70.00 | 1  |
+| 5  | Stephen Moses        | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                     | 330   | 66.00 |    |
+| 6  | Alissa Garrett       | Grace Assembly of God | Grace A/G (New Whiteland, IN)                | 295   | 59.00 |    |
+| 7  | Emilia Chavez        | New Life C.L.A.Y.     | New Life Church (Billings, MT)               | 285   | 57.00 | 4  |
+| 8  | Benjamin Judd        | S.P.Y. Kids 007       | The Worship Center (Leesburg, VA)            | 255   | 51.00 | 2  |
+| 9  | Tyler Cardiel        | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)     | 235   | 47.00 | 1  |
+| 10 | Danika Houde         | New Life C.L.A.Y.     | New Life Church (Billings, MT)               | 215   | 43.00 |    |
+| 11 | Jonathan Larson      | JUMP Kids             | Family Life Christian Ctr. (Federal Way, WA) | 205   | 41.00 |    |
+| 12 | David Moses          | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                     | 190   | 38.00 | 1  |
+| 13 | Braden Pennington    | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)     | 160   | 32.00 | 1  |
+| 14 | Maddie Hawkes        | JUMP Kids             | Family Life Christian Ctr. (Federal Way, WA) | 135   | 27.00 | 1  |
+| 14 | Aidan Strain         | Grace Assembly of God | Grace A/G (New Whiteland, IN)                | 135   | 27.00 | 1  |
+| 15 | Peter Moses          | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                     | 80    | 16.00 |    |
+| 16 | Maggie Akinleye      | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)     | 75    | 15.00 |    |
+| 17 | Lizzie Dambacher     | JUMP Kids             | Family Life Christian Ctr. (Federal Way, WA) | 60    | 12.00 |    |
+| 18 | Keenan Messmer       | New Life C.L.A.Y.     | New Life Church (Billings, MT)               | 50    | 10.00 |    |
+| 19 | Luke Yoder           | S.P.Y. Kids 007       | The Worship Center (Leesburg, VA)            | 45    | 9.00  |    |
+| 20 | Sarah Judd           | S.P.Y. Kids 007       | The Worship Center (Leesburg, VA)            | 40    | 8.00  |    |
+| 21 | Tyler Bernheisel     | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)     | 15    | 3.00  |    |
+| 21 | Joanna Moses         | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                     | 15    | 3.00  |    |
+| 22 | Holly Garrett        | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                     | 10    | 2.00  |    |
+| 23 | Tessa Houde          | New Life C.L.A.Y.     | New Life Church (Billings, MT)               |       | .00   |    |
+| 23 | Claire Richardson    | Grace Assembly of God | Grace A/G (New Whiteland, IN)                |       | .00   |    |
+| 23 | Elle Leebrick        | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                     |       | .00   |    |
+| 23 | Andrea Little        | Grace Assembly of God | Grace A/G (New Whiteland, IN)                |       | .00   |    |
+| 24 | Vincent Hall-Shipley | New Life C.L.A.Y.     | New Life Church (Billings, MT)               | -20   | -4    |    |
+
+
+### Cream
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                          | Church                            | W/L | Total | Avg    |
+|--:|-------------------------------|-----------------------------------|-----|------:|-------:|
+| 1 | Seed Sowers                   | Trinity A/G (Georgetown, KY)      | 4/1 | 900   | 180.00 |
+| 2 | Naperville                    | Calvary Church (Naperville, IL)   | 4/1 | 860   | 172.00 |
+| 3 | Buzz Hogs                     | River of Life (Mabelvale, AR)     | 3/2 | 720   | 144.00 |
+| 4 | International Assembly of God | International A/G (Warren, MI)    | 2/3 | 610   | 122.00 |
+| 5 | Army of God                   | Calvary Church (Greensboro, NC)   | 1/4 | 700   | 140.00 |
+| 6 | S.P.Y. Kids 006               | The Worship Center (Leesburg, VA) | 1/4 | 545   | 109.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                          | Church                            | Total | Avg   | QO |
+|---:|---------------------|-------------------------------|-----------------------------------|------:|------:|---:|
+| 1  | Jared Minick        | Buzz Hogs                     | River of Life (Mabelvale, AR)     | 485   | 97.00 | 1  |
+| 2  | Lily Johnson        | Seed Sowers                   | Trinity A/G (Georgetown, KY)      | 465   | 93.00 | 3  |
+| 3  | Shreanna Powell     | Naperville                    | Calvary Church (Naperville, IL)   | 450   | 90.00 | 1  |
+| 4  | Robert Laboy        | Naperville                    | Calvary Church (Naperville, IL)   | 350   | 70.00 | 4  |
+| 5  | Christopher Turner  | Seed Sowers                   | Trinity A/G (Georgetown, KY)      | 325   | 65.00 |    |
+| 6  | Alecia Rajesh       | Army of God                   | Calvary Church (Greensboro, NC)   | 295   | 59.00 |    |
+| 7  | Sherlin Chacko      | International Assembly of God | International A/G (Warren, MI)    | 250   | 50.00 |    |
+| 8  | Matthew Bozzay      | S.P.Y. Kids 006               | The Worship Center (Leesburg, VA) | 220   | 44.00 |    |
+| 9  | Erin O\'Mara        | S.P.Y. Kids 006               | The Worship Center (Leesburg, VA) | 215   | 43.00 |    |
+| 10 | Rohan George        | Army of God                   | Calvary Church (Greensboro, NC)   | 170   | 34.00 | 1  |
+| 11 | Albert George       | International Assembly of God | International A/G (Warren, MI)    | 160   | 32.00 | 1  |
+| 12 | Trenton Page        | Buzz Hogs                     | River of Life (Mabelvale, AR)     | 150   | 30.00 |    |
+| 13 | Jerrin George       | International Assembly of God | International A/G (Warren, MI)    | 145   | 29.00 |    |
+| 14 | Aaron CyrilJohn     | Army of God                   | Calvary Church (Greensboro, NC)   | 130   | 26.00 |    |
+| 15 | Ben Rozelle         | S.P.Y. Kids 006               | The Worship Center (Leesburg, VA) | 110   | 22.00 |    |
+| 15 | Sarah Steinbach     | Seed Sowers                   | Trinity A/G (Georgetown, KY)      | 110   | 22.00 |    |
+| 16 | Faith Davis         | Army of God                   | Calvary Church (Greensboro, NC)   | 90    | 18.00 |    |
+| 17 | Bridge Biniakewitz  | Buzz Hogs                     | River of Life (Mabelvale, AR)     | 80    | 16.00 |    |
+| 18 | Lauren Huseman      | Naperville                    | Calvary Church (Naperville, IL)   | 60    | 12.00 |    |
+| 19 | Sarah Jacob         | International Assembly of God | International A/G (Warren, MI)    | 55    | 11.00 |    |
+| 20 | Abigail Prejean     | Army of God                   | Calvary Church (Greensboro, NC)   | 15    | 3.00  |    |
+| 21 | Savanah Biniakewitz | Buzz Hogs                     | River of Life (Mabelvale, AR)     | 10    | 2.00  |    |
+| 22 | Duncan Connors      | S.P.Y. Kids 006               | The Worship Center (Leesburg, VA) |       | .00   |    |
+| 22 | Abbye Evans         | Seed Sowers                   | Trinity A/G (Georgetown, KY)      |       | .00   |    |
+| 22 | Katherine Bozzay    | S.P.Y. Kids 006               | The Worship Center (Leesburg, VA) |       | .00   |    |
+| 22 | Jessica McElwee     | Naperville                    | Calvary Church (Naperville, IL)   |       | .00   |    |
+| 22 | Autumn Pettit       | Seed Sowers                   | Trinity A/G (Georgetown, KY)      |       | .00   |    |
+| 22 | Elijah Pettit       | Seed Sowers                   | Trinity A/G (Georgetown, KY)      |       | .00   |    |
+| 22 | Julia DeGraff       | Naperville                    | Calvary Church (Naperville, IL)   |       | .00   |    |
+| 22 | Brian O\'Mara       | S.P.Y. Kids 006               | The Worship Center (Leesburg, VA) |       | .00   |    |
+| 22 | Elizabeth Steinbach | Seed Sowers                   | Trinity A/G (Georgetown, KY)      |       | .00   |    |
+| 22 | Maddi Evans         | Seed Sowers                   | Trinity A/G (Georgetown, KY)      |       | .00   |    |
+| 23 | Levi Biniakewitz    | Buzz Hogs                     | River of Life (Mabelvale, AR)     | -5    | -1    |    |
+
+
+### Gold
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church                                   | W/L | Total | Avg    |
+|--:|---------------------------|------------------------------------------|-----|------:|-------:|
+| 1 | God Squad                 | 1st A/G (Bernalillo, NM)                 | 3/1 | 710   | 177.50 |
+| 2 | Sonburst Alpha            | MCC (Mechanicsville, VA)                 | 3/1 | 840   | 210.00 |
+| 3 | Swordsmen                 | Vailsburg Assembly (Newark, NJ)          | 2/2 | 640   | 160.00 |
+| 4 | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 2/2 | 625   | 156.25 |
+| 5 | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            | 0/4 | 75    | 18.75  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                      | Church                                   | Total | Avg    | QO |
+|---:|----------------------|---------------------------|------------------------------------------|------:|-------:|---:|
+| 1  | Alyssa Walker        | Sonburst Alpha            | MCC (Mechanicsville, VA)                 | 440   | 110.00 | 2  |
+| 2  | Aaron Hardinge       | God Squad                 | 1st A/G (Bernalillo, NM)                 | 400   | 100.00 | 2  |
+| 3  | Elijah O\'Brien      | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 370   | 92.50  | 1  |
+| 4  | Brooklyne Sederwall  | Swordsmen                 | Vailsburg Assembly (Newark, NJ)          | 240   | 60.00  | 2  |
+| 5  | Joshua Kukuvka       | Sonburst Alpha            | MCC (Mechanicsville, VA)                 | 210   | 52.50  |    |
+| 6  | William Ubert        | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 170   | 42.50  | 1  |
+| 7  | Chad Sederwall       | Swordsmen                 | Vailsburg Assembly (Newark, NJ)          | 170   | 42.50  |    |
+| 8  | Emma Tercero         | God Squad                 | 1st A/G (Bernalillo, NM)                 | 145   | 36.25  | 1  |
+| 9  | Daniel Green         | Swordsmen                 | Vailsburg Assembly (Newark, NJ)          | 140   | 35.00  | 1  |
+| 10 | Emily Beker          | God Squad                 | 1st A/G (Bernalillo, NM)                 | 100   | 25.00  |    |
+| 11 | Nathaniel Walker     | Sonburst Alpha            | MCC (Mechanicsville, VA)                 | 90    | 22.50  |    |
+| 12 | Taylor Bridges       | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 80    | 20.00  |    |
+| 13 | Noah Zook            | Sonburst Alpha            | MCC (Mechanicsville, VA)                 | 75    | 18.75  |    |
+| 14 | Fran-jec Makoule     | Swordsmen                 | Vailsburg Assembly (Newark, NJ)          | 70    | 17.50  |    |
+| 15 | Hans Beker           | God Squad                 | 1st A/G (Bernalillo, NM)                 | 35    | 8.75   |    |
+| 16 | JD Welter            | God Squad                 | 1st A/G (Bernalillo, NM)                 | 30    | 7.50   |    |
+| 17 | Chasity Stalcup      | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            | 25    | 6.25   |    |
+| 17 | Anthony Webster      | Sonburst Alpha            | MCC (Mechanicsville, VA)                 | 25    | 6.25   |    |
+| 18 | Jonah Gomes          | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            | 20    | 5.00   |    |
+| 18 | Acacia Todd          | Swordsmen                 | Vailsburg Assembly (Newark, NJ)          | 20    | 5.00   |    |
+| 18 | Isaac Stalcup        | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            | 20    | 5.00   |    |
+| 19 | Isaiah Gomes         | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            | 10    | 2.50   |    |
+| 20 | Anthony Mikolajewski | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 5     | 1.25   |    |
+| 21 | Madison Doise        | Sonburst Alpha            | MCC (Mechanicsville, VA)                 |       | .00    |    |
+| 21 | Yasmine Barlow       | God Squad                 | 1st A/G (Bernalillo, NM)                 |       | .00    |    |
+| 21 | Nathan Isner         | Sonburst Alpha            | MCC (Mechanicsville, VA)                 |       | .00    |    |
+| 21 | Sofia Beker          | God Squad                 | 1st A/G (Bernalillo, NM)                 |       | .00    |    |
+| 21 | Leslie Flores        | God Squad                 | 1st A/G (Bernalillo, NM)                 |       | .00    |    |
+| 21 | Katie Stalcup        | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            |       | .00    |    |
+| 21 | Shanzie Tiqui        | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            |       | .00    |    |
+| 21 | Jasmine Nazaire      | Swordsmen                 | Vailsburg Assembly (Newark, NJ)          |       | .00    |    |
+| 21 | Katie Van Nuck       | Swordsmen                 | Vailsburg Assembly (Newark, NJ)          |       | .00    |    |
+| 21 | George Austin        | Swordsmen                 | Vailsburg Assembly (Newark, NJ)          |       | .00    |    |
+| 21 | Ayzhia-Marie Tadeo   | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            |       | .00    |    |
+| 21 | Tristyn Celestino    | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            |       | .00    |    |
+| 21 | Heather Erickson     | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) |       | .00    |    |
+
+
+### Gray
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church                              | W/L | Total | Avg    |
+|--:|---------------------------|-------------------------------------|-----|------:|-------:|
+| 1 | Word of Life Swordbearers | Word of Life (Springfield, VA)      | 5/0 | 980   | 196.00 |
+| 2 | 3-n-1                     | 1st A/G (Goldsboro, NC)             | 4/1 | 855   | 171.00 |
+| 3 | Kingdom Explorers         | Mt. Creek Comm. Church (Dallas, TX) | 3/2 | 790   | 158.00 |
+| 4 | Supernova                 | Central Assembly (Springfield, MO)  | 2/3 | 725   | 145.00 |
+| 5 | Fearsome Foursome         | Trinity Church (Cedar Hill, TX)     | 1/4 | 460   | 92.00  |
+| 6 | God Worshippers           | Glad Tidings (Omaha, NE)            | 0/5 | 510   | 102.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                      | Church                              | Total | Avg    | QO |
+|---:|------------------------|---------------------------|-------------------------------------|------:|-------:|---:|
+| 1  | Hannah Quick           | Supernova                 | Central Assembly (Springfield, MO)  | 550   | 110.00 | 1  |
+| 2  | Deyja Middleton        | 3-n-1                     | 1st A/G (Goldsboro, NC)             | 430   | 86.00  | 2  |
+| 3  | Samuel Grey            | Kingdom Explorers         | Mt. Creek Comm. Church (Dallas, TX) | 420   | 84.00  | 4  |
+| 4  | Samuel Wilkerson       | 3-n-1                     | 1st A/G (Goldsboro, NC)             | 400   | 80.00  | 1  |
+| 5  | Elle Miller            | Fearsome Foursome         | Trinity Church (Cedar Hill, TX)     | 350   | 70.00  | 1  |
+| 6  | David Inyangson        | Word of Life Swordbearers | Word of Life (Springfield, VA)      | 290   | 58.00  |    |
+| 7  | Luis Torres            | Kingdom Explorers         | Mt. Creek Comm. Church (Dallas, TX) | 280   | 56.00  |    |
+| 8  | Divya Mathews          | Word of Life Swordbearers | Word of Life (Springfield, VA)      | 230   | 46.00  | 2  |
+| 9  | Leah Thomas            | Word of Life Swordbearers | Word of Life (Springfield, VA)      | 215   | 43.00  | 1  |
+| 10 | Elizabeth Kaffenberger | God Worshippers           | Glad Tidings (Omaha, NE)            | 210   | 42.00  | 1  |
+| 11 | Luke Slater            | Supernova                 | Central Assembly (Springfield, MO)  | 140   | 28.00  | 1  |
+| 12 | Jerrell Sydney         | Word of Life Swordbearers | Word of Life (Springfield, VA)      | 125   | 25.00  | 1  |
+| 13 | Keiron Fontaine        | Word of Life Swordbearers | Word of Life (Springfield, VA)      | 120   | 24.00  |    |
+| 14 | Will Brovold           | God Worshippers           | Glad Tidings (Omaha, NE)            | 100   | 20.00  |    |
+| 15 | Coby Calvery           | Fearsome Foursome         | Trinity Church (Cedar Hill, TX)     | 90    | 18.00  |    |
+| 16 | Amanda Kepplin         | God Worshippers           | Glad Tidings (Omaha, NE)            | 80    | 16.00  |    |
+| 16 | Catherine Hetrick      | God Worshippers           | Glad Tidings (Omaha, NE)            | 80    | 16.00  |    |
+| 17 | Patrick Keenan         | Kingdom Explorers         | Mt. Creek Comm. Church (Dallas, TX) | 60    | 12.00  |    |
+| 18 | Natalie Slater         | Supernova                 | Central Assembly (Springfield, MO)  | 45    | 9.00   |    |
+| 19 | Laura Hetrick          | God Worshippers           | Glad Tidings (Omaha, NE)            | 40    | 8.00   |    |
+| 20 | Renee Betterson        | 3-n-1                     | 1st A/G (Goldsboro, NC)             | 25    | 5.00   |    |
+| 21 | Matthew Keenan         | Kingdom Explorers         | Mt. Creek Comm. Church (Dallas, TX) | 20    | 4.00   |    |
+| 21 | Rachel Rimmer          | Fearsome Foursome         | Trinity Church (Cedar Hill, TX)     | 20    | 4.00   |    |
+| 22 | AryAnna Bennett        | Kingdom Explorers         | Mt. Creek Comm. Church (Dallas, TX) | 10    | 2.00   |    |
+| 23 | Isabella Burt          | Word of Life Swordbearers | Word of Life (Springfield, VA)      |       | .00    |    |
+| 23 | Ben Manoli             | Fearsome Foursome         | Trinity Church (Cedar Hill, TX)     |       | .00    |    |
+| 23 | Gerald Koon            | Word of Life Swordbearers | Word of Life (Springfield, VA)      |       | .00    |    |
+| 23 | Lily Slater            | Supernova                 | Central Assembly (Springfield, MO)  |       | .00    |    |
+| 24 | Lucas Clark            | Supernova                 | Central Assembly (Springfield, MO)  | -10   | -2     |    |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team              | Church                             | W/L | Total | Avg    |
+|--:|-------------------|------------------------------------|-----|------:|-------:|
+| 1 | Skittles          | Evangel A/G (Bismarck, ND)         | 4/1 | 845   | 169.00 |
+| 2 | Greater Lansing   | 1st A/G (East Lansing, MI)         | 3/2 | 825   | 165.00 |
+| 3 | Evangel Qwizzlers | Evangel Church (Scotch Plains, NJ) | 3/2 | 745   | 149.00 |
+| 4 | Bible Cadets      | Ross Prep. Academy (Fallbrook, CA) | 3/2 | 740   | 148.00 |
+| 5 | Ashland           | 1st A/G (Ashland, AL)              | 1/4 | 520   | 104.00 |
+| 6 | Fizz Up           | James River Assembly (Ozark, MO)   | 1/4 | 720   | 144.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                       | Team              | Church                             | Total | Avg    | QO |
+|---:|-------------------------------|-------------------|------------------------------------|------:|-------:|---:|
+| 1  | Joshua Sipes                  | Skittles          | Evangel A/G (Bismarck, ND)         | 595   | 119.00 | 2  |
+| 2  | Alexandra E. E. Ross          | Bible Cadets      | Ross Prep. Academy (Fallbrook, CA) | 520   | 104.00 | 1  |
+| 3  | Stephen Thomas                | Evangel Qwizzlers | Evangel Church (Scotch Plains, NJ) | 470   | 94.00  | 3  |
+| 4  | Kelise Braithwaite            | Fizz Up           | James River Assembly (Ozark, MO)   | 395   | 79.00  | 1  |
+| 5  | Kirsten Andrews               | Greater Lansing   | 1st A/G (East Lansing, MI)         | 370   | 74.00  | 1  |
+| 6  | Paul Willis                   | Ashland           | 1st A/G (Ashland, AL)              | 305   | 61.00  |    |
+| 7  | Beatrice-Elizabeth A. C. Ross | Bible Cadets      | Ross Prep. Academy (Fallbrook, CA) | 220   | 44.00  | 3  |
+| 8  | Tyler McCartney               | Greater Lansing   | 1st A/G (East Lansing, MI)         | 210   | 42.00  | 1  |
+| 9  | Teddy Willis                  | Ashland           | 1st A/G (Ashland, AL)              | 175   | 35.00  | 1  |
+| 10 | Travis Griessel               | Fizz Up           | James River Assembly (Ozark, MO)   | 175   | 35.00  |    |
+| 11 | Claire Convis                 | Greater Lansing   | 1st A/G (East Lansing, MI)         | 155   | 31.00  | 1  |
+| 12 | Reagan Griessel               | Fizz Up           | James River Assembly (Ozark, MO)   | 145   | 29.00  |    |
+| 13 | Ruth Anne Sanderson           | Evangel Qwizzlers | Evangel Church (Scotch Plains, NJ) | 140   | 28.00  |    |
+| 14 | Jayden Freyer                 | Skittles          | Evangel A/G (Bismarck, ND)         | 115   | 23.00  | 1  |
+| 15 | Benshel Bright                | Evangel Qwizzlers | Evangel Church (Scotch Plains, NJ) | 105   | 21.00  |    |
+| 16 | John Schafer                  | Greater Lansing   | 1st A/G (East Lansing, MI)         | 90    | 18.00  |    |
+| 17 | Brianna Sipes                 | Skittles          | Evangel A/G (Bismarck, ND)         | 70    | 14.00  |    |
+| 18 | Elijah Sauer                  | Skittles          | Evangel A/G (Bismarck, ND)         | 55    | 11.00  |    |
+| 19 | Grace Catchings               | Ashland           | 1st A/G (Ashland, AL)              | 30    | 6.00   |    |
+| 20 | Brianna Haufman               | Evangel Qwizzlers | Evangel Church (Scotch Plains, NJ) | 20    | 4.00   |    |
+| 21 | Stanley Thomas                | Evangel Qwizzlers | Evangel Church (Scotch Plains, NJ) | 10    | 2.00   |    |
+| 21 | Caroline Coleman              | Ashland           | 1st A/G (Ashland, AL)              | 10    | 2.00   |    |
+| 21 | Ashlyn Sipes                  | Skittles          | Evangel A/G (Bismarck, ND)         | 10    | 2.00   |    |
+| 22 | Nathanael Heide               | Fizz Up           | James River Assembly (Ozark, MO)   | 5     | 1.00   |    |
+| 23 | Celah Convis                  | Greater Lansing   | 1st A/G (East Lansing, MI)         |       | .00    |    |
+| 23 | Darcie Harr                   | Greater Lansing   | 1st A/G (East Lansing, MI)         |       | .00    |    |
+| 23 | Sara Gaither                  | Ashland           | 1st A/G (Ashland, AL)              |       | .00    |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team              | Church                               | W/L | Total | Avg    |
+|--:|-------------------|--------------------------------------|-----|------:|-------:|
+| 1 | SPY Warriors      | River of Life Fellowship (Kent, WA)  | 4/1 | 940   | 188.00 |
+| 2 | Lifeguards        | Destiny Christian Ctr. (Dayton, OH)  | 4/1 | 810   | 162.00 |
+| 3 | Tribulation Force | The Oaks Fellowship (Red Oak, TX)    | 3/2 | 865   | 173.00 |
+| 4 | FCA - Cincinnati  | First Christian A/G (Cincinnati, OH) | 2/3 | 750   | 150.00 |
+| 5 | Jedi Knights      | Calvary A/G (Elkhart, IN)            | 2/3 | 570   | 114.00 |
+| 6 | God\'s C.R.E.W.   | Capitol Hill A/G (OKC, OK)           | 0/5 | 430   | 86.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team              | Church                               | Total | Avg    | QO |
+|---:|--------------------|-------------------|--------------------------------------|------:|-------:|---:|
+| 1  | Savannah Gutterud  | SPY Warriors      | River of Life Fellowship (Kent, WA)  | 610   | 122.00 | 3  |
+| 2  | Caleb Jones        | Lifeguards        | Destiny Christian Ctr. (Dayton, OH)  | 435   | 87.00  | 4  |
+| 3  | Vanessa Steiner    | Jedi Knights      | Calvary A/G (Elkhart, IN)            | 375   | 75.00  | 1  |
+| 4  | Parker Frankiewicz | Tribulation Force | The Oaks Fellowship (Red Oak, TX)    | 320   | 64.00  |    |
+| 5  | Brennan Dodds      | FCA - Cincinnati  | First Christian A/G (Cincinnati, OH) | 285   | 57.00  | 2  |
+| 6  | David Saunders     | Tribulation Force | The Oaks Fellowship (Red Oak, TX)    | 255   | 51.00  |    |
+| 7  | Christina Baxter   | God\'s C.R.E.W.   | Capitol Hill A/G (OKC, OK)           | 230   | 46.00  |    |
+| 8  | Cameron Berta      | Tribulation Force | The Oaks Fellowship (Red Oak, TX)    | 210   | 42.00  | 1  |
+| 9  | Sean Jones         | Lifeguards        | Destiny Christian Ctr. (Dayton, OH)  | 210   | 42.00  |    |
+| 10 | Jared Kleinhenz    | FCA - Cincinnati  | First Christian A/G (Cincinnati, OH) | 170   | 34.00  |    |
+| 11 | Bekah Ray          | FCA - Cincinnati  | First Christian A/G (Cincinnati, OH) | 130   | 26.00  |    |
+| 11 | Sarah Toole        | SPY Warriors      | River of Life Fellowship (Kent, WA)  | 130   | 26.00  |    |
+| 12 | Jonathan Gomez     | Jedi Knights      | Calvary A/G (Elkhart, IN)            | 125   | 25.00  | 1  |
+| 13 | Daniel Gallegos    | SPY Warriors      | River of Life Fellowship (Kent, WA)  | 125   | 25.00  |    |
+| 13 | Ethan Smith        | FCA - Cincinnati  | First Christian A/G (Cincinnati, OH) | 125   | 25.00  |    |
+| 14 | Kaelyn Comfort     | God\'s C.R.E.W.   | Capitol Hill A/G (OKC, OK)           | 100   | 20.00  |    |
+| 15 | Catherine Baxter   | God\'s C.R.E.W.   | Capitol Hill A/G (OKC, OK)           | 90    | 18.00  |    |
+| 16 | Joey Jones         | Lifeguards        | Destiny Christian Ctr. (Dayton, OH)  | 85    | 17.00  |    |
+| 17 | Matthew Braham     | SPY Warriors      | River of Life Fellowship (Kent, WA)  | 75    | 15.00  |    |
+| 18 | Jason Root         | Lifeguards        | Destiny Christian Ctr. (Dayton, OH)  | 60    | 12.00  |    |
+| 18 | Matthew Hipshire   | Tribulation Force | The Oaks Fellowship (Red Oak, TX)    | 60    | 12.00  |    |
+| 19 | Lauren Randolph    | Jedi Knights      | Calvary A/G (Elkhart, IN)            | 40    | 8.00   |    |
+| 20 | Lance Lewis        | Jedi Knights      | Calvary A/G (Elkhart, IN)            | 25    | 5.00   |    |
+| 21 | Jeannah Jones      | Lifeguards        | Destiny Christian Ctr. (Dayton, OH)  | 20    | 4.00   |    |
+| 21 | Harrison Hoggard   | Tribulation Force | The Oaks Fellowship (Red Oak, TX)    | 20    | 4.00   |    |
+| 21 | Jack Titkemeyer    | FCA - Cincinnati  | First Christian A/G (Cincinnati, OH) | 20    | 4.00   |    |
+| 21 | Gunnar Smart       | FCA - Cincinnati  | First Christian A/G (Cincinnati, OH) | 20    | 4.00   |    |
+| 22 | Jonathan Burke     | God\'s C.R.E.W.   | Capitol Hill A/G (OKC, OK)           | 10    | 2.00   |    |
+| 23 | Dylan Quiggle      | Jedi Knights      | Calvary A/G (Elkhart, IN)            | 5     | 1.00   |    |
+| 24 | Ben Beeson         | Lifeguards        | Destiny Christian Ctr. (Dayton, OH)  |       | .00    |    |
+| 24 | Natalie Isaacs     | Lifeguards        | Destiny Christian Ctr. (Dayton, OH)  |       | .00    |    |
+| 24 | Miken Melvin       | God\'s C.R.E.W.   | Capitol Hill A/G (OKC, OK)           |       | .00    |    |
+| 24 | Dena Schaeffer     | Lifeguards        | Destiny Christian Ctr. (Dayton, OH)  |       | .00    |    |
+| 24 | Nathan Burke       | God\'s C.R.E.W.   | Capitol Hill A/G (OKC, OK)           |       | .00    |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                                | Church                                         | W/L | Total | Avg    |
+|--:|-------------------------------------|------------------------------------------------|-----|------:|-------:|
+| 1 | SPY All Stars                       | River of Life Fellowship (Kent, WA)            | 4/1 | 910   | 182.00 |
+| 2 | CRK Almighty                        | Church of the Risen King (Gloucester City, NJ) | 4/1 | 870   | 174.00 |
+| 3 | Super Sonic Sailfish                | New Life Church (Princeton, MN)                | 4/1 | 740   | 148.00 |
+| 4 | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)                    | 2/3 | 635   | 127.00 |
+| 5 | Oak Creek Biblikids                 | Oak Creek A/G (Oak Creek, WI)                  | 1/4 | 490   | 98.00  |
+| 6 | Fizz Over                           | James River Assembly (Ozark, MO)               | 0/5 | 515   | 103.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer          | Team                                | Church                                         | Total | Avg    | QO |
+|---:|------------------|-------------------------------------|------------------------------------------------|------:|-------:|---:|
+| 1  | Aliyah Fashaw    | SPY All Stars                       | River of Life Fellowship (Kent, WA)            | 560   | 112.00 | 3  |
+| 2  | Russell Flores   | CRK Almighty                        | Church of the Risen King (Gloucester City, NJ) | 345   | 69.00  | 2  |
+| 3  | Jared Jordan     | CRK Almighty                        | Church of the Risen King (Gloucester City, NJ) | 335   | 67.00  |    |
+| 4  | Thomas Stewart   | Super Sonic Sailfish                | New Life Church (Princeton, MN)                | 325   | 65.00  | 1  |
+| 5  | Elijah Evers     | Oak Creek Biblikids                 | Oak Creek A/G (Oak Creek, WI)                  | 300   | 60.00  | 1  |
+| 6  | Tyler Howard     | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)                    | 270   | 54.00  | 1  |
+| 7  | Jaron Klassen    | Fizz Over                           | James River Assembly (Ozark, MO)               | 260   | 52.00  | 1  |
+| 8  | Micah Roelofs    | Super Sonic Sailfish                | New Life Church (Princeton, MN)                | 250   | 50.00  |    |
+| 9  | Erika Fox        | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)                    | 235   | 47.00  |    |
+| 10 | Jillian Griffith | Fizz Over                           | James River Assembly (Ozark, MO)               | 215   | 43.00  |    |
+| 11 | Austin Shepherd  | SPY All Stars                       | River of Life Fellowship (Kent, WA)            | 180   | 36.00  | 2  |
+| 12 | Glenn Kaboskey   | Oak Creek Biblikids                 | Oak Creek A/G (Oak Creek, WI)                  | 170   | 34.00  | 2  |
+| 13 | Elijah Abad      | CRK Almighty                        | Church of the Risen King (Gloucester City, NJ) | 170   | 34.00  |    |
+| 14 | Tirzah Brookbank | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)                    | 130   | 26.00  | 1  |
+| 15 | Michaela Toole   | SPY All Stars                       | River of Life Fellowship (Kent, WA)            | 115   | 23.00  |    |
+| 15 | Josiah Stewart   | Super Sonic Sailfish                | New Life Church (Princeton, MN)                | 115   | 23.00  |    |
+| 16 | Teddy Gutterud   | SPY All Stars                       | River of Life Fellowship (Kent, WA)            | 60    | 12.00  |    |
+| 17 | Montana Lawrence | Super Sonic Sailfish                | New Life Church (Princeton, MN)                | 40    | 8.00   |    |
+| 17 | Abby O\'Connell  | Fizz Over                           | James River Assembly (Ozark, MO)               | 40    | 8.00   |    |
+| 18 | Katie Tamblyn    | Oak Creek Biblikids                 | Oak Creek A/G (Oak Creek, WI)                  | 20    | 4.00   |    |
+| 18 | Jillian Angeles  | CRK Almighty                        | Church of the Risen King (Gloucester City, NJ) | 20    | 4.00   |    |
+| 19 | Ryan Moos        | Super Sonic Sailfish                | New Life Church (Princeton, MN)                | 10    | 2.00   |    |
+| 20 | Alyssa Sachs     | Oak Creek Biblikids                 | Oak Creek A/G (Oak Creek, WI)                  |       | .00    |    |
+| 20 | Leisl Janesen    | Fizz Over                           | James River Assembly (Ozark, MO)               |       | .00    |    |
+| 20 | Gavin Griffith   | Fizz Over                           | James River Assembly (Ozark, MO)               |       | .00    |    |
+| 20 | Jed Brookbank    | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)                    |       | .00    |    |
+| 20 | Esji Johnson     | Oak Creek Biblikids                 | Oak Creek A/G (Oak Creek, WI)                  |       | .00    |    |
+| 20 | Caleb Daniels    | Super Sonic Sailfish                | New Life Church (Princeton, MN)                |       | .00    |    |
+| 20 | Hannah Merrell   | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)                    |       | .00    |    |
+| 20 | Danielle Borja   | CRK Almighty                        | Church of the Risen King (Gloucester City, NJ) |       | .00    |    |
+| 20 | Kristiana Ramos  | CRK Almighty                        | Church of the Risen King (Gloucester City, NJ) |       | .00    |    |
+
+
+### Purple
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                        | Church                                        | W/L | Total | Avg    |
+|--:|-----------------------------|-----------------------------------------------|-----|------:|-------:|
+| 1 | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX)        | 4/1 | 940   | 188.00 |
+| 2 | Ocala First                 | 1st A/G (Ocala, FL)                           | 4/1 | 905   | 181.00 |
+| 3 | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)          | 4/1 | 890   | 178.00 |
+| 4 | Silver Spurs                | Bethel A/G (Askewville, NC)                   | 2/3 | 785   | 157.00 |
+| 5 | Lightning                   | Carmel A/G (Bonifay, FL)                      | 1/4 | 500   | 100.00 |
+| 6 | Double Edge Swordmans       | Orange Co. Christian Evangelical (Irvine, CA) | 0/5 | 325   | 65.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                        | Church                                        | Total | Avg    | QO |
+|---:|--------------------|-----------------------------|-----------------------------------------------|------:|-------:|---:|
+| 1  | Chase Petry        | Ocala First                 | 1st A/G (Ocala, FL)                           | 615   | 123.00 | 4  |
+| 2  | Jessica Rutland    | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX)        | 560   | 112.00 | 2  |
+| 3  | Jaret Williams     | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)          | 430   | 86.00  | 1  |
+| 4  | Will Bazemore      | Silver Spurs                | Bethel A/G (Askewville, NC)                   | 305   | 61.00  | 1  |
+| 5  | Daniel Castello    | Silver Spurs                | Bethel A/G (Askewville, NC)                   | 255   | 51.00  | 2  |
+| 6  | Will Zepp          | Lightning                   | Carmel A/G (Bonifay, FL)                      | 240   | 48.00  |    |
+| 7  | Emma Alfey         | Ocala First                 | 1st A/G (Ocala, FL)                           | 235   | 47.00  | 3  |
+| 8  | Alyssa Harden      | Silver Spurs                | Bethel A/G (Askewville, NC)                   | 210   | 42.00  |    |
+| 9  | Alex Rawlings      | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX)        | 200   | 40.00  |    |
+| 10 | Joy Okafor         | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)          | 180   | 36.00  | 2  |
+| 11 | Brady Powell       | Lightning                   | Carmel A/G (Bonifay, FL)                      | 170   | 34.00  |    |
+| 12 | Jeanette Surajbali | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)          | 145   | 29.00  |    |
+| 13 | Ariana Zhu         | Double Edge Swordmans       | Orange Co. Christian Evangelical (Irvine, CA) | 115   | 23.00  |    |
+| 14 | Kaitlyn Ballard    | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX)        | 100   | 20.00  |    |
+| 14 | Jeremy Wu          | Double Edge Swordmans       | Orange Co. Christian Evangelical (Irvine, CA) | 100   | 20.00  |    |
+| 15 | Madie Rawlings     | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX)        | 80    | 16.00  |    |
+| 15 | Harrison Ku        | Double Edge Swordmans       | Orange Co. Christian Evangelical (Irvine, CA) | 80    | 16.00  |    |
+| 16 | Rebecca Ramnauth   | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)          | 50    | 10.00  |    |
+| 17 | JJ Paul            | Lightning                   | Carmel A/G (Bonifay, FL)                      | 45    | 9.00   |    |
+| 17 | Jeremiah Umali     | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)          | 45    | 9.00   |    |
+| 18 | Shashendri DeSilva | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)          | 40    | 8.00   |    |
+| 19 | Joel Alfrey        | Ocala First                 | 1st A/G (Ocala, FL)                           | 35    | 7.00   |    |
+| 20 | Carmel Lee         | Double Edge Swordmans       | Orange Co. Christian Evangelical (Irvine, CA) | 30    | 6.00   |    |
+| 21 | Nick Stewart       | Lightning                   | Carmel A/G (Bonifay, FL)                      | 25    | 5.00   |    |
+| 22 | Cameron Moore      | Lightning                   | Carmel A/G (Bonifay, FL)                      | 20    | 4.00   |    |
+| 22 | Philip Greenaway   | Ocala First                 | 1st A/G (Ocala, FL)                           | 20    | 4.00   |    |
+| 23 | Colton Hoggard     | Silver Spurs                | Bethel A/G (Askewville, NC)                   | 15    | 3.00   |    |
+| 24 | Calvin Lee         | Double Edge Swordmans       | Orange Co. Christian Evangelical (Irvine, CA) |       | .00    |    |
+| 24 | Nicole DeSilva     | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)          |       | .00    |    |
+| 24 | Christon Stewart   | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY)          |       | .00    |    |
+| 24 | Janet Li           | Double Edge Swordmans       | Orange Co. Christian Evangelical (Irvine, CA) |       | .00    |    |
+| 24 | Zeke Rashid        | Swords of the Spirit        | Grace Community A/G (Flower Mound, TX)        |       | .00    |    |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                        | Church                             | W/L | Total | Avg    |
+|--:|-----------------------------|------------------------------------|-----|------:|-------:|
+| 1 | Powerful Praying Platypuses | 1st A/G (Phoenix, AZ)              | 4/1 | 900   | 180.00 |
+| 2 | FBI                         | Celebration Church (Lakeville, MN) | 4/1 | 875   | 175.00 |
+| 3 | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)   | 3/2 | 875   | 175.00 |
+| 4 | Harrison Thrashers          | Faith A/G (Harrison, AR)           | 3/2 | 710   | 142.00 |
+| 5 | Word Warriors               | Bethany Comm. Church (Mendon, MA)  | 1/4 | 505   | 101.00 |
+| 6 | The Giant Smarties          | Bethel Temple A/G (Huntington, WV) | 0/5 | 315   | 63.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                        | Church                             | Total | Avg    | QO |
+|---:|----------------------|-----------------------------|------------------------------------|------:|-------:|---:|
+| 1  | Hannah Stephens      | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)   | 560   | 112.00 | 3  |
+| 2  | Tia Lubinski         | FBI                         | Celebration Church (Lakeville, MN) | 390   | 78.00  | 1  |
+| 3  | Makenzie Bradshaw    | Harrison Thrashers          | Faith A/G (Harrison, AR)           | 320   | 64.00  |    |
+| 4  | Connell Donoghue     | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)   | 285   | 57.00  | 1  |
+| 5  | Cassidy Neal         | Powerful Praying Platypuses | 1st A/G (Phoenix, AZ)              | 280   | 56.00  | 3  |
+| 6  | Evan Still           | Harrison Thrashers          | Faith A/G (Harrison, AR)           | 245   | 49.00  |    |
+| 7  | Jordan Raum          | Powerful Praying Platypuses | 1st A/G (Phoenix, AZ)              | 220   | 44.00  |    |
+| 8  | Katherine Preudhomme | Powerful Praying Platypuses | 1st A/G (Phoenix, AZ)              | 210   | 42.00  |    |
+| 8  | Madison Heath        | FBI                         | Celebration Church (Lakeville, MN) | 210   | 42.00  |    |
+| 9  | Elijah Vanderhule    | Powerful Praying Platypuses | 1st A/G (Phoenix, AZ)              | 190   | 38.00  |    |
+| 10 | Katie Burke          | Word Warriors               | Bethany Comm. Church (Mendon, MA)  | 160   | 32.00  |    |
+| 11 | Noah Hensley         | The Giant Smarties          | Bethel Temple A/G (Huntington, WV) | 155   | 31.00  | 2  |
+| 12 | Eva Clark            | FBI                         | Celebration Church (Lakeville, MN) | 145   | 29.00  |    |
+| 13 | John Fugere          | Word Warriors               | Bethany Comm. Church (Mendon, MA)  | 130   | 26.00  | 1  |
+| 14 | Dylan Lovick         | FBI                         | Celebration Church (Lakeville, MN) | 120   | 24.00  |    |
+| 15 | Grace Caughey        | Word Warriors               | Bethany Comm. Church (Mendon, MA)  | 100   | 20.00  | 1  |
+| 16 | Seth Hensley         | The Giant Smarties          | Bethel Temple A/G (Huntington, WV) | 85    | 17.00  |    |
+| 16 | Filip DaSilva        | Word Warriors               | Bethany Comm. Church (Mendon, MA)  | 85    | 17.00  |    |
+| 17 | Kerigan Bradshaw     | Harrison Thrashers          | Faith A/G (Harrison, AR)           | 75    | 15.00  |    |
+| 18 | Abby Bailey          | Harrison Thrashers          | Faith A/G (Harrison, AR)           | 70    | 14.00  |    |
+| 19 | Ashley Webb          | The Giant Smarties          | Bethel Temple A/G (Huntington, WV) | 55    | 11.00  |    |
+| 20 | Hope Richards        | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)   | 20    | 4.00   |    |
+| 20 | Tayla Vannelli       | Word Warriors               | Bethany Comm. Church (Mendon, MA)  | 20    | 4.00   |    |
+| 21 | Makayla Lowe         | The Giant Smarties          | Bethel Temple A/G (Huntington, WV) | 10    | 2.00   |    |
+| 21 | Bethany Perry        | Word Warriors               | Bethany Comm. Church (Mendon, MA)  | 10    | 2.00   |    |
+| 21 | Ashton Heath         | FBI                         | Celebration Church (Lakeville, MN) | 10    | 2.00   |    |
+| 21 | Mark Ziegler         | The Giant Smarties          | Bethel Temple A/G (Huntington, WV) | 10    | 2.00   |    |
+| 21 | Noble Frazier        | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)   | 10    | 2.00   |    |
+| 22 | Joy Richards         | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)   |       | .00    |    |
+| 22 | Michael Webb         | The Giant Smarties          | Bethel Temple A/G (Huntington, WV) |       | .00    |    |
+| 22 | Laura Henderson      | Harrison Thrashers          | Faith A/G (Harrison, AR)           |       | .00    |    |
+
+
+### White
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                    | Church                                   | W/L | Total | Avg    |
+|--:|-------------------------|------------------------------------------|-----|------:|-------:|
+| 1 | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) | 4/1 | 775   | 155.00 |
+| 2 | Tazmanian Truth Seekers | 1st A/G (Ft. Wayne, IN)                  | 4/1 | 805   | 161.00 |
+| 3 | Blazing Swords          | West County (Chesterfield, MO)           | 3/2 | 715   | 143.00 |
+| 4 | Los Chicos              | City Church (Sanford, FL)                | 2/3 | 705   | 141.00 |
+| 5 | Quiz CREW               | Trinity Tabernacle (Crossville, TN)      | 1/4 | 735   | 147.00 |
+| 6 | G.R.I.P.                | The Bridge (Mustang, OK)                 | 1/4 | 605   | 121.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                    | Church                                   | Total | Avg    | QO |
+|---:|---------------------|-------------------------|------------------------------------------|------:|-------:|---:|
+| 1  | Sarah Kinger        | Blazing Swords          | West County (Chesterfield, MO)           | 530   | 106.00 | 1  |
+| 2  | Jordan Landry       | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) | 465   | 93.00  | 2  |
+| 3  | Buddy Guenther      | Quiz CREW               | Trinity Tabernacle (Crossville, TN)      | 425   | 85.00  | 1  |
+| 4  | Peyton Goss         | Los Chicos              | City Church (Sanford, FL)                | 340   | 68.00  |    |
+| 5  | Ethan Storms        | Tazmanian Truth Seekers | 1st A/G (Ft. Wayne, IN)                  | 330   | 66.00  | 1  |
+| 6  | Bridgett Guenther   | Quiz CREW               | Trinity Tabernacle (Crossville, TN)      | 305   | 61.00  | 2  |
+| 7  | Landin Jacquay      | Tazmanian Truth Seekers | 1st A/G (Ft. Wayne, IN)                  | 265   | 53.00  | 3  |
+| 8  | Alex Shell          | G.R.I.P.                | The Bridge (Mustang, OK)                 | 195   | 39.00  | 1  |
+| 9  | Luke Grisham        | G.R.I.P.                | The Bridge (Mustang, OK)                 | 190   | 38.00  | 1  |
+| 10 | Matthew Robinson    | Los Chicos              | City Church (Sanford, FL)                | 175   | 35.00  |    |
+| 11 | Alyssa Campbell     | G.R.I.P.                | The Bridge (Mustang, OK)                 | 135   | 27.00  |    |
+| 12 | Samuel King         | Tazmanian Truth Seekers | 1st A/G (Ft. Wayne, IN)                  | 130   | 26.00  |    |
+| 13 | Brendon Sturgeon    | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) | 125   | 25.00  | 1  |
+| 14 | Bailey Bullock      | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) | 125   | 25.00  |    |
+| 15 | Evan Gray           | G.R.I.P.                | The Bridge (Mustang, OK)                 | 85    | 17.00  |    |
+| 15 | Aubrey Goss         | Los Chicos              | City Church (Sanford, FL)                | 85    | 17.00  |    |
+| 16 | Toby Robinson       | Los Chicos              | City Church (Sanford, FL)                | 80    | 16.00  |    |
+| 17 | Eliott Gathman      | Blazing Swords          | West County (Chesterfield, MO)           | 75    | 15.00  |    |
+| 18 | David Boller        | Tazmanian Truth Seekers | 1st A/G (Ft. Wayne, IN)                  | 70    | 14.00  |    |
+| 19 | Daniel Kinger       | Blazing Swords          | West County (Chesterfield, MO)           | 65    | 13.00  | 1  |
+| 20 | Nicholas Theriot    | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) | 60    | 12.00  |    |
+| 21 | Kaleb Smith         | Blazing Swords          | West County (Chesterfield, MO)           | 45    | 9.00   |    |
+| 22 | Jonathan Robinson   | Los Chicos              | City Church (Sanford, FL)                | 20    | 4.00   |    |
+| 23 | Makayla Olsen       | Quiz CREW               | Trinity Tabernacle (Crossville, TN)      | 10    | 2.00   |    |
+| 23 | Grayson Vestergaard | Tazmanian Truth Seekers | 1st A/G (Ft. Wayne, IN)                  | 10    | 2.00   |    |
+| 24 | Jonathan Huber      | Los Chicos              | City Church (Sanford, FL)                | 5     | 1.00   |    |
+| 25 | Lauren Grisham      | G.R.I.P.                | The Bridge (Mustang, OK)                 |       | .00    |    |
+| 25 | Landon Grisham      | G.R.I.P.                | The Bridge (Mustang, OK)                 |       | .00    |    |
+| 25 | Abigail Olsen       | Quiz CREW               | Trinity Tabernacle (Crossville, TN)      |       | .00    |    |
+| 25 | Caleb Horn          | G.R.I.P.                | The Bridge (Mustang, OK)                 |       | .00    |    |
+| 25 | John Guenther       | Quiz CREW               | Trinity Tabernacle (Crossville, TN)      |       | .00    |    |
+| 25 | Jeremiah Olsen      | Quiz CREW               | Trinity Tabernacle (Crossville, TN)      |       | .00    |    |
+| 25 | Abigail Bullock     | Crossing Place Quizzers | Crossing Place Fellowship (Franklin, LA) |       | .00    |    |
+| 25 | Ethan Collins       | Quiz CREW               | Trinity Tabernacle (Crossville, TN)      |       | .00    |    |
+| 25 | Kailan Weidner      | G.R.I.P.                | The Bridge (Mustang, OK)                 |       | .00    |    |
+| 25 | Julie Huber         | Los Chicos              | City Church (Sanford, FL)                |       | .00    |    |
+| 25 | Seth King           | Tazmanian Truth Seekers | 1st A/G (Ft. Wayne, IN)                  |       | .00    |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church                               | W/L | Total | Avg    |
+|--:|---------------------------|--------------------------------------|-----|------:|-------:|
+| 1 | Stone Quizzers            | Stone Church (Palos Heights, IL)     | 5/0 | 910   | 182.00 |
+| 2 | Master\'s Mavericks       | Abundant Life Church (Grapevine, TX) | 4/1 | 955   | 191.00 |
+| 3 | Greeneway Gospel Warriors | Greeneway Church (Orlando, FL)       | 3/2 | 755   | 151.00 |
+| 4 | Christ\'s Crew            | Dayspring A/G (Bowling Green, OH)    | 2/3 | 590   | 118.00 |
+| 5 | Soul Survivors            | Lawson A/G (Lawson, MO)              | 1/4 | 530   | 106.00 |
+| 6 | Alien Ambassadors         | River of Life (Minot, ND)            | 0/5 | 495   | 99.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                      | Church                               | Total | Avg   | QO |
+|---:|-------------------|---------------------------|--------------------------------------|------:|------:|---:|
+| 1  | David Brauchler   | Master\'s Mavericks       | Abundant Life Church (Grapevine, TX) | 485   | 97.00 | 2  |
+| 2  | Zachary Barlow    | Greeneway Gospel Warriors | Greeneway Church (Orlando, FL)       | 385   | 77.00 |    |
+| 3  | Caleb Czaja       | Stone Quizzers            | Stone Church (Palos Heights, IL)     | 360   | 72.00 |    |
+| 4  | Zachary Cook      | Soul Survivors            | Lawson A/G (Lawson, MO)              | 350   | 70.00 | 1  |
+| 5  | McKenzie Barlow   | Greeneway Gospel Warriors | Greeneway Church (Orlando, FL)       | 310   | 62.00 | 2  |
+| 6  | Jaden Werley      | Master\'s Mavericks       | Abundant Life Church (Grapevine, TX) | 295   | 59.00 | 3  |
+| 7  | Casey Walin       | Stone Quizzers            | Stone Church (Palos Heights, IL)     | 280   | 56.00 | 3  |
+| 8  | Lilly Schmitz     | Christ\'s Crew            | Dayspring A/G (Bowling Green, OH)    | 220   | 44.00 | 2  |
+| 9  | Caleb Hoverson    | Alien Ambassadors         | River of Life (Minot, ND)            | 205   | 41.00 |    |
+| 10 | Sopulu Anidobu    | Stone Quizzers            | Stone Church (Palos Heights, IL)     | 180   | 36.00 |    |
+| 10 | Aaron Smith       | Christ\'s Crew            | Dayspring A/G (Bowling Green, OH)    | 180   | 36.00 |    |
+| 10 | Evan Kobylski     | Christ\'s Crew            | Dayspring A/G (Bowling Green, OH)    | 180   | 36.00 |    |
+| 11 | Jacob Jeter       | Master\'s Mavericks       | Abundant Life Church (Grapevine, TX) | 175   | 35.00 |    |
+| 12 | Kristian Hoverson | Alien Ambassadors         | River of Life (Minot, ND)            | 165   | 33.00 |    |
+| 13 | Breanna Cole      | Soul Survivors            | Lawson A/G (Lawson, MO)              | 140   | 28.00 |    |
+| 14 | Tucker Paulson    | Alien Ambassadors         | River of Life (Minot, ND)            | 125   | 25.00 |    |
+| 15 | Naomi Czaja       | Stone Quizzers            | Stone Church (Palos Heights, IL)     | 50    | 10.00 |    |
+| 16 | Jonathan Archer   | Soul Survivors            | Lawson A/G (Lawson, MO)              | 40    | 8.00  |    |
+| 16 | Kyler Stephan     | Stone Quizzers            | Stone Church (Palos Heights, IL)     | 40    | 8.00  |    |
+| 17 | Kyle Ritter       | Greeneway Gospel Warriors | Greeneway Church (Orlando, FL)       | 30    | 6.00  |    |
+| 17 | Caleb Barlow      | Greeneway Gospel Warriors | Greeneway Church (Orlando, FL)       | 30    | 6.00  |    |
+| 18 | Seth Estep        | Christ\'s Crew            | Dayspring A/G (Bowling Green, OH)    | 10    | 2.00  |    |
+| 19 | Udo Anidobu       | Stone Quizzers            | Stone Church (Palos Heights, IL)     |       | .00   |    |
+
+
+## Saturday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                        | Church                               | W/L | Total | Avg    |
+|---:|-----------------------------|--------------------------------------|-----|------:|-------:|
+| 1  | Grace Assembly of God       | Grace A/G (New Whiteland, IN)        | 8/1 | 1675  | 186.11 |
+| 2  | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)     | 7/2 | 1515  | 168.33 |
+| 3  | S.P.Y. Kids 007             | The Worship Center (Leesburg, VA)    | 6/3 | 1440  | 160.00 |
+| 4  | Evangel Qwizzlers           | Evangel Church (Scotch Plains, NJ)   | 6/3 | 1610  | 178.89 |
+| 5  | Silver Spurs                | Bethel A/G (Askewville, NC)          | 4/5 | 1120  | 124.44 |
+| 6  | Blazing Swords              | West County (Chesterfield, MO)       | 4/5 | 1050  | 116.67 |
+| 7  | Harrison Thrashers          | Faith A/G (Harrison, AR)             | 3/6 | 1165  | 129.44 |
+| 8  | Bible Cadets                | Ross Prep. Academy (Fallbrook, CA)   | 3/6 | 1175  | 130.56 |
+| 9  | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY) | 2/7 | 985   | 109.44 |
+| 10 | Los Chicos                  | City Church (Sanford, FL)            | 2/7 | 975   | 108.33 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                       | Team                        | Church                               | Total | Avg    | QO |
+|---:|-------------------------------|-----------------------------|--------------------------------------|------:|-------:|---:|
+| 1  | Stephen Thomas                | Evangel Qwizzlers           | Evangel Church (Scotch Plains, NJ)   | 1150  | 127.78 | 7  |
+| 2  | Hannah Stephens               | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)     | 990   | 110.00 | 4  |
+| 3  | Alexandra E. E. Ross          | Bible Cadets                | Ross Prep. Academy (Fallbrook, CA)   | 745   | 82.78  | 1  |
+| 4  | Alissa Garrett                | Grace Assembly of God       | Grace A/G (New Whiteland, IN)        | 640   | 71.11  | 1  |
+| 5  | Luke Richardson               | Grace Assembly of God       | Grace A/G (New Whiteland, IN)        | 610   | 67.78  | 2  |
+| 6  | Josh Rozelle                  | S.P.Y. Kids 007             | The Worship Center (Leesburg, VA)    | 605   | 67.22  | 1  |
+| 7  | Alyssa Harden                 | Silver Spurs                | Bethel A/G (Askewville, NC)          | 555   | 61.67  | 1  |
+| 8  | Sarah Kinger                  | Blazing Swords              | West County (Chesterfield, MO)       | 505   | 56.11  | 1  |
+| 9  | Evan Still                    | Harrison Thrashers          | Faith A/G (Harrison, AR)             | 470   | 52.22  |    |
+| 10 | Beatrice-Elizabeth A. C. Ross | Bible Cadets                | Ross Prep. Academy (Fallbrook, CA)   | 435   | 48.33  | 5  |
+| 11 | Makenzie Bradshaw             | Harrison Thrashers          | Faith A/G (Harrison, AR)             | 435   | 48.33  |    |
+| 11 | Benjamin Judd                 | S.P.Y. Kids 007             | The Worship Center (Leesburg, VA)    | 435   | 48.33  |    |
+| 12 | Aidan Strain                  | Grace Assembly of God       | Grace A/G (New Whiteland, IN)        | 395   | 43.89  | 4  |
+| 13 | Matthew Robinson              | Los Chicos                  | City Church (Sanford, FL)            | 390   | 43.33  | 1  |
+| 14 | Jeanette Surajbali            | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY) | 320   | 35.56  |    |
+| 15 | Peyton Goss                   | Los Chicos                  | City Church (Sanford, FL)            | 315   | 35.00  |    |
+| 16 | Will Bazemore                 | Silver Spurs                | Bethel A/G (Askewville, NC)          | 305   | 33.89  | 2  |
+| 17 | Joy Okafor                    | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY) | 280   | 31.11  | 2  |
+| 17 | Daniel Kinger                 | Blazing Swords              | West County (Chesterfield, MO)       | 280   | 31.11  | 2  |
+| 18 | Connell Donoghue              | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)     | 255   | 28.33  |    |
+| 19 | Luke Yoder                    | S.P.Y. Kids 007             | The Worship Center (Leesburg, VA)    | 250   | 27.78  | 1  |
+| 20 | Jaret Williams                | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY) | 245   | 27.22  |    |
+| 21 | Daniel Castello               | Silver Spurs                | Bethel A/G (Askewville, NC)          | 235   | 26.11  | 1  |
+| 22 | Eliott Gathman                | Blazing Swords              | West County (Chesterfield, MO)       | 215   | 23.89  |    |
+| 23 | Toby Robinson                 | Los Chicos                  | City Church (Sanford, FL)            | 205   | 22.78  |    |
+| 24 | Abby Bailey                   | Harrison Thrashers          | Faith A/G (Harrison, AR)             | 180   | 20.00  | 1  |
+| 25 | Ruth Anne Sanderson           | Evangel Qwizzlers           | Evangel Church (Scotch Plains, NJ)   | 175   | 19.44  | 1  |
+| 26 | Sarah Judd                    | S.P.Y. Kids 007             | The Worship Center (Leesburg, VA)    | 150   | 16.67  |    |
+| 27 | Benshel Bright                | Evangel Qwizzlers           | Evangel Church (Scotch Plains, NJ)   | 145   | 16.11  |    |
+| 28 | Noble Frazier                 | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)     | 135   | 15.00  |    |
+| 29 | Stanley Thomas                | Evangel Qwizzlers           | Evangel Church (Scotch Plains, NJ)   | 100   | 11.11  |    |
+| 30 | Hope Richards                 | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)     | 85    | 9.44   |    |
+| 30 | Rebecca Ramnauth              | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY) | 85    | 9.44   |    |
+| 31 | Kerigan Bradshaw              | Harrison Thrashers          | Faith A/G (Harrison, AR)             | 80    | 8.89   |    |
+| 32 | Joy Richards                  | Tallahassee Freedom         | Freedom Church (Tallahassee, FL)     | 50    | 5.56   |    |
+| 32 | Jeremiah Umali                | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY) | 50    | 5.56   |    |
+| 32 | Kaleb Smith                   | Blazing Swords              | West County (Chesterfield, MO)       | 50    | 5.56   |    |
+| 33 | Brianna Haufman               | Evangel Qwizzlers           | Evangel Church (Scotch Plains, NJ)   | 40    | 4.44   |    |
+| 33 | Shashendri DeSilva            | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY) | 40    | 4.44   |    |
+| 34 | Aubrey Goss                   | Los Chicos                  | City Church (Sanford, FL)            | 30    | 3.33   |    |
+| 34 | Jonathan Robinson             | Los Chicos                  | City Church (Sanford, FL)            | 30    | 3.33   |    |
+| 35 | Colton Hoggard                | Silver Spurs                | Bethel A/G (Askewville, NC)          | 25    | 2.78   |    |
+| 36 | Claire Richardson             | Grace Assembly of God       | Grace A/G (New Whiteland, IN)        | 20    | 2.22   |    |
+| 37 | Andrea Little                 | Grace Assembly of God       | Grace A/G (New Whiteland, IN)        | 10    | 1.11   |    |
+| 38 | Jonathan Huber                | Los Chicos                  | City Church (Sanford, FL)            | 5     | .56    |    |
+| 39 | Julie Huber                   | Los Chicos                  | City Church (Sanford, FL)            |       | .00    |    |
+| 39 | Christon Stewart              | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY) |       | .00    |    |
+| 39 | Laura Henderson               | Harrison Thrashers          | Faith A/G (Harrison, AR)             |       | .00    |    |
+| 40 | Nicole DeSilva                | Bethlehem Church Fast Track | Bethlehem Church (Richmond Hill, NY) | -30   | -3.33  |    |
+
+
+### Gray
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                      | Church                                   | W/L | Total | Avg    |
+|---:|---------------------------|------------------------------------------|-----|------:|-------:|
+| 1  | Light                     | World Harvest (Roswell, GA)              | 8/1 | 1675  | 186.11 |
+| 2  | Phoenix First Frogs       | 1st A/G (Phoenix, AZ)                    | 8/1 | 1650  | 183.33 |
+| 3  | Quiztastic Four           | Tiffany Fellowship (KC, MO)              | 6/3 | 1330  | 147.78 |
+| 4  | God\'s Victory Kids       | Victory A/G (Universal City, TX)         | 6/3 | 1340  | 148.89 |
+| 5  | Cordova                   | 1st A/G (Cordova, TN)                    | 5/4 | 1050  | 116.67 |
+| 6  | Get Smart                 | 1st A/G (Des Moines, IA)                 | 4/5 | 1480  | 164.44 |
+| 7  | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 4/5 | 1405  | 156.11 |
+| 8  | Wild Things               | Glad Tidings Church (Hanford, CA)        | 3/6 | 890   | 98.89  |
+| 9  | IAG Seals                 | International A/G (Mesa, AZ)             | 1/8 | 700   | 77.78  |
+| 10 | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            | 0/9 | 265   | 29.44  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                      | Church                                   | Total | Avg   | QO |
+|---:|----------------------|---------------------------|------------------------------------------|------:|------:|---:|
+| 1  | Daniel Ferreira      | Light                     | World Harvest (Roswell, GA)              | 875   | 97.22 | 2  |
+| 2  | Elijah O\'Brien      | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 720   | 80.00 | 1  |
+| 3  | Bethany Lane         | Phoenix First Frogs       | 1st A/G (Phoenix, AZ)                    | 675   | 75.00 |    |
+| 4  | Brendan Ferguson     | Quiztastic Four           | Tiffany Fellowship (KC, MO)              | 660   | 73.33 | 2  |
+| 5  | Robert Brock         | Wild Things               | Glad Tidings Church (Hanford, CA)        | 630   | 70.00 | 3  |
+| 6  | Sarah Lane           | Phoenix First Frogs       | 1st A/G (Phoenix, AZ)                    | 630   | 70.00 | 2  |
+| 7  | Sophia Ridgway       | Get Smart                 | 1st A/G (Des Moines, IA)                 | 585   | 65.00 | 1  |
+| 8  | Paul Russell, Jr.    | God\'s Victory Kids       | Victory A/G (Universal City, TX)         | 515   | 57.22 |    |
+| 9  | Daniel Deppe         | Cordova                   | 1st A/G (Cordova, TN)                    | 510   | 56.67 | 2  |
+| 10 | Noah Ridgway         | Get Smart                 | 1st A/G (Des Moines, IA)                 | 480   | 53.33 | 2  |
+| 11 | Taylor Bridges       | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 475   | 52.78 | 2  |
+| 12 | Grace Artis          | Light                     | World Harvest (Roswell, GA)              | 465   | 51.67 | 3  |
+| 13 | Ashley Theesfeld     | IAG Seals                 | International A/G (Mesa, AZ)             | 430   | 47.78 | 1  |
+| 14 | Amelia Dixon         | Get Smart                 | 1st A/G (Des Moines, IA)                 | 400   | 44.44 | 3  |
+| 15 | Noah Harris          | God\'s Victory Kids       | Victory A/G (Universal City, TX)         | 390   | 43.33 | 4  |
+| 16 | Jared Deppe          | Cordova                   | 1st A/G (Cordova, TN)                    | 385   | 42.78 | 2  |
+| 17 | Zach Wylie           | God\'s Victory Kids       | Victory A/G (Universal City, TX)         | 385   | 42.78 |    |
+| 18 | James Lane           | Phoenix First Frogs       | 1st A/G (Phoenix, AZ)                    | 345   | 38.33 | 4  |
+| 19 | Cristian Huix        | Light                     | World Harvest (Roswell, GA)              | 335   | 37.22 | 1  |
+| 20 | Connor Ferguson      | Quiztastic Four           | Tiffany Fellowship (KC, MO)              | 325   | 36.11 |    |
+| 21 | Madyson Theesfeld    | IAG Seals                 | International A/G (Mesa, AZ)             | 275   | 30.56 | 2  |
+| 22 | Trent Stafford       | Wild Things               | Glad Tidings Church (Hanford, CA)        | 265   | 29.44 | 2  |
+| 23 | Tyler Lake           | Quiztastic Four           | Tiffany Fellowship (KC, MO)              | 175   | 19.44 | 1  |
+| 24 | William Ubert        | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 170   | 18.89 | 1  |
+| 25 | Jordan Birmingham    | Quiztastic Four           | Tiffany Fellowship (KC, MO)              | 170   | 18.89 |    |
+| 26 | Isaiah Gomes         | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            | 115   | 12.78 |    |
+| 27 | Abbigail Vaughan     | Cordova                   | 1st A/G (Cordova, TN)                    | 90    | 10.00 |    |
+| 28 | Jonah Gomes          | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            | 75    | 8.33  |    |
+| 29 | Nicole Bradberry     | Cordova                   | 1st A/G (Cordova, TN)                    | 65    | 7.22  |    |
+| 30 | Isaac Stalcup        | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            | 55    | 6.11  |    |
+| 31 | Jakob Schweizerhoff  | God\'s Victory Kids       | Victory A/G (Universal City, TX)         | 50    | 5.56  |    |
+| 32 | Anthony Mikolajewski | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) | 40    | 4.44  |    |
+| 33 | Chasity Stalcup      | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            | 25    | 2.78  |    |
+| 34 | Lola Phillips        | Get Smart                 | 1st A/G (Des Moines, IA)                 | 15    | 1.67  |    |
+| 35 | Shanzie Tiqui        | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            |       | .00   |    |
+| 35 | Tristyn Celestino    | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            |       | .00   |    |
+| 35 | Katie Stalcup        | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            |       | .00   |    |
+| 35 | Heather Erickson     | The BK - Believing Kids   | Victory Int. Fellowship (Brookfield, WI) |       | .00   |    |
+| 35 | Kasie Narvaez        | God\'s Victory Kids       | Victory A/G (Universal City, TX)         |       | .00   |    |
+| 35 | Justin Cheriyan      | IAG Seals                 | International A/G (Mesa, AZ)             |       | .00   |    |
+| 36 | Ayzhia-Marie Tadeo   | Ewa Beach Assembly of God | Ewa Beach A/G (Ewa Beach, HI)            | -5    | -0.56 |    |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                      | Church                                  | W/L | Total | Avg    |
+|---:|---------------------------|-----------------------------------------|-----|------:|-------:|
+| 1  | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                   | 8/1 | 1540  | 171.11 |
+| 2  | Sonburst Alpha            | MCC (Mechanicsville, VA)                | 7/2 | 1815  | 201.67 |
+| 3  | Westgate Chapel A Team    | Westgate Chapel (Edmonds, WA)           | 6/3 | 1300  | 144.44 |
+| 4  | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 5/4 | 1535  | 170.56 |
+| 5  | Bible Worms               | 1st A/G (Dumas,TX)                      | 4/5 | 1285  | 142.78 |
+| 6  | Swordsmen                 | Vailsburg Assembly (Newark, NJ)         | 4/5 | 1160  | 128.89 |
+| 7  | God Squad                 | 1st A/G (Bernalillo, NM)                | 4/5 | 1145  | 127.22 |
+| 8  | Justified Gems            | Evangel (Columbus, MS)                  | 3/6 | 1295  | 143.89 |
+| 9  | Status Update             | 1st A/G (Fargo, ND)                     | 3/6 | 995   | 110.56 |
+| 10 | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | 1/8 | 890   | 98.89  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                      | Church                                  | Total | Avg    | QO |
+|---:|---------------------|---------------------------|-----------------------------------------|------:|-------:|---:|
+| 1  | Chris Collins       | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                   | 905   | 100.56 | 3  |
+| 2  | Weslee Kate Green   | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 810   | 90.00  | 1  |
+| 3  | Aaron Hardinge      | God Squad                 | 1st A/G (Bernalillo, NM)                | 780   | 86.67  | 1  |
+| 4  | Alyssa Walker       | Sonburst Alpha            | MCC (Mechanicsville, VA)                | 720   | 80.00  | 2  |
+| 5  | Joshua Kukuvka      | Sonburst Alpha            | MCC (Mechanicsville, VA)                | 630   | 70.00  | 2  |
+| 6  | Maggie Akins        | Bible Worms               | 1st A/G (Dumas,TX)                      | 625   | 69.44  | 2  |
+| 7  | Garrett Miyaoka     | Westgate Chapel A Team    | Westgate Chapel (Edmonds, WA)           | 540   | 60.00  |    |
+| 8  | Mary Frances Harris | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | 460   | 51.11  |    |
+| 9  | Cody Collins        | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                   | 455   | 50.56  | 5  |
+| 10 | Trent Hashimoto     | Westgate Chapel A Team    | Westgate Chapel (Edmonds, WA)           | 410   | 45.56  |    |
+| 11 | Kathryn Mackey      | Justified Gems            | Evangel (Columbus, MS)                  | 390   | 43.33  |    |
+| 12 | Nathan Green        | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 375   | 41.67  |    |
+| 13 | Daniel Green        | Swordsmen                 | Vailsburg Assembly (Newark, NJ)         | 365   | 40.56  | 2  |
+| 14 | Micah Marchand      | Status Update             | 1st A/G (Fargo, ND)                     | 360   | 40.00  |    |
+| 14 | Emilee Wilcox       | Justified Gems            | Evangel (Columbus, MS)                  | 360   | 40.00  |    |
+| 15 | Dayna Burns         | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 350   | 38.89  | 3  |
+| 16 | Chad Sederwall      | Swordsmen                 | Vailsburg Assembly (Newark, NJ)         | 335   | 37.22  |    |
+| 17 | Aaron Marchand      | Status Update             | 1st A/G (Fargo, ND)                     | 325   | 36.11  | 2  |
+| 18 | Carson Nix          | Status Update             | 1st A/G (Fargo, ND)                     | 310   | 34.44  |    |
+| 19 | Nicholas Tveit      | Westgate Chapel A Team    | Westgate Chapel (Edmonds, WA)           | 290   | 32.22  | 3  |
+| 20 | Nathaniel Walker    | Sonburst Alpha            | MCC (Mechanicsville, VA)                | 290   | 32.22  | 2  |
+| 21 | Brooklyne Sederwall | Swordsmen                 | Vailsburg Assembly (Newark, NJ)         | 290   | 32.22  |    |
+| 22 | Nicholas Clemens    | Bible Worms               | 1st A/G (Dumas,TX)                      | 265   | 29.44  | 2  |
+| 23 | Cody Goodwyn        | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | 245   | 27.22  | 2  |
+| 24 | Billy Brewer        | Justified Gems            | Evangel (Columbus, MS)                  | 235   | 26.11  | 3  |
+| 25 | Dugan Akins         | Bible Worms               | 1st A/G (Dumas,TX)                      | 205   | 22.78  |    |
+| 26 | Ashli Sauer         | Bible Worms               | 1st A/G (Dumas,TX)                      | 190   | 21.11  | 1  |
+| 26 | Hans Beker          | God Squad                 | 1st A/G (Bernalillo, NM)                | 190   | 21.11  | 1  |
+| 27 | Cameron Wilcox      | Justified Gems            | Evangel (Columbus, MS)                  | 180   | 20.00  |    |
+| 28 | Brittany Steinberg  | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | 135   | 15.00  |    |
+| 29 | Caleb Brewer        | Justified Gems            | Evangel (Columbus, MS)                  | 130   | 14.44  | 1  |
+| 30 | Emma Tercero        | God Squad                 | 1st A/G (Bernalillo, NM)                | 105   | 11.67  |    |
+| 31 | Isaac Reading       | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                   | 100   | 11.11  |    |
+| 32 | Noah Zook           | Sonburst Alpha            | MCC (Mechanicsville, VA)                | 85    | 9.44   |    |
+| 33 | Emily Rogers        | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                   | 70    | 7.78   |    |
+| 34 | Isabelle Smith      | Westgate Chapel A Team    | Westgate Chapel (Edmonds, WA)           | 60    | 6.67   |    |
+| 34 | Nathan Isner        | Sonburst Alpha            | MCC (Mechanicsville, VA)                | 60    | 6.67   |    |
+| 34 | Micah Rodriguez     | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | 60    | 6.67   |    |
+| 35 | JD Welter           | God Squad                 | 1st A/G (Bernalillo, NM)                | 50    | 5.56   |    |
+| 35 | George Austin       | Swordsmen                 | Vailsburg Assembly (Newark, NJ)         | 50    | 5.56   |    |
+| 36 | Katie Van Nuck      | Swordsmen                 | Vailsburg Assembly (Newark, NJ)         | 45    | 5.00   |    |
+| 37 | Acacia Todd         | Swordsmen                 | Vailsburg Assembly (Newark, NJ)         | 40    | 4.44   |    |
+| 38 | Anthony Webster     | Sonburst Alpha            | MCC (Mechanicsville, VA)                | 35    | 3.89   |    |
+| 38 | Fran-jec Makoule    | Swordsmen                 | Vailsburg Assembly (Newark, NJ)         | 35    | 3.89   |    |
+| 39 | Emily Beker         | God Squad                 | 1st A/G (Bernalillo, NM)                | 20    | 2.22   |    |
+| 40 | Alisa Rosen         | Lebanon Swordsmen         | 1st A/G (Lebanon, MO)                   | 10    | 1.11   |    |
+| 41 | Yasmine Barlow      | God Squad                 | 1st A/G (Bernalillo, NM)                |       | .00    |    |
+| 41 | Madison Doise       | Sonburst Alpha            | MCC (Mechanicsville, VA)                |       | .00    |    |
+| 41 | Leslie Flores       | God Squad                 | 1st A/G (Bernalillo, NM)                |       | .00    |    |
+| 41 | Sofia Beker         | God Squad                 | 1st A/G (Bernalillo, NM)                |       | .00    |    |
+| 41 | Jasmine Nazaire     | Swordsmen                 | Vailsburg Assembly (Newark, NJ)         |       | .00    |    |
+| 42 | Rudy Narvaez        | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | -10   | -1.11  |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                | Church                            | W/L | Total | Avg    |
+|--:|---------------------|-----------------------------------|-----|------:|-------:|
+| 1 | Oak Creek Biblikids | Oak Creek A/G (Oak Creek, WI)     | 7/2 | 1395  | 155.00 |
+| 2 | Jedi Knights        | Calvary A/G (Elkhart, IN)         | 7/2 | 1640  | 182.22 |
+| 3 | God\'s C.R.E.W.     | Capitol Hill A/G (OKC, OK)        | 6/3 | 1305  | 145.00 |
+| 4 | Soul Survivors      | Lawson A/G (Lawson, MO)           | 5/4 | 1425  | 158.33 |
+| 4 | Fearsome Foursome   | Trinity Church (Cedar Hill, TX)   | 5/4 | 1425  | 158.33 |
+| 5 | Fizz Over           | James River Assembly (Ozark, MO)  | 5/4 | 1320  | 146.67 |
+| 6 | Army of God         | Calvary Church (Greensboro, NC)   | 4/5 | 1185  | 131.67 |
+| 7 | S.P.Y. Kids 006     | The Worship Center (Leesburg, VA) | 3/6 | 1035  | 115.00 |
+| 8 | Alien Ambassadors   | River of Life (Minot, ND)         | 2/7 | 930   | 103.33 |
+| 9 | God Worshippers     | Glad Tidings (Omaha, NE)          | 1/8 | 1010  | 112.22 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                | Church                            | Total | Avg    | QO |
+|---:|------------------------|---------------------|-----------------------------------|------:|-------:|---:|
+| 1  | Vanessa Steiner        | Jedi Knights        | Calvary A/G (Elkhart, IN)         | 1190  | 132.22 | 6  |
+| 2  | Zachary Cook           | Soul Survivors      | Lawson A/G (Lawson, MO)           | 1080  | 120.00 | 7  |
+| 3  | Elle Miller            | Fearsome Foursome   | Trinity Church (Cedar Hill, TX)   | 765   | 85.00  | 1  |
+| 4  | Jaron Klassen          | Fizz Over           | James River Assembly (Ozark, MO)  | 755   | 83.89  | 2  |
+| 5  | Elijah Evers           | Oak Creek Biblikids | Oak Creek A/G (Oak Creek, WI)     | 740   | 82.22  | 4  |
+| 6  | Christina Baxter       | God\'s C.R.E.W.     | Capitol Hill A/G (OKC, OK)        | 720   | 80.00  | 1  |
+| 7  | Caleb Hoverson         | Alien Ambassadors   | River of Life (Minot, ND)         | 605   | 67.22  | 1  |
+| 8  | Glenn Kaboskey         | Oak Creek Biblikids | Oak Creek A/G (Oak Creek, WI)     | 520   | 57.78  | 4  |
+| 9  | Coby Calvery           | Fearsome Foursome   | Trinity Church (Cedar Hill, TX)   | 485   | 53.89  | 6  |
+| 10 | Alecia Rajesh          | Army of God         | Calvary Church (Greensboro, NC)   | 455   | 50.56  | 2  |
+| 11 | Matthew Bozzay         | S.P.Y. Kids 006     | The Worship Center (Leesburg, VA) | 420   | 46.67  |    |
+| 12 | Rohan George           | Army of God         | Calvary Church (Greensboro, NC)   | 370   | 41.11  | 2  |
+| 13 | Jillian Griffith       | Fizz Over           | James River Assembly (Ozark, MO)  | 350   | 38.89  | 1  |
+| 14 | Elizabeth Kaffenberger | God Worshippers     | Glad Tidings (Omaha, NE)          | 285   | 31.67  | 3  |
+| 15 | Breanna Cole           | Soul Survivors      | Lawson A/G (Lawson, MO)           | 265   | 29.44  | 3  |
+| 16 | Erin O\'Mara           | S.P.Y. Kids 006     | The Worship Center (Leesburg, VA) | 260   | 28.89  |    |
+| 17 | Will Brovold           | God Worshippers     | Glad Tidings (Omaha, NE)          | 245   | 27.22  |    |
+| 18 | Kaelyn Comfort         | God\'s C.R.E.W.     | Capitol Hill A/G (OKC, OK)        | 240   | 26.67  |    |
+| 19 | Ben Rozelle            | S.P.Y. Kids 006     | The Worship Center (Leesburg, VA) | 235   | 26.11  | 1  |
+| 20 | Amanda Kepplin         | God Worshippers     | Glad Tidings (Omaha, NE)          | 230   | 25.56  |    |
+| 21 | Abby O\'Connell        | Fizz Over           | James River Assembly (Ozark, MO)  | 215   | 23.89  | 1  |
+| 22 | Laura Hetrick          | God Worshippers     | Glad Tidings (Omaha, NE)          | 205   | 22.78  | 1  |
+| 23 | Catherine Baxter       | God\'s C.R.E.W.     | Capitol Hill A/G (OKC, OK)        | 205   | 22.78  |    |
+| 24 | Jonathan Gomez         | Jedi Knights        | Calvary A/G (Elkhart, IN)         | 190   | 21.11  | 1  |
+| 24 | Tucker Paulson         | Alien Ambassadors   | River of Life (Minot, ND)         | 190   | 21.11  | 1  |
+| 25 | Aaron CyrilJohn        | Army of God         | Calvary Church (Greensboro, NC)   | 180   | 20.00  |    |
+| 26 | Lauren Randolph        | Jedi Knights        | Calvary A/G (Elkhart, IN)         | 160   | 17.78  |    |
+| 27 | Katie Tamblyn          | Oak Creek Biblikids | Oak Creek A/G (Oak Creek, WI)     | 135   | 15.00  |    |
+| 27 | Kristian Hoverson      | Alien Ambassadors   | River of Life (Minot, ND)         | 135   | 15.00  |    |
+| 28 | Rachel Rimmer          | Fearsome Foursome   | Trinity Church (Cedar Hill, TX)   | 100   | 11.11  |    |
+| 29 | Brian O\'Mara          | S.P.Y. Kids 006     | The Worship Center (Leesburg, VA) | 95    | 10.56  |    |
+| 30 | Abigail Prejean        | Army of God         | Calvary Church (Greensboro, NC)   | 90    | 10.00  |    |
+| 30 | Faith Davis            | Army of God         | Calvary Church (Greensboro, NC)   | 90    | 10.00  |    |
+| 30 | Miken Melvin           | God\'s C.R.E.W.     | Capitol Hill A/G (OKC, OK)        | 90    | 10.00  |    |
+| 31 | Jonathan Archer        | Soul Survivors      | Lawson A/G (Lawson, MO)           | 85    | 9.44   |    |
+| 32 | Lance Lewis            | Jedi Knights        | Calvary A/G (Elkhart, IN)         | 75    | 8.33   |    |
+| 32 | Ben Manoli             | Fearsome Foursome   | Trinity Church (Cedar Hill, TX)   | 75    | 8.33   |    |
+| 33 | Jonathan Burke         | God\'s C.R.E.W.     | Capitol Hill A/G (OKC, OK)        | 50    | 5.56   |    |
+| 34 | Catherine Hetrick      | God Worshippers     | Glad Tidings (Omaha, NE)          | 45    | 5.00   |    |
+| 35 | Duncan Connors         | S.P.Y. Kids 006     | The Worship Center (Leesburg, VA) | 25    | 2.78   |    |
+| 35 | Dylan Quiggle          | Jedi Knights        | Calvary A/G (Elkhart, IN)         | 25    | 2.78   |    |
+| 36 | Leisl Janesen          | Fizz Over           | James River Assembly (Ozark, MO)  | 5     | .56    |    |
+| 37 | Nathan Burke           | God\'s C.R.E.W.     | Capitol Hill A/G (OKC, OK)        |       | .00    |    |
+| 37 | Alyssa Sachs           | Oak Creek Biblikids | Oak Creek A/G (Oak Creek, WI)     |       | .00    |    |
+| 37 | Esji Johnson           | Oak Creek Biblikids | Oak Creek A/G (Oak Creek, WI)     |       | .00    |    |
+| 37 | Gavin Griffith         | Fizz Over           | James River Assembly (Ozark, MO)  |       | .00    |    |
+| 37 | Katherine Bozzay       | S.P.Y. Kids 006     | The Worship Center (Leesburg, VA) |       | .00    |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                  | Church                                        | W/L | Total | Avg    |
+|---:|-----------------------|-----------------------------------------------|-----|------:|-------:|
+| 1  | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                      | 7/2 | 1765  | 196.11 |
+| 2  | Fizz Up               | James River Assembly (Ozark, MO)              | 7/2 | 1515  | 168.33 |
+| 3  | Quiz CREW             | Trinity Tabernacle (Crossville, TN)           | 6/3 | 1420  | 157.78 |
+| 4  | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)      | 6/3 | 1390  | 154.44 |
+| 5  | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 6/3 | 1270  | 141.11 |
+| 6  | G.R.I.P.              | The Bridge (Mustang, OK)                      | 5/4 | 1310  | 145.56 |
+| 7  | Ashland               | 1st A/G (Ashland, AL)                         | 4/5 | 1270  | 141.11 |
+| 8  | Word Warriors         | Bethany Comm. Church (Mendon, MA)             | 2/7 | 980   | 108.89 |
+| 9  | Lightning             | Carmel A/G (Bonifay, FL)                      | 1/8 | 970   | 107.78 |
+| 10 | The Giant Smarties    | Bethel Temple A/G (Huntington, WV)            | 1/8 | 1120  | 124.44 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                  | Church                                        | Total | Avg    | QO |
+|---:|--------------------|-----------------------|-----------------------------------------------|------:|-------:|---:|
+| 1  | Tyler Cardiel      | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)      | 1015  | 112.78 | 6  |
+| 2  | Buddy Guenther     | Quiz CREW             | Trinity Tabernacle (Crossville, TN)           | 890   | 98.89  | 3  |
+| 3  | Stephen Moses      | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                      | 865   | 96.11  | 5  |
+| 4  | Paul Willis        | Ashland               | 1st A/G (Ashland, AL)                         | 840   | 93.33  | 4  |
+| 5  | Kelise Braithwaite | Fizz Up               | James River Assembly (Ozark, MO)              | 685   | 76.11  | 3  |
+| 6  | Katie Burke        | Word Warriors         | Bethany Comm. Church (Mendon, MA)             | 565   | 62.78  | 1  |
+| 7  | Travis Griessel    | Fizz Up               | James River Assembly (Ozark, MO)              | 560   | 62.22  | 3  |
+| 8  | Seth Hensley       | The Giant Smarties    | Bethel Temple A/G (Huntington, WV)            | 555   | 61.67  | 2  |
+| 9  | Bridgett Guenther  | Quiz CREW             | Trinity Tabernacle (Crossville, TN)           | 485   | 53.89  | 4  |
+| 10 | Carmel Lee         | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 470   | 52.22  |    |
+| 11 | Luke Grisham       | G.R.I.P.              | The Bridge (Mustang, OK)                      | 450   | 50.00  |    |
+| 12 | Alex Shell         | G.R.I.P.              | The Bridge (Mustang, OK)                      | 395   | 43.89  | 5  |
+| 13 | David Moses        | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                      | 395   | 43.89  | 4  |
+| 14 | Brady Powell       | Lightning             | Carmel A/G (Bonifay, FL)                      | 380   | 42.22  |    |
+| 15 | Teddy Willis       | Ashland               | 1st A/G (Ashland, AL)                         | 370   | 41.11  | 4  |
+| 16 | Noah Hensley       | The Giant Smarties    | Bethel Temple A/G (Huntington, WV)            | 370   | 41.11  | 3  |
+| 17 | Will Zepp          | Lightning             | Carmel A/G (Bonifay, FL)                      | 360   | 40.00  |    |
+| 18 | Ariana Zhu         | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 345   | 38.33  |    |
+| 19 | Jeremy Wu          | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 340   | 37.78  | 4  |
+| 20 | Peter Moses        | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                      | 285   | 31.67  |    |
+| 21 | Evan Gray          | G.R.I.P.              | The Bridge (Mustang, OK)                      | 245   | 27.22  |    |
+| 22 | Reagan Griessel    | Fizz Up               | James River Assembly (Ozark, MO)              | 225   | 25.00  | 1  |
+| 23 | Alyssa Campbell    | G.R.I.P.              | The Bridge (Mustang, OK)                      | 220   | 24.44  |    |
+| 24 | Joanna Moses       | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                      | 210   | 23.33  | 2  |
+| 25 | Filip DaSilva      | Word Warriors         | Bethany Comm. Church (Mendon, MA)             | 165   | 18.33  |    |
+| 25 | Braden Pennington  | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)      | 165   | 18.33  |    |
+| 26 | Nick Stewart       | Lightning             | Carmel A/G (Bonifay, FL)                      | 140   | 15.56  |    |
+| 27 | John Fugere        | Word Warriors         | Bethany Comm. Church (Mendon, MA)             | 135   | 15.00  |    |
+| 28 | Tyler Bernheisel   | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)      | 130   | 14.44  | 1  |
+| 29 | Ashley Webb        | The Giant Smarties    | Bethel Temple A/G (Huntington, WV)            | 110   | 12.22  |    |
+| 30 | Harrison Ku        | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 105   | 11.67  |    |
+| 31 | Makayla Lowe       | The Giant Smarties    | Bethel Temple A/G (Huntington, WV)            | 85    | 9.44   |    |
+| 32 | JJ Paul            | Lightning             | Carmel A/G (Bonifay, FL)                      | 80    | 8.89   |    |
+| 32 | Maggie Akinleye    | Parkway               | Parkway Christian Ctr. (Grants Pass, OR)      | 80    | 8.89   |    |
+| 33 | Tayla Vannelli     | Word Warriors         | Bethany Comm. Church (Mendon, MA)             | 65    | 7.22   |    |
+| 34 | Nathanael Heide    | Fizz Up               | James River Assembly (Ozark, MO)              | 45    | 5.00   |    |
+| 35 | Makayla Olsen      | Quiz CREW             | Trinity Tabernacle (Crossville, TN)           | 40    | 4.44   |    |
+| 36 | Grace Caughey      | Word Warriors         | Bethany Comm. Church (Mendon, MA)             | 30    | 3.33   |    |
+| 36 | Caroline Coleman   | Ashland               | 1st A/G (Ashland, AL)                         | 30    | 3.33   |    |
+| 36 | Grace Catchings    | Ashland               | 1st A/G (Ashland, AL)                         | 30    | 3.33   |    |
+| 37 | Bethany Perry      | Word Warriors         | Bethany Comm. Church (Mendon, MA)             | 20    | 2.22   |    |
+| 38 | Kailan Weidner     | G.R.I.P.              | The Bridge (Mustang, OK)                      | 10    | 1.11   |    |
+| 38 | Cameron Moore      | Lightning             | Carmel A/G (Bonifay, FL)                      | 10    | 1.11   |    |
+| 38 | Holly Garrett      | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                      | 10    | 1.11   |    |
+| 38 | Calvin Lee         | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) | 10    | 1.11   |    |
+| 39 | Jeremiah Olsen     | Quiz CREW             | Trinity Tabernacle (Crossville, TN)           | 5     | .56    |    |
+| 40 | Ethan Collins      | Quiz CREW             | Trinity Tabernacle (Crossville, TN)           |       | .00    |    |
+| 40 | John Guenther      | Quiz CREW             | Trinity Tabernacle (Crossville, TN)           |       | .00    |    |
+| 40 | Janet Li           | Double Edge Swordmans | Orange Co. Christian Evangelical (Irvine, CA) |       | .00    |    |
+| 40 | Lauren Grisham     | G.R.I.P.              | The Bridge (Mustang, OK)                      |       | .00    |    |
+| 40 | Elle Leebrick      | Scottsdale Free       | 1st A/G (Scottsdale, AZ)                      |       | .00    |    |
+| 40 | Abigail Olsen      | Quiz CREW             | Trinity Tabernacle (Crossville, TN)           |       | .00    |    |
+| 40 | Michael Webb       | The Giant Smarties    | Bethel Temple A/G (Huntington, WV)            |       | .00    |    |
+| 40 | Mark Ziegler       | The Giant Smarties    | Bethel Temple A/G (Huntington, WV)            |       | .00    |    |
+| 40 | Sara Gaither       | Ashland               | 1st A/G (Ashland, AL)                         |       | .00    |    |
+| 41 | Landon Grisham     | G.R.I.P.              | The Bridge (Mustang, OK)                      | -5    | -0.56  |    |
+| 41 | Caleb Horn         | G.R.I.P.              | The Bridge (Mustang, OK)                      | -5    | -0.56  |    |
+
+
+### Purple
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                                | Church                               | W/L | Total | Avg    |
+|---:|-------------------------------------|--------------------------------------|-----|------:|-------:|
+| 1  | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)          | 7/2 | 1355  | 150.56 |
+| 2  | Supernova                           | Central Assembly (Springfield, MO)   | 7/2 | 1495  | 166.11 |
+| 3  | Tribulation Force                   | The Oaks Fellowship (Red Oak, TX)    | 6/3 | 1605  | 178.33 |
+| 4  | Christ\'s Crew                      | Dayspring A/G (Bowling Green, OH)    | 6/3 | 1480  | 164.44 |
+| 5  | FCA - Cincinnati                    | First Christian A/G (Cincinnati, OH) | 6/3 | 1340  | 148.89 |
+| 6  | International Assembly of God       | International A/G (Warren, MI)       | 5/4 | 1240  | 137.78 |
+| 7  | Super Sonic Sailfish                | New Life Church (Princeton, MN)      | 3/6 | 1190  | 132.22 |
+| 8  | Buzz Hogs                           | River of Life (Mabelvale, AR)        | 2/7 | 1090  | 121.11 |
+| 9  | Kingdom Explorers                   | Mt. Creek Comm. Church (Dallas, TX)  | 2/7 | 1285  | 142.78 |
+| 10 | Greeneway Gospel Warriors           | Greeneway Church (Orlando, FL)       | 1/8 | 975   | 108.33 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                                | Church                               | Total | Avg   | QO |
+|---:|---------------------|-------------------------------------|--------------------------------------|------:|------:|---:|
+| 1  | Hannah Quick        | Supernova                           | Central Assembly (Springfield, MO)   | 865   | 96.11 | 1  |
+| 2  | Erika Fox           | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)          | 795   | 88.33 | 6  |
+| 3  | Evan Kobylski       | Christ\'s Crew                      | Dayspring A/G (Bowling Green, OH)    | 790   | 87.78 | 4  |
+| 4  | Sherlin Chacko      | International Assembly of God       | International A/G (Warren, MI)       | 780   | 86.67 | 4  |
+| 5  | Brennan Dodds       | FCA - Cincinnati                    | First Christian A/G (Cincinnati, OH) | 765   | 85.00 | 3  |
+| 6  | Parker Frankiewicz  | Tribulation Force                   | The Oaks Fellowship (Red Oak, TX)    | 720   | 80.00 | 2  |
+| 7  | Samuel Grey         | Kingdom Explorers                   | Mt. Creek Comm. Church (Dallas, TX)  | 670   | 74.44 | 4  |
+| 8  | Zachary Barlow      | Greeneway Gospel Warriors           | Greeneway Church (Orlando, FL)       | 625   | 69.44 | 1  |
+| 9  | Jared Minick        | Buzz Hogs                           | River of Life (Mabelvale, AR)        | 605   | 67.22 | 1  |
+| 10 | Thomas Stewart      | Super Sonic Sailfish                | New Life Church (Princeton, MN)      | 600   | 66.67 | 2  |
+| 11 | Tyler Howard        | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)          | 470   | 52.22 | 1  |
+| 12 | David Saunders      | Tribulation Force                   | The Oaks Fellowship (Red Oak, TX)    | 465   | 51.67 |    |
+| 13 | Luis Torres         | Kingdom Explorers                   | Mt. Creek Comm. Church (Dallas, TX)  | 460   | 51.11 | 1  |
+| 14 | Luke Slater         | Supernova                           | Central Assembly (Springfield, MO)   | 420   | 46.67 | 3  |
+| 15 | Aaron Smith         | Christ\'s Crew                      | Dayspring A/G (Bowling Green, OH)    | 350   | 38.89 |    |
+| 16 | Lilly Schmitz       | Christ\'s Crew                      | Dayspring A/G (Bowling Green, OH)    | 340   | 37.78 | 2  |
+| 17 | Micah Roelofs       | Super Sonic Sailfish                | New Life Church (Princeton, MN)      | 320   | 35.56 | 1  |
+| 18 | Bridge Biniakewitz  | Buzz Hogs                           | River of Life (Mabelvale, AR)        | 260   | 28.89 | 2  |
+| 19 | Bekah Ray           | FCA - Cincinnati                    | First Christian A/G (Cincinnati, OH) | 255   | 28.33 | 1  |
+| 20 | McKenzie Barlow     | Greeneway Gospel Warriors           | Greeneway Church (Orlando, FL)       | 250   | 27.78 |    |
+| 21 | Josiah Stewart      | Super Sonic Sailfish                | New Life Church (Princeton, MN)      | 240   | 26.67 | 1  |
+| 22 | Sarah Jacob         | International Assembly of God       | International A/G (Warren, MI)       | 220   | 24.44 |    |
+| 23 | Trenton Page        | Buzz Hogs                           | River of Life (Mabelvale, AR)        | 215   | 23.89 |    |
+| 23 | Matthew Hipshire    | Tribulation Force                   | The Oaks Fellowship (Red Oak, TX)    | 215   | 23.89 |    |
+| 24 | Cameron Berta       | Tribulation Force                   | The Oaks Fellowship (Red Oak, TX)    | 205   | 22.78 |    |
+| 25 | Natalie Slater      | Supernova                           | Central Assembly (Springfield, MO)   | 190   | 21.11 |    |
+| 26 | Albert George       | International Assembly of God       | International A/G (Warren, MI)       | 165   | 18.33 |    |
+| 27 | Ethan Smith         | FCA - Cincinnati                    | First Christian A/G (Cincinnati, OH) | 155   | 17.22 |    |
+| 28 | Jared Kleinhenz     | FCA - Cincinnati                    | First Christian A/G (Cincinnati, OH) | 100   | 11.11 |    |
+| 29 | Patrick Keenan      | Kingdom Explorers                   | Mt. Creek Comm. Church (Dallas, TX)  | 90    | 10.00 |    |
+| 30 | Jerrin George       | International Assembly of God       | International A/G (Warren, MI)       | 75    | 8.33  |    |
+| 31 | Kyle Ritter         | Greeneway Gospel Warriors           | Greeneway Church (Orlando, FL)       | 70    | 7.78  |    |
+| 32 | Gunnar Smart        | FCA - Cincinnati                    | First Christian A/G (Cincinnati, OH) | 60    | 6.67  |    |
+| 33 | Tirzah Brookbank    | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)          | 50    | 5.56  |    |
+| 34 | Matthew Keenan      | Kingdom Explorers                   | Mt. Creek Comm. Church (Dallas, TX)  | 45    | 5.00  |    |
+| 35 | Hannah Merrell      | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)          | 40    | 4.44  |    |
+| 36 | Caleb Barlow        | Greeneway Gospel Warriors           | Greeneway Church (Orlando, FL)       | 30    | 3.33  |    |
+| 37 | AryAnna Bennett     | Kingdom Explorers                   | Mt. Creek Comm. Church (Dallas, TX)  | 20    | 2.22  |    |
+| 37 | Lucas Clark         | Supernova                           | Central Assembly (Springfield, MO)   | 20    | 2.22  |    |
+| 37 | Montana Lawrence    | Super Sonic Sailfish                | New Life Church (Princeton, MN)      | 20    | 2.22  |    |
+| 38 | Savanah Biniakewitz | Buzz Hogs                           | River of Life (Mabelvale, AR)        | 10    | 1.11  |    |
+| 38 | Ryan Moos           | Super Sonic Sailfish                | New Life Church (Princeton, MN)      | 10    | 1.11  |    |
+| 39 | Jack Titkemeyer     | FCA - Cincinnati                    | First Christian A/G (Cincinnati, OH) | 5     | .56   |    |
+| 40 | Seth Estep          | Christ\'s Crew                      | Dayspring A/G (Bowling Green, OH)    |       | .00   |    |
+| 40 | Harrison Hoggard    | Tribulation Force                   | The Oaks Fellowship (Red Oak, TX)    |       | .00   |    |
+| 40 | Jed Brookbank       | Overland Park First Assembly of God | 1st A/G (Overland Park, KS)          |       | .00   |    |
+| 40 | Caleb Daniels       | Super Sonic Sailfish                | New Life Church (Princeton, MN)      |       | .00   |    |
+| 40 | Lily Slater         | Supernova                           | Central Assembly (Springfield, MO)   |       | .00   |    |
+| 40 | Levi Biniakewitz    | Buzz Hogs                           | River of Life (Mabelvale, AR)        |       | .00   |    |
+

--- a/_pages/jbq/2011/index.md
+++ b/_pages/jbq/2011/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2011 JBQ Season"
+permalink: /jbq/2011/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+<a href="{% link _pages/jbq/2011/nationals.md %}" class="button is-primary">National Finals</a>
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2011/nationals.md
+++ b/_pages/jbq/2011/nationals.md
@@ -1,0 +1,1834 @@
+---
+layout: page
+title: "2011 National Festival: Minneapolis, MN"
+permalink: /jbq/2011/nationals/
+date: "2015-06-10"
+toc_title: Results
+menubar_toc: true
+---
+
+## Friday (AM)
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                          | Church             | W/L | Total | Avg    |
+|--:|-------------------------------|--------------------|-----|------:|-------:|
+| 1 | C-Tongues of Fire             | Louisville-KY      | 6/1 | 1270  | 181.43 |
+| 2 | D-Word Warriors               | Flower Mound-TX    | 5/2 | 1160  | 165.71 |
+| 3 | A-Greater Lansing             | East Lansing-MI    | 5/2 | 1100  | 157.14 |
+| 4 | E-Awesome Answerers           | Billings-MT        | 4/3 | 960   | 137.14 |
+| 5 | J-Christ Runners              | Fargo-ND           | 3/4 | 1015  | 145.00 |
+| 6 | H-Bethlehem Church            | Richmond Hill-NY   | 2/5 | 730   | 104.29 |
+| 7 | I-CLC                         | Fort Lauderdale-FL | 2/5 | 925   | 132.14 |
+| 8 | G-The Crossing Place Quizzers | Franklin-LA        | 1/6 | 815   | 116.43 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                          | Church             | Total | Avg   | QO |
+|---:|--------------------|-------------------------------|--------------------|------:|------:|---:|
+| 1  | Tyler McCartney    | A-Greater Lansing             | East Lansing-MI    | 580   | 82.86 | 3  |
+| 2  | Ope Morakinyo      | I-CLC                         | Fort Lauderdale-FL | 550   | 78.57 | 1  |
+| 3  | Jordan Landry      | G-The Crossing Place Quizzers | Franklin-LA        | 535   | 76.43 |    |
+| 4  | Lucie Price        | C-Tongues of Fire             | Louisville-KY      | 485   | 69.29 | 1  |
+| 5  | Kaitlyn Ballard    | D-Word Warriors               | Flower Mound-TX    | 455   | 65.00 |    |
+| 6  | Tessa Houde        | E-Awesome Answerers           | Billings-MT        | 430   | 61.43 | 1  |
+| 7  | Jaret Williams     | H-Bethlehem Church            | Richmond Hill-NY   | 405   | 57.86 | 2  |
+| 8  | Micah Marchand     | J-Christ Runners              | Fargo-ND           | 375   | 53.57 |    |
+| 9  | Alex Rawlings      | D-Word Warriors               | Flower Mound-TX    | 365   | 52.14 | 3  |
+| 10 | Ben Harsha         | E-Awesome Answerers           | Billings-MT        | 355   | 50.71 |    |
+| 11 | Luke Yantz         | C-Tongues of Fire             | Louisville-KY      | 340   | 48.57 |    |
+| 12 | Trea Webb          | C-Tongues of Fire             | Louisville-KY      | 315   | 45.00 | 3  |
+| 13 | Madie Rawlings     | D-Word Warriors               | Flower Mound-TX    | 315   | 45.00 |    |
+| 14 | Chase Buher        | A-Greater Lansing             | East Lansing-MI    | 295   | 42.14 | 3  |
+| 15 | Brendon Sturgeon   | G-The Crossing Place Quizzers | Franklin-LA        | 280   | 40.00 | 2  |
+| 16 | Carson Nix         | J-Christ Runners              | Fargo-ND           | 280   | 40.00 |    |
+| 17 | Michael Notman     | I-CLC                         | Fort Lauderdale-FL | 270   | 38.57 |    |
+| 18 | Darcie Harr        | A-Greater Lansing             | East Lansing-MI    | 240   | 34.29 | 1  |
+| 19 | Jordan Nix         | J-Christ Runners              | Fargo-ND           | 165   | 23.57 | 2  |
+| 20 | Aaron Marchand     | J-Christ Runners              | Fargo-ND           | 140   | 20.00 | 1  |
+| 21 | Matthew Frick      | E-Awesome Answerers           | Billings-MT        | 140   | 20.00 |    |
+| 22 | Jonathan Green     | C-Tongues of Fire             | Louisville-KY      | 130   | 18.57 |    |
+| 23 | Sara Ann Haimchand | H-Bethlehem Church            | Richmond Hill-NY   | 125   | 17.86 |    |
+| 24 | Joy Okafor         | H-Bethlehem Church            | Richmond Hill-NY   | 115   | 16.43 |    |
+| 25 | Jonathan Irizarry  | I-CLC                         | Fort Lauderdale-FL | 105   | 15.00 |    |
+| 26 | Nicole DeSilva     | H-Bethlehem Church            | Richmond Hill-NY   | 100   | 14.29 |    |
+| 27 | Jayda Houde        | E-Awesome Answerers           | Billings-MT        | 40    | 5.71  |    |
+| 28 | Hannah Nix         | J-Christ Runners              | Fargo-ND           | 30    | 4.29  |    |
+| 29 | Zeke Rashid        | D-Word Warriors               | Flower Mound-TX    | 25    | 3.57  |    |
+| 30 | Andrew Manske      | J-Christ Runners              | Fargo-ND           | 25    | 3.57  |    |
+| 31 | Celah Convis       | A-Greater Lansing             | East Lansing-MI    | 10    | 1.43  |    |
+
+
+### Cream
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                 | Church        | W/L | Total | Avg    |
+|--:|----------------------|---------------|-----|------:|-------:|
+| 1 | C-Naperville\'       | Naperville-IL | 6/1 | 1305  | 186.43 |
+| 2 | E-Westgate A1        | Edmonds-WA    | 6/1 | 1320  | 188.57 |
+| 3 | B-Sabia              | Roswell-GA    | 5/2 | 1065  | 152.14 |
+| 4 | D-BBT Hayah          | Scottsdale-AZ | 3/4 | 1015  | 145.00 |
+| 5 | J-BC United          | Wyckoff-NJ    | 3/4 | 965   | 137.86 |
+| 6 | G-The Praying Amigos | Brookfield-WI | 3/4 | 935   | 133.57 |
+| 7 | F-Q\'s               | Lexington-TN  | 2/5 | 1025  | 146.43 |
+| 8 | H-Gospel Gang        | Amarillo-TX   | 0/7 | 265   | 37.86  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer               | Team                 | Church        | Total | Avg    | QO |
+|---:|-----------------------|----------------------|---------------|------:|-------:|---:|
+| 1  | Shreanna Powell       | C-Naperville\'       | Naperville-IL | 710   | 101.43 | 3  |
+| 2  | Daniel Ferreira       | B-Sabia              | Roswell-GA    | 675   | 96.43  | 3  |
+| 3  | Reuben Savage         | F-Q\'s               | Lexington-TN  | 610   | 87.14  | 1  |
+| 4  | Garrett Miyaoka       | E-Westgate A1        | Edmonds-WA    | 600   | 85.71  | 2  |
+| 5  | Stephen Moses         | D-BBT Hayah          | Scottsdale-AZ | 595   | 85.00  | 3  |
+| 6  | Robert Laboy          | C-Naperville\'       | Naperville-IL | 410   | 58.57  | 5  |
+| 7  | Elijah O\'Brien       | G-The Praying Amigos | Brookfield-WI | 370   | 52.86  |    |
+| 8  | Nicholas Tveit        | E-Westgate A1        | Edmonds-WA    | 340   | 48.57  | 4  |
+| 9  | Noah Ku               | E-Westgate A1        | Edmonds-WA    | 330   | 47.14  |    |
+| 10 | Rachel Girimonte      | J-BC United          | Wyckoff-NJ    | 315   | 45.00  |    |
+| 11 | Cayla Brodeur         | J-BC United          | Wyckoff-NJ    | 275   | 39.29  |    |
+| 12 | Emma Moorman          | J-BC United          | Wyckoff-NJ    | 265   | 37.86  | 2  |
+| 13 | David Moses           | D-BBT Hayah          | Scottsdale-AZ | 245   | 35.00  |    |
+| 14 | Cristian Huix         | B-Sabia              | Roswell-GA    | 240   | 34.29  | 1  |
+| 15 | Esther O\'Brien       | G-The Praying Amigos | Brookfield-WI | 220   | 31.43  | 1  |
+| 16 | Seth Savage           | F-Q\'s               | Lexington-TN  | 205   | 29.29  | 2  |
+| 17 | Ryan Chunn            | H-Gospel Gang        | Amarillo-TX   | 185   | 26.43  |    |
+| 18 | Anthony Mikolajewski  | G-The Praying Amigos | Brookfield-WI | 180   | 25.71  |    |
+| 19 | Esji Johnson          | G-The Praying Amigos | Brookfield-WI | 165   | 23.57  |    |
+| 20 | Eli Price             | F-Q\'s               | Lexington-TN  | 150   | 21.43  | 1  |
+| 21 | Jake Wolfe            | C-Naperville\'       | Naperville-IL | 150   | 21.43  |    |
+| 21 | Grace Artis           | B-Sabia              | Roswell-GA    | 150   | 21.43  |    |
+| 22 | Joanna Moses          | D-BBT Hayah          | Scottsdale-AZ | 105   | 15.00  |    |
+| 23 | Holly Garrett         | D-BBT Hayah          | Scottsdale-AZ | 70    | 10.00  |    |
+| 23 | Michaela McLeod       | J-BC United          | Wyckoff-NJ    | 70    | 10.00  |    |
+| 24 | Ashlynn Price         | F-Q\'s               | Lexington-TN  | 60    | 8.57   |    |
+| 25 | Anastasia Yevtushenko | E-Westgate A1        | Edmonds-WA    | 50    | 7.14   |    |
+| 26 | Rachel Adelmann       | J-BC United          | Wyckoff-NJ    | 40    | 5.71   |    |
+| 27 | Erin Laboy            | C-Naperville\'       | Naperville-IL | 35    | 5.00   |    |
+| 27 | Zachary Westmoreland  | H-Gospel Gang        | Amarillo-TX   | 35    | 5.00   |    |
+| 28 | Elizabeth Chunn       | H-Gospel Gang        | Amarillo-TX   | 30    | 4.29   |    |
+| 29 | Brendan Marrow        | H-Gospel Gang        | Amarillo-TX   | 20    | 2.86   |    |
+| 30 | Natalie Salerno       | J-BC United          | Wyckoff-NJ    |       | .00    |    |
+| 30 | Todd Pettet           | J-BC United          | Wyckoff-NJ    |       | .00    |    |
+| 30 | Olivia Cypcar         | G-The Praying Amigos | Brookfield-WI |       | .00    |    |
+| 31 | Abigail Chunn         | H-Gospel Gang        | Amarillo-TX   | -5    | -0.71  |    |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                   | Church           | W/L | Total | Avg    |
+|--:|------------------------|------------------|-----|------:|-------:|
+| 1 | E-Soaring Eagles       | Poland-OH        | 6/1 | 1310  | 187.14 |
+| 2 | B-S.P.Y. Kids 007      | Leesburg-VA      | 5/2 | 1270  | 181.43 |
+| 3 | C-Memphis Advanced     | Cordova-TN       | 5/2 | 1005  | 143.57 |
+| 4 | A-OCCEC                | Irvine-CA        | 4/3 | 1135  | 162.14 |
+| 5 | G-Warriors in Training | Columbiaville-MI | 3/4 | 1000  | 142.86 |
+| 6 | F-God\'s C.R.E.W.      | Oklahoma City-OK | 3/4 | 965   | 137.86 |
+| 7 | J-SWAT                 | Lakeville-MN     | 2/5 | 745   | 106.43 |
+| 8 | I-ACOG                 | Lawrenceville-GA | 0/7 | 480   | 68.57  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                   | Church           | Total | Avg    | QO |
+|---:|-------------------|------------------------|------------------|------:|-------:|---:|
+| 1  | Jolia Madigan     | E-Soaring Eagles       | Poland-OH        | 805   | 115.00 | 3  |
+| 2  | Jared Deppe       | C-Memphis Advanced     | Cordova-TN       | 695   | 99.29  | 3  |
+| 3  | Christina Baxter  | F-God\'s C.R.E.W.      | Oklahoma City-OK | 645   | 92.14  | 3  |
+| 4  | Matthew Bozzay    | B-S.P.Y. Kids 007      | Leesburg-VA      | 575   | 82.14  | 3  |
+| 5  | Harrison Ku       | A-OCCEC                | Irvine-CA        | 555   | 79.29  | 2  |
+| 6  | Olivia Madigan    | E-Soaring Eagles       | Poland-OH        | 410   | 58.57  | 2  |
+| 7  | Ashton Heath      | J-SWAT                 | Lakeville-MN     | 400   | 57.14  | 6  |
+| 8  | Jeremy Wu         | A-OCCEC                | Irvine-CA        | 400   | 57.14  | 4  |
+| 9  | Josh Rozelle      | B-S.P.Y. Kids 007      | Leesburg-VA      | 340   | 48.57  |    |
+| 10 | Hudson Hollin     | G-Warriors in Training | Columbiaville-MI | 325   | 46.43  |    |
+| 11 | Joey Huntley      | G-Warriors in Training | Columbiaville-MI | 305   | 43.57  |    |
+| 12 | Bennett Thomas    | I-ACOG                 | Lawrenceville-GA | 290   | 41.43  | 1  |
+| 13 | Abbigail Vaughan  | C-Memphis Advanced     | Cordova-TN       | 230   | 32.86  | 1  |
+| 14 | Luke Yoder        | B-S.P.Y. Kids 007      | Leesburg-VA      | 210   | 30.00  | 1  |
+| 15 | Hunter Hollin     | G-Warriors in Training | Columbiaville-MI | 190   | 27.14  | 2  |
+| 16 | Calvin Lee        | A-OCCEC                | Irvine-CA        | 190   | 27.14  |    |
+| 17 | Alex Peters       | G-Warriors in Training | Columbiaville-MI | 180   | 25.71  |    |
+| 18 | Kyle Ringley      | J-SWAT                 | Lakeville-MN     | 165   | 23.57  |    |
+| 19 | Miken Melvin      | F-God\'s C.R.E.W.      | Oklahoma City-OK | 160   | 22.86  | 1  |
+| 20 | Catherine Baxter  | F-God\'s C.R.E.W.      | Oklahoma City-OK | 160   | 22.86  |    |
+| 21 | Melvin Mathew     | I-ACOG                 | Lawrenceville-GA | 125   | 17.86  | 1  |
+| 22 | Madison Heath     | J-SWAT                 | Lakeville-MN     | 105   | 15.00  |    |
+| 23 | Ben Rozelle       | B-S.P.Y. Kids 007      | Leesburg-VA      | 90    | 12.86  |    |
+| 24 | Gabby Ringley     | J-SWAT                 | Lakeville-MN     | 75    | 10.71  |    |
+| 25 | Julia Browning    | C-Memphis Advanced     | Cordova-TN       | 70    | 10.00  |    |
+| 26 | Brennann Thomas   | I-ACOG                 | Lawrenceville-GA | 65    | 9.29   |    |
+| 26 | Ty Homrighausen   | E-Soaring Eagles       | Poland-OH        | 65    | 9.29   |    |
+| 27 | Andrew Otchere    | B-S.P.Y. Kids 007      | Leesburg-VA      | 55    | 7.86   |    |
+| 28 | Will Homrighausen | E-Soaring Eagles       | Poland-OH        | 30    | 4.29   |    |
+| 29 | Nema Sarwar       | C-Memphis Advanced     | Cordova-TN       | 10    | 1.43   |    |
+| 30 | Nathan Burke      | F-God\'s C.R.E.W.      | Oklahoma City-OK |       | .00    |    |
+| 30 | Hailie Huntley    | G-Warriors in Training | Columbiaville-MI |       | .00    |    |
+| 30 | Jonathan Burke    | F-God\'s C.R.E.W.      | Oklahoma City-OK |       | .00    |    |
+| 30 | Sarah Judd        | B-S.P.Y. Kids 007      | Leesburg-VA      |       | .00    |    |
+| 30 | Katherine Bozzay  | B-S.P.Y. Kids 007      | Leesburg-VA      |       | .00    |    |
+| 30 | Brandon Byers     | G-Warriors in Training | Columbiaville-MI |       | .00    |    |
+
+
+### Grey
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                       | Church             | W/L | Total | Avg    |
+|--:|----------------------------|--------------------|-----|------:|-------:|
+| 1 | A-JAG                      | Meriden-KS         | 6/1 | 1270  | 181.43 |
+| 2 | D-Naperville               | Naperville-IL      | 6/1 | 1335  | 190.71 |
+| 3 | B-Purple                   | Ozark-MO           | 4/3 | 1125  | 160.71 |
+| 4 | C-MARS                     | Baxter-MN          | 4/3 | 1010  | 144.29 |
+| 5 | I-CRK Almighty             | Gloucester City-NJ | 4/3 | 855   | 122.14 |
+| 6 | H-Temple - Clanton         | Clanton-AL         | 2/5 | 975   | 139.29 |
+| 7 | F-Desert Joy Bible Buzzers | Litchfield Park-AZ | 1/6 | 715   | 102.14 |
+| 8 | Flamin\' Hot Buzzers       | Albuquerque-NM     | 1/6 | 660   | 94.29  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                       | Church             | Total | Avg    | QO |
+|---:|--------------------|----------------------------|--------------------|------:|-------:|---:|
+| 1  | Parker Frankiewicz | D-Naperville               | Naperville-IL      | 890   | 127.14 | 5  |
+| 2  | Julia Rivera       | A-JAG                      | Meriden-KS         | 660   | 94.29  | 3  |
+| 3  | Bailey Watley      | H-Temple - Clanton         | Clanton-AL         | 580   | 82.86  | 3  |
+| 4  | Lynne Borowicz     | C-MARS                     | Baxter-MN          | 580   | 82.86  | 2  |
+| 5  | Jazmynn Wilson     | Flamin\' Hot Buzzers       | Albuquerque-NM     | 480   | 68.57  | 2  |
+| 6  | Linsey Garrison    | B-Purple                   | Ozark-MO           | 475   | 67.86  | 1  |
+| 7  | Jacob Kilian       | F-Desert Joy Bible Buzzers | Litchfield Park-AZ | 450   | 64.29  |    |
+| 8  | Elijah Abad        | I-CRK Almighty             | Gloucester City-NJ | 380   | 54.29  | 1  |
+| 9  | Jonathan Moore     | A-JAG                      | Meriden-KS         | 335   | 47.86  |    |
+| 10 | Brandon Watley     | H-Temple - Clanton         | Clanton-AL         | 325   | 46.43  | 2  |
+| 11 | Hayden Ballard     | B-Purple                   | Ozark-MO           | 295   | 42.14  |    |
+| 12 | Victoriah Shook    | B-Purple                   | Ozark-MO           | 265   | 37.86  | 1  |
+| 13 | Eric Loschko       | C-MARS                     | Baxter-MN          | 220   | 31.43  |    |
+| 14 | Brant Dabill       | C-MARS                     | Baxter-MN          | 210   | 30.00  |    |
+| 15 | Kyle Reichart      | A-JAG                      | Meriden-KS         | 185   | 26.43  | 1  |
+| 16 | Jillian Angeles    | I-CRK Almighty             | Gloucester City-NJ | 185   | 26.43  |    |
+| 17 | Will Wolfe         | D-Naperville               | Naperville-IL      | 170   | 24.29  | 1  |
+| 17 | Sheldon Powell     | D-Naperville               | Naperville-IL      | 170   | 24.29  | 1  |
+| 18 | Jacob Flores       | I-CRK Almighty             | Gloucester City-NJ | 160   | 22.86  | 1  |
+| 19 | Joshua Kilian      | F-Desert Joy Bible Buzzers | Litchfield Park-AZ | 155   | 22.14  |    |
+| 20 | Jessica McElwee    | D-Naperville               | Naperville-IL      | 105   | 15.00  |    |
+| 21 | Drew Wilson        | Flamin\' Hot Buzzers       | Albuquerque-NM     | 100   | 14.29  | 1  |
+| 22 | Russel Flores      | I-CRK Almighty             | Gloucester City-NJ | 85    | 12.14  |    |
+| 23 | Jonathan Morales   | F-Desert Joy Bible Buzzers | Litchfield Park-AZ | 70    | 10.00  |    |
+| 23 | Elian Gonzales     | Flamin\' Hot Buzzers       | Albuquerque-NM     | 70    | 10.00  |    |
+| 23 | James Harris       | A-JAG                      | Meriden-KS         | 70    | 10.00  |    |
+| 24 | Brenden Reeves     | B-Purple                   | Ozark-MO           | 55    | 7.86   |    |
+| 25 | Junny Jayme        | I-CRK Almighty             | Gloucester City-NJ | 45    | 6.43   |    |
+| 26 | Emma Cleckler      | H-Temple - Clanton         | Clanton-AL         | 40    | 5.71   |    |
+| 26 | Jeremy Morales     | F-Desert Joy Bible Buzzers | Litchfield Park-AZ | 40    | 5.71   |    |
+| 27 | Zara Rethman       | B-Purple                   | Ozark-MO           | 35    | 5.00   |    |
+| 28 | Katelyn Johnson    | H-Temple - Clanton         | Clanton-AL         | 30    | 4.29   |    |
+| 29 | Colton Huffman     | A-JAG                      | Meriden-KS         | 20    | 2.86   |    |
+| 30 | Gabriel Gonzales   | Flamin\' Hot Buzzers       | Albuquerque-NM     | 10    | 1.43   |    |
+| 31 | Matthew Rydeski    | Flamin\' Hot Buzzers       | Albuquerque-NM     |       | .00    |    |
+| 31 | Mandy Rydeski      | Flamin\' Hot Buzzers       | Albuquerque-NM     |       | .00    |    |
+| 31 | Naomi Kilian       | F-Desert Joy Bible Buzzers | Litchfield Park-AZ |       | .00    |    |
+| 31 | Landon Lundeby     | C-MARS                     | Baxter-MN          |       | .00    |    |
+| 31 | Grace Riedel       | C-MARS                     | Baxter-MN          |       | .00    |    |
+| 31 | Emily Stevens      | C-MARS                     | Baxter-MN          |       | .00    |    |
+| 31 | Eva Dabill         | C-MARS                     | Baxter-MN          |       | .00    |    |
+| 31 | Taylor Borowicz    | C-MARS                     | Baxter-MN          |       | .00    |    |
+| 31 | Julia DeGraff      | D-Naperville               | Naperville-IL      |       | .00    |    |
+| 31 | Mattie Cleckler    | H-Temple - Clanton         | Clanton-AL         |       | .00    |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                 | Church           | W/L | Total | Avg    |
+|--:|----------------------|------------------|-----|------:|-------:|
+| 1 | B-Faithful Falcons   | Austin-TX        | 6/1 | 1295  | 185.00 |
+| 2 | A-Harrison Thrashers | Harrison-AR      | 5/2 | 1150  | 164.29 |
+| 3 | C-Cedar Park         | Bothell-WA       | 4/3 | 1085  | 155.00 |
+| 4 | E-The CIA            | Mendon-MA        | 4/3 | 1030  | 147.14 |
+| 5 | F-Gideon\'s Army     | Huber Heights-OH | 3/4 | 1025  | 146.43 |
+| 6 | I-N 2 God Again      | Concord-NC       | 2/5 | 900   | 128.57 |
+| 7 | J-Earth Shakers      | Chandler-AZ      | 2/5 | 865   | 123.57 |
+| 8 | G-Word Nerds         | Des Moines-IA    | 2/5 | 770   | 110.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                 | Church           | Total | Avg    | QO |
+|---:|---------------------|----------------------|------------------|------:|-------:|---:|
+| 1  | Joel James          | B-Faithful Falcons   | Austin-TX        | 750   | 107.14 | 4  |
+| 2  | Sean Jones          | F-Gideon\'s Army     | Huber Heights-OH | 645   | 92.14  | 3  |
+| 3  | Makenzie Bradshaw   | A-Harrison Thrashers | Harrison-AR      | 615   | 87.86  | 2  |
+| 4  | Feba Cherian        | J-Earth Shakers      | Chandler-AZ      | 510   | 72.86  | 1  |
+| 5  | Jacob Brechtel      | G-Word Nerds         | Des Moines-IA    | 380   | 54.29  |    |
+| 6  | Joshua Roberts      | C-Cedar Park         | Bothell-WA       | 375   | 53.57  | 1  |
+| 7  | Shannon Morrill     | E-The CIA            | Mendon-MA        | 370   | 52.86  | 2  |
+| 8  | John Fugere         | E-The CIA            | Mendon-MA        | 345   | 49.29  |    |
+| 9  | Ida Ekuban          | I-N 2 God Again      | Concord-NC       | 330   | 47.14  | 1  |
+| 10 | Kerigan Bradshaw    | A-Harrison Thrashers | Harrison-AR      | 325   | 46.43  | 2  |
+| 11 | Warner Pool         | G-Word Nerds         | Des Moines-IA    | 310   | 44.29  | 4  |
+| 12 | Samuel Birrell      | B-Faithful Falcons   | Austin-TX        | 270   | 38.57  | 2  |
+| 12 | Gabriel Ison        | F-Gideon\'s Army     | Huber Heights-OH | 270   | 38.57  | 2  |
+| 13 | Tayla Vannelli      | E-The CIA            | Mendon-MA        | 260   | 37.14  |    |
+| 14 | Erin Clay           | I-N 2 God Again      | Concord-NC       | 240   | 34.29  |    |
+| 15 | Max Fowler          | I-N 2 God Again      | Concord-NC       | 230   | 32.86  | 2  |
+| 16 | Jackson Houser      | C-Cedar Park         | Bothell-WA       | 230   | 32.86  | 1  |
+| 17 | Sierra Smith        | C-Cedar Park         | Bothell-WA       | 215   | 30.71  | 1  |
+| 18 | Madyson Theesfeld   | J-Earth Shakers      | Chandler-AZ      | 210   | 30.00  | 1  |
+| 19 | Johan West          | C-Cedar Park         | Bothell-WA       | 185   | 26.43  | 1  |
+| 20 | Jessica Emeodi      | B-Faithful Falcons   | Austin-TX        | 130   | 18.57  |    |
+| 20 | Josh James          | B-Faithful Falcons   | Austin-TX        | 130   | 18.57  |    |
+| 21 | Crystal Thomas      | J-Earth Shakers      | Chandler-AZ      | 120   | 17.14  |    |
+| 21 | Abby Bailey         | A-Harrison Thrashers | Harrison-AR      | 120   | 17.14  |    |
+| 22 | Victoria Dahlman    | I-N 2 God Again      | Concord-NC       | 100   | 14.29  |    |
+| 23 | Laura Henderson     | A-Harrison Thrashers | Harrison-AR      | 80    | 11.43  |    |
+| 23 | Andreya Snyder      | C-Cedar Park         | Bothell-WA       | 80    | 11.43  |    |
+| 24 | Jeannah Jones       | F-Gideon\'s Army     | Huber Heights-OH | 75    | 10.71  |    |
+| 25 | Claire Roe          | G-Word Nerds         | Des Moines-IA    | 60    | 8.57   |    |
+| 26 | Bethany Perry       | E-The CIA            | Mendon-MA        | 55    | 7.86   |    |
+| 27 | Ryleigh Jones       | F-Gideon\'s Army     | Huber Heights-OH | 35    | 5.00   |    |
+| 28 | Rhea Nathaniel      | J-Earth Shakers      | Chandler-AZ      | 25    | 3.57   |    |
+| 29 | Annie Pool          | G-Word Nerds         | Des Moines-IA    | 20    | 2.86   |    |
+| 30 | Samuel Sundararaman | B-Faithful Falcons   | Austin-TX        | 15    | 2.14   |    |
+| 31 | Reagan Warren       | A-Harrison Thrashers | Harrison-AR      | 10    | 1.43   |    |
+| 32 | Bethany Warren      | A-Harrison Thrashers | Harrison-AR      |       | .00    |    |
+| 32 | Rebekah Birrell     | B-Faithful Falcons   | Austin-TX        |       | .00    |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                           | Church            | W/L | Total | Avg    |
+|--:|--------------------------------|-------------------|-----|------:|-------:|
+| 1 | D-Bible Treasure Seekers       | Greensboro-NC     | 7/0 | 1335  | 190.71 |
+| 2 | C-Brightmoor                   | Novi-MI           | 5/2 | 1200  | 171.43 |
+| 3 | E-Blazing Swords               | Chesterfield-MO   | 5/2 | 1245  | 177.86 |
+| 4 | B-Quiz Kidz                    | Scotch Plains-NJ  | 4/3 | 985   | 140.71 |
+| 5 | J-Family Life Christian Center | Federal Way-WA    | 3/4 | 910   | 130.00 |
+| 6 | G-CIA                          | Mustang-OK        | 2/5 | 930   | 132.86 |
+| 7 | H-Karate Quizzers              | Bismarck-ND       | 2/5 | 895   | 127.86 |
+| 8 | F-The Four-ce Unleashed        | Universal City-TX | 0/7 | 750   | 107.14 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                           | Church            | Total | Avg    | QO |
+|---:|---------------------|--------------------------------|-------------------|------:|-------:|---:|
+| 1  | Alecia Rajesh       | D-Bible Treasure Seekers       | Greensboro-NC     | 775   | 110.71 | 2  |
+| 2  | Nicolas Boyce       | J-Family Life Christian Center | Federal Way-WA    | 635   | 90.71  | 2  |
+| 3  | Daniel Kinger       | E-Blazing Swords               | Chesterfield-MO   | 550   | 78.57  | 3  |
+| 4  | Maxwell Holleman    | C-Brightmoor                   | Novi-MI           | 510   | 72.86  | 6  |
+| 5  | Lauren Chapman      | C-Brightmoor                   | Novi-MI           | 485   | 69.29  | 2  |
+| 6  | Eliott Gathman      | E-Blazing Swords               | Chesterfield-MO   | 485   | 69.29  | 1  |
+| 7  | Alex Shell          | G-CIA                          | Mustang-OK        | 420   | 60.00  | 1  |
+| 8  | Benshel Bright      | B-Quiz Kidz                    | Scotch Plains-NJ  | 390   | 55.71  |    |
+| 9  | Abigail Prejean     | D-Bible Treasure Seekers       | Greensboro-NC     | 350   | 50.00  | 4  |
+| 10 | Derek Leingang      | H-Karate Quizzers              | Bismarck-ND       | 295   | 42.14  | 1  |
+| 11 | Mary Frances Harris | F-The Four-ce Unleashed        | Universal City-TX | 290   | 41.43  |    |
+| 12 | Zach Wylie          | F-The Four-ce Unleashed        | Universal City-TX | 280   | 40.00  |    |
+| 13 | Landon Grisham      | G-CIA                          | Mustang-OK        | 270   | 38.57  | 3  |
+| 14 | Ashlyn Sipes        | H-Karate Quizzers              | Bismarck-ND       | 265   | 37.86  | 1  |
+| 15 | Lucas Bender        | H-Karate Quizzers              | Bismarck-ND       | 220   | 31.43  | 1  |
+| 16 | Kaleb Smith         | E-Blazing Swords               | Chesterfield-MO   | 210   | 30.00  | 2  |
+| 17 | Lydia Kidroske      | D-Bible Treasure Seekers       | Greensboro-NC     | 210   | 30.00  | 1  |
+| 18 | Andrew Davenport    | C-Brightmoor                   | Novi-MI           | 185   | 26.43  | 1  |
+| 19 | Maddie Hawkes       | J-Family Life Christian Center | Federal Way-WA    | 185   | 26.43  |    |
+| 19 | Stanley Thomas      | B-Quiz Kidz                    | Scotch Plains-NJ  | 185   | 26.43  |    |
+| 20 | Joe Cheeli          | B-Quiz Kidz                    | Scotch Plains-NJ  | 170   | 24.29  | 1  |
+| 21 | Lauren Grisham      | G-CIA                          | Mustang-OK        | 165   | 23.57  |    |
+| 22 | Josiah Baik         | B-Quiz Kidz                    | Scotch Plains-NJ  | 150   | 21.43  |    |
+| 23 | Seth Davis          | H-Karate Quizzers              | Bismarck-ND       | 115   | 16.43  |    |
+| 24 | Noah Harris         | F-The Four-ce Unleashed        | Universal City-TX | 105   | 15.00  | 1  |
+| 25 | Jonathan Dambacher  | J-Family Life Christian Center | Federal Way-WA    | 90    | 12.86  |    |
+| 26 | Michael Fletcher    | B-Quiz Kidz                    | Scotch Plains-NJ  | 85    | 12.14  |    |
+| 27 | Rudy Narvaez        | F-The Four-ce Unleashed        | Universal City-TX | 75    | 10.71  |    |
+| 28 | Kailan Weidner      | G-CIA                          | Mustang-OK        | 65    | 9.29   |    |
+| 29 | Megan Holleman      | C-Brightmoor                   | Novi-MI           | 20    | 2.86   |    |
+| 30 | Anna Schafhauser    | B-Quiz Kidz                    | Scotch Plains-NJ  | 10    | 1.43   |    |
+| 30 | Esther Faiella      | G-CIA                          | Mustang-OK        | 10    | 1.43   |    |
+| 31 | Grace Schafhauser   | B-Quiz Kidz                    | Scotch Plains-NJ  |       | .00    |    |
+| 31 | Madelyn Holleman    | C-Brightmoor                   | Novi-MI           |       | .00    |    |
+| 31 | Elisabeth Nelson    | C-Brightmoor                   | Novi-MI           |       | .00    |    |
+| 31 | Danelle Ragains     | H-Karate Quizzers              | Bismarck-ND       |       | .00    |    |
+| 31 | Lynnae Chapman      | C-Brightmoor                   | Novi-MI           |       | .00    |    |
+| 31 | Julia Martello      | D-Bible Treasure Seekers       | Greensboro-NC     |       | .00    |    |
+
+
+### Purple
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                        | Church                  | W/L | Total | Avg    |
+|--:|-----------------------------|-------------------------|-----|------:|-------:|
+| 1 | D-Grace Assembly of God     | New Whiteland-IN        | 5/2 | 1075  | 153.57 |
+| 2 | A-Tribulation Force         | Red Oak-TX              | 5/2 | 1285  | 183.57 |
+| 3 | D-Askewville                | Windsor (Askewville)-NC | 4/3 | 1035  | 147.86 |
+| 4 | B-Word of Life Lightbearers | Springfield-VA          | 4/3 | 955   | 136.43 |
+| 5 | G-Supernova                 | Springfield-MO          | 4/3 | 950   | 135.71 |
+| 6 | I-Transformed               | Huntington-WV           | 3/4 | 1015  | 145.00 |
+| 7 | H-FBI                       | Lakeville-MN            | 2/5 | 910   | 130.00 |
+| 8 | F-Mighty Disciples          | Santa Ana-CA            | 1/6 | 635   | 90.71  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                        | Church                  | Total | Avg   | QO |
+|---:|--------------------|-----------------------------|-------------------------|------:|------:|---:|
+| 1  | Cameron Berta      | A-Tribulation Force         | Red Oak-TX              | 630   | 90.00 | 2  |
+| 2  | Seth Hensley       | I-Transformed               | Huntington-WV           | 580   | 82.86 | 1  |
+| 3  | Hannah Quick       | G-Supernova                 | Springfield-MO          | 555   | 79.29 | 2  |
+| 4  | Kelsey Cruz        | F-Mighty Disciples          | Santa Ana-CA            | 500   | 71.43 | 1  |
+| 5  | Daniel Castello    | D-Askewville                | Windsor (Askewville)-NC | 500   | 71.43 |    |
+| 6  | Aidan Strain       | D-Grace Assembly of God     | New Whiteland-IN        | 385   | 55.00 | 1  |
+| 7  | Sharon Morara      | H-FBI                       | Lakeville-MN            | 385   | 55.00 |    |
+| 8  | Cayden Wiggington  | D-Grace Assembly of God     | New Whiteland-IN        | 380   | 54.29 |    |
+| 9  | Leah Thomas        | B-Word of Life Lightbearers | Springfield-VA          | 365   | 52.14 | 2  |
+| 10 | David Saunders     | A-Tribulation Force         | Red Oak-TX              | 330   | 47.14 |    |
+| 11 | Harrison Hoggard   | A-Tribulation Force         | Red Oak-TX              | 325   | 46.43 | 3  |
+| 12 | Will Bazemore      | D-Askewville                | Windsor (Askewville)-NC | 315   | 45.00 | 2  |
+| 13 | Nick Richardson    | D-Grace Assembly of God     | New Whiteland-IN        | 310   | 44.29 | 2  |
+| 14 | Noah Hensley       | I-Transformed               | Huntington-WV           | 310   | 44.29 | 1  |
+| 15 | Divya Mathews      | B-Word of Life Lightbearers | Springfield-VA          | 310   | 44.29 |    |
+| 16 | Zach Morara        | H-FBI                       | Lakeville-MN            | 295   | 42.14 | 3  |
+| 17 | Lucas Clark        | G-Supernova                 | Springfield-MO          | 225   | 32.14 | 2  |
+| 18 | Blessing Inyangson | B-Word of Life Lightbearers | Springfield-VA          | 195   | 27.86 |    |
+| 19 | Colton Hoggard     | D-Askewville                | Windsor (Askewville)-NC | 175   | 25.00 | 1  |
+| 20 | Natalie Slater     | G-Supernova                 | Springfield-MO          | 170   | 24.29 |    |
+| 21 | Andy Prazuch       | H-FBI                       | Lakeville-MN            | 110   | 15.71 |    |
+| 22 | Sydney Ames        | H-FBI                       | Lakeville-MN            | 90    | 12.86 |    |
+| 23 | Mark Ziegler       | I-Transformed               | Huntington-WV           | 85    | 12.14 |    |
+| 24 | Kimber Cruz        | F-Mighty Disciples          | Santa Ana-CA            | 80    | 11.43 |    |
+| 25 | Debi Tariku        | B-Word of Life Lightbearers | Springfield-VA          | 60    | 8.57  |    |
+| 26 | Bridgette Dupree   | F-Mighty Disciples          | Santa Ana-CA            | 55    | 7.86  |    |
+| 27 | Caitlin Leedy      | I-Transformed               | Huntington-WV           | 40    | 5.71  |    |
+| 28 | Bryce Lofton       | H-FBI                       | Lakeville-MN            | 30    | 4.29  |    |
+| 29 | Nneka Eleogu       | B-Word of Life Lightbearers | Springfield-VA          | 25    | 3.57  |    |
+| 29 | Cody Younger       | D-Askewville                | Windsor (Askewville)-NC | 25    | 3.57  |    |
+| 30 | Grace Todd         | D-Askewville                | Windsor (Askewville)-NC | 20    | 2.86  |    |
+| 31 | Teighlor Darnall   | D-Grace Assembly of God     | New Whiteland-IN        |       | .00   |    |
+| 31 | Alyssa Franklin    | D-Grace Assembly of God     | New Whiteland-IN        |       | .00   |    |
+| 31 | Lily Slater        | G-Supernova                 | Springfield-MO          |       | .00   |    |
+| 31 | Isabella Burt      | B-Word of Life Lightbearers | Springfield-VA          |       | .00   |    |
+| 31 | Landon Clark       | G-Supernova                 | Springfield-MO          |       | .00   |    |
+| 31 | David Solomon      | B-Word of Life Lightbearers | Springfield-VA          |       | .00   |    |
+| 31 | Annah Hensley      | I-Transformed               | Huntington-WV           |       | .00   |    |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                   | Church            | W/L | Total | Avg    |
+|--:|------------------------|-------------------|-----|------:|-------:|
+| 1 | A-Fire Starters        | Lawson-MO         | 6/1 | 1275  | 182.14 |
+| 2 | B-E=MC3                | Dallas-TX         | 4/3 | 1200  | 171.43 |
+| 3 | E-Bible Jammers        | Sanford-FL        | 4/3 | 1155  | 165.00 |
+| 4 | D-Called To Duty       | Omaha-NE          | 4/3 | 935   | 133.57 |
+| 5 | I-Bethel Bereans       | San Jose-CA       | 3/4 | 805   | 115.00 |
+| 6 | F-The Spirit\'s Swords | Ozark-MO          | 3/4 | 900   | 128.57 |
+| 7 | G-Spicy Chicken Wings  | Louisville-KY     | 2/5 | 750   | 107.14 |
+| 8 | H-Sonburst Omega       | Mechanicsville-VA | 2/5 | 765   | 109.29 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                   | Church            | Total | Avg   | QO |
+|---:|------------------------|------------------------|-------------------|------:|------:|---:|
+| 1  | Peyton Goss            | E-Bible Jammers        | Sanford-FL        | 555   | 79.29 | 2  |
+| 2  | Isaac Grey             | B-E=MC3                | Dallas-TX         | 545   | 77.86 | 3  |
+| 3  | Steven Torres          | B-E=MC3                | Dallas-TX         | 525   | 75.00 | 1  |
+| 4  | Brendan Ferguson       | A-Fire Starters        | Lawson-MO         | 505   | 72.14 | 1  |
+| 5  | Savannah Shannon       | F-The Spirit\'s Swords | Ozark-MO          | 495   | 70.71 | 3  |
+| 6  | Noah Barnes            | G-Spicy Chicken Wings  | Louisville-KY     | 455   | 65.00 | 2  |
+| 7  | Elizabeth Kaffenberger | D-Called To Duty       | Omaha-NE          | 425   | 60.71 | 1  |
+| 8  | Connor Ferguson        | A-Fire Starters        | Lawson-MO         | 400   | 57.14 | 1  |
+| 9  | Solomon Joseph         | I-Bethel Bereans       | San Jose-CA       | 345   | 49.29 |    |
+| 10 | Holly Bowen            | H-Sonburst Omega       | Mechanicsville-VA | 330   | 47.14 |    |
+| 11 | Cassidy Neal           | E-Bible Jammers        | Sanford-FL        | 325   | 46.43 |    |
+| 12 | Jonathan Archer        | A-Fire Starters        | Lawson-MO         | 305   | 43.57 | 2  |
+| 13 | Aubrey Goss            | E-Bible Jammers        | Sanford-FL        | 275   | 39.29 | 2  |
+| 14 | Kelise Braithwaite     | F-The Spirit\'s Swords | Ozark-MO          | 215   | 30.71 |    |
+| 15 | Jackson Atwell         | D-Called To Duty       | Omaha-NE          | 205   | 29.29 | 1  |
+| 16 | Nathan Isner           | H-Sonburst Omega       | Mechanicsville-VA | 190   | 27.14 | 1  |
+| 17 | Travis Griessel        | F-The Spirit\'s Swords | Ozark-MO          | 175   | 25.00 | 2  |
+| 18 | Isabel Gonzalez        | G-Spicy Chicken Wings  | Louisville-KY     | 165   | 23.57 |    |
+| 19 | David Daniel           | I-Bethel Bereans       | San Jose-CA       | 160   | 22.86 | 1  |
+| 20 | Madison Doise          | H-Sonburst Omega       | Mechanicsville-VA | 160   | 22.86 |    |
+| 21 | Aaron Palensky         | D-Called To Duty       | Omaha-NE          | 135   | 19.29 |    |
+| 21 | Jabez Williams         | I-Bethel Bereans       | San Jose-CA       | 135   | 19.29 |    |
+| 22 | Leah Palensky          | D-Called To Duty       | Omaha-NE          | 100   | 14.29 |    |
+| 23 | Andrew Cox             | G-Spicy Chicken Wings  | Louisville-KY     | 95    | 13.57 |    |
+| 24 | Hannah Stumper         | B-E=MC3                | Dallas-TX         | 90    | 12.86 |    |
+| 25 | Nikki Rittenhouse      | H-Sonburst Omega       | Mechanicsville-VA | 85    | 12.14 |    |
+| 26 | Timothy Nirmal         | I-Bethel Bereans       | San Jose-CA       | 80    | 11.43 |    |
+| 27 | Dillon Shores          | D-Called To Duty       | Omaha-NE          | 70    | 10.00 |    |
+| 28 | Zachary Ferguson       | A-Fire Starters        | Lawson-MO         | 65    | 9.29  |    |
+| 29 | Paul Daniel            | I-Bethel Bereans       | San Jose-CA       | 45    | 6.43  |    |
+| 30 | Tabitha Nirmal         | I-Bethel Bereans       | San Jose-CA       | 40    | 5.71  |    |
+| 30 | Abby Bennett           | B-E=MC3                | Dallas-TX         | 40    | 5.71  |    |
+| 31 | Trevor Webb            | G-Spicy Chicken Wings  | Louisville-KY     | 35    | 5.00  |    |
+| 32 | Reagan Griessel        | F-The Spirit\'s Swords | Ozark-MO          | 15    | 2.14  |    |
+| 33 | Gabriel Roberts        | I-Bethel Bereans       | San Jose-CA       |       | .00   |    |
+
+
+### White
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                    | Church        | W/L | Total | Avg    |
+|--:|-------------------------|---------------|-----|------:|-------:|
+| 1 | B-Men of Faith          | Sanford-FL    | 6/1 | 1300  | 185.71 |
+| 2 | C-International #1      | Warren-MI     | 5/2 | 1205  | 172.14 |
+| 3 | D-SPY Warriors          | Kent-WA       | 4/3 | 1210  | 172.86 |
+| 4 | A-TLC Thunder & co.     | Elk River-MN  | 3/4 | 1025  | 146.43 |
+| 5 | I-Lightening McQuizzers | Dumas-TX      | 3/4 | 915   | 130.71 |
+| 6 | J-Pillars of Fire       | Marlboro-NJ   | 3/4 | 730   | 104.29 |
+| 7 | H-Buzz Hogs             | Mabelvale-AR  | 2/5 | 680   | 97.14  |
+| 8 | I-Fantastic Five        | Des Moines-IA | 2/5 | 700   | 100.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                    | Church        | Total | Avg    | QO |
+|---:|---------------------|-------------------------|---------------|------:|-------:|---:|
+| 1  | Toby Robinson       | B-Men of Faith          | Sanford-FL    | 765   | 109.29 | 3  |
+| 2  | Thomas Stewart      | A-TLC Thunder & co.     | Elk River-MN  | 680   | 97.14  | 4  |
+| 3  | Jerrin George       | C-International #1      | Warren-MI     | 525   | 75.00  | 2  |
+| 4  | Gabrielle Davy      | D-SPY Warriors          | Kent-WA       | 425   | 60.71  | 1  |
+| 5  | Jonathan Huber      | B-Men of Faith          | Sanford-FL    | 405   | 57.86  | 5  |
+| 6  | Sarah Jacob         | C-International #1      | Warren-MI     | 385   | 55.00  |    |
+| 7  | Jared Minick        | H-Buzz Hogs             | Mabelvale-AR  | 335   | 47.86  | 2  |
+| 8  | Dylan Marmion       | J-Pillars of Fire       | Marlboro-NJ   | 330   | 47.14  | 1  |
+| 9  | Matthew Braham      | D-SPY Warriors          | Kent-WA       | 310   | 44.29  | 4  |
+| 10 | Nicholas Clemens    | I-Lightening McQuizzers | Dumas-TX      | 305   | 43.57  | 3  |
+| 11 | Bridge Biniakewitz  | H-Buzz Hogs             | Mabelvale-AR  | 295   | 42.14  | 2  |
+| 12 | Stephen Cowan       | I-Fantastic Five        | Des Moines-IA | 285   | 40.71  | 1  |
+| 13 | Maggie Akins        | I-Lightening McQuizzers | Dumas-TX      | 265   | 37.86  |    |
+| 14 | Austin Shepherd     | D-SPY Warriors          | Kent-WA       | 250   | 35.71  | 1  |
+| 15 | Dugan Akins         | I-Lightening McQuizzers | Dumas-TX      | 210   | 30.00  |    |
+| 16 | Joshua Sam          | C-International #1      | Warren-MI     | 190   | 27.14  | 1  |
+| 17 | Josiah Stewart      | A-TLC Thunder & co.     | Elk River-MN  | 175   | 25.00  |    |
+| 18 | David Swanson       | A-TLC Thunder & co.     | Elk River-MN  | 170   | 24.29  |    |
+| 19 | Teddy Gutterud      | D-SPY Warriors          | Kent-WA       | 165   | 23.57  |    |
+| 20 | Kaitlyn Clarkson    | I-Fantastic Five        | Des Moines-IA | 155   | 22.14  |    |
+| 21 | Andrew Mascillaro   | J-Pillars of Fire       | Marlboro-NJ   | 145   | 20.71  |    |
+| 22 | Jonathan Robinson   | B-Men of Faith          | Sanford-FL    | 130   | 18.57  |    |
+| 23 | Dylan Clarkson      | I-Fantastic Five        | Des Moines-IA | 125   | 17.86  | 2  |
+| 24 | Zachary John        | C-International #1      | Warren-MI     | 105   | 15.00  |    |
+| 25 | Joel Valliath       | J-Pillars of Fire       | Marlboro-NJ   | 100   | 14.29  |    |
+| 26 | Olivia May          | J-Pillars of Fire       | Marlboro-NJ   | 95    | 13.57  |    |
+| 27 | Bella Wilkins       | I-Lightening McQuizzers | Dumas-TX      | 90    | 12.86  |    |
+| 28 | Aaron Bopp          | I-Fantastic Five        | Des Moines-IA | 75    | 10.71  |    |
+| 29 | Sarah Abel          | J-Pillars of Fire       | Marlboro-NJ   | 60    | 8.57   |    |
+| 29 | Libby Lorts         | I-Fantastic Five        | Des Moines-IA | 60    | 8.57   |    |
+| 29 | Michaela Toole      | D-SPY Warriors          | Kent-WA       | 60    | 8.57   |    |
+| 30 | Ashli Sauer         | I-Lightening McQuizzers | Dumas-TX      | 45    | 6.43   |    |
+| 31 | Levi Biniakewitz    | H-Buzz Hogs             | Mabelvale-AR  | 30    | 4.29   |    |
+| 32 | Savanah Biniakewitz | H-Buzz Hogs             | Mabelvale-AR  | 20    | 2.86   |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                       | Church            | W/L | Total | Avg    |
+|--:|----------------------------|-------------------|-----|------:|-------:|
+| 1 | D-Quadruple Threat         | Cedar Hill-TX     | 7/0 | 1615  | 230.71 |
+| 2 | E-Guardians of God\'s Word | Cincinnati-OH     | 5/2 | 1190  | 170.00 |
+| 3 | A-The Nerds                | Bismarck-ND       | 5/2 | 1180  | 168.57 |
+| 4 | C-Sonburst Alpha           | Mechanicsville-VA | 3/4 | 1015  | 145.00 |
+| 5 | H-Calvary Champions        | Chattanooga-TN    | 3/4 | 1005  | 143.57 |
+| 6 | G-Ashland, Al              | Ashland-AL        | 3/4 | 905   | 129.29 |
+| 7 | F-Lightning                | Bonifay-FL        | 2/5 | 910   | 130.00 |
+| 8 | J-God\'s Girlz             | Surprise-AZ       | 0/7 | 580   | 82.86  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer          | Team                       | Church            | Total | Avg    | QO |
+|---:|------------------|----------------------------|-------------------|------:|-------:|---:|
+| 1  | Joshua Sipes     | A-The Nerds                | Bismarck-ND       | 700   | 100.00 | 2  |
+| 2  | Lau McGill       | D-Quadruple Threat         | Cedar Hill-TX     | 670   | 95.71  | 5  |
+| 3  | Elijah Garmany   | H-Calvary Champions        | Chattanooga-TN    | 625   | 89.29  | 3  |
+| 4  | Parker Lubbe     | D-Quadruple Threat         | Cedar Hill-TX     | 620   | 88.57  | 3  |
+| 5  | Paul Willis      | G-Ashland, Al              | Ashland-AL        | 585   | 83.57  | 1  |
+| 6  | Noah Zook        | C-Sonburst Alpha           | Mechanicsville-VA | 540   | 77.14  | 2  |
+| 7  | Brennan Dodds    | E-Guardians of God\'s Word | Cincinnati-OH     | 510   | 72.86  | 3  |
+| 8  | Ethan Smith      | E-Guardians of God\'s Word | Cincinnati-OH     | 475   | 67.86  | 1  |
+| 9  | Andrew Warren    | F-Lightning                | Bonifay-FL        | 460   | 65.71  | 1  |
+| 10 | Samuel Garmany   | H-Calvary Champions        | Chattanooga-TN    | 385   | 55.00  | 3  |
+| 11 | Coby Calvery     | D-Quadruple Threat         | Cedar Hill-TX     | 330   | 47.14  | 1  |
+| 12 | Teddy Willis     | G-Ashland, Al              | Ashland-AL        | 305   | 43.57  | 3  |
+| 13 | Will Zepp        | F-Lightning                | Bonifay-FL        | 225   | 32.14  |    |
+| 14 | Nathaniel Walker | C-Sonburst Alpha           | Mechanicsville-VA | 220   | 31.43  |    |
+| 15 | Jayden Freyer    | A-The Nerds                | Bismarck-ND       | 215   | 30.71  |    |
+| 16 | Faith Brown      | J-God\'s Girlz             | Surprise-AZ       | 210   | 30.00  |    |
+| 17 | Kenzie Brown     | J-God\'s Girlz             | Surprise-AZ       | 200   | 28.57  | 1  |
+| 18 | Griffin Simpson  | C-Sonburst Alpha           | Mechanicsville-VA | 190   | 27.14  | 1  |
+| 19 | McKenna Kollman  | J-God\'s Girlz             | Surprise-AZ       | 170   | 24.29  |    |
+| 20 | Elijah Sauer     | A-The Nerds                | Bismarck-ND       | 165   | 23.57  |    |
+| 21 | Nick Stewart     | F-Lightning                | Bonifay-FL        | 125   | 17.86  |    |
+| 22 | Jack Titkemeyer  | E-Guardians of God\'s Word | Cincinnati-OH     | 115   | 16.43  |    |
+| 23 | Brianna Sipes    | A-The Nerds                | Bismarck-ND       | 100   | 14.29  |    |
+| 24 | JJ Paul          | F-Lightning                | Bonifay-FL        | 80    | 11.43  |    |
+| 25 | Anthony Webster  | C-Sonburst Alpha           | Mechanicsville-VA | 65    | 9.29   |    |
+| 26 | Gunnar Smart     | E-Guardians of God\'s Word | Cincinnati-OH     | 50    | 7.14   |    |
+| 27 | Henry Diller     | E-Guardians of God\'s Word | Cincinnati-OH     | 20    | 2.86   |    |
+| 27 | Cameron Moore    | F-Lightning                | Bonifay-FL        | 20    | 2.86   |    |
+| 27 | David Haynes     | E-Guardians of God\'s Word | Cincinnati-OH     | 20    | 2.86   |    |
+| 28 | Grace Catchings  | G-Ashland, Al              | Ashland-AL        | 15    | 2.14   |    |
+| 29 | Ben Manoli       | D-Quadruple Threat         | Cedar Hill-TX     |       | .00    |    |
+| 29 | Kendal Calvery   | D-Quadruple Threat         | Cedar Hill-TX     |       | .00    |    |
+
+
+## Friday (PM)
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                        | Church           | W/L | Total | Avg    |
+|--:|-----------------------------|------------------|-----|------:|-------:|
+| 1 | B-Faithful Falcons          | Austin-TX        | 5/2 | 1290  | 184.29 |
+| 2 | B-E=MC3                     | Dallas-TX        | 5/2 | 1195  | 170.71 |
+| 3 | B-Sabia                     | Roswell-GA       | 4/3 | 1050  | 150.00 |
+| 4 | B-Men of Faith              | Sanford-FL       | 4/3 | 1005  | 143.57 |
+| 5 | B-S.P.Y. Kids 007           | Leesburg-VA      | 4/3 | 885   | 126.43 |
+| 6 | B-Purple                    | Ozark-MO         | 3/4 | 885   | 126.43 |
+| 7 | B-Word of Life Lightbearers | Springfield-VA   | 3/4 | 1005  | 143.57 |
+| 8 | B-Quiz Kidz                 | Scotch Plains-NJ | 0/7 | 460   | 65.71  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                        | Church           | Total | Avg    | QO |
+|---:|---------------------|-----------------------------|------------------|------:|-------:|---:|
+| 1  | Joel James          | B-Faithful Falcons          | Austin-TX        | 765   | 109.29 | 5  |
+| 2  | Toby Robinson       | B-Men of Faith              | Sanford-FL       | 635   | 90.71  | 1  |
+| 3  | Isaac Grey          | B-E=MC3                     | Dallas-TX        | 595   | 85.00  | 2  |
+| 4  | Daniel Ferreira     | B-Sabia                     | Roswell-GA       | 575   | 82.14  | 2  |
+| 5  | Steven Torres       | B-E=MC3                     | Dallas-TX        | 500   | 71.43  |    |
+| 6  | Divya Mathews       | B-Word of Life Lightbearers | Springfield-VA   | 450   | 64.29  | 1  |
+| 7  | Josh Rozelle        | B-S.P.Y. Kids 007           | Leesburg-VA      | 355   | 50.71  |    |
+| 8  | Grace Artis         | B-Sabia                     | Roswell-GA       | 335   | 47.86  |    |
+| 9  | Linsey Garrison     | B-Purple                    | Ozark-MO         | 330   | 47.14  | 1  |
+| 10 | Jonathan Huber      | B-Men of Faith              | Sanford-FL       | 270   | 38.57  | 1  |
+| 11 | Matthew Bozzay      | B-S.P.Y. Kids 007           | Leesburg-VA      | 270   | 38.57  |    |
+| 12 | Leah Thomas         | B-Word of Life Lightbearers | Springfield-VA   | 260   | 37.14  | 2  |
+| 13 | Hayden Ballard      | B-Purple                    | Ozark-MO         | 230   | 32.86  |    |
+| 14 | Victoriah Shook     | B-Purple                    | Ozark-MO         | 210   | 30.00  |    |
+| 15 | Josh James          | B-Faithful Falcons          | Austin-TX        | 190   | 27.14  |    |
+| 16 | Luke Yoder          | B-S.P.Y. Kids 007           | Leesburg-VA      | 170   | 24.29  | 1  |
+| 17 | Josiah Baik         | B-Quiz Kidz                 | Scotch Plains-NJ | 165   | 23.57  | 1  |
+| 18 | Jessica Emeodi      | B-Faithful Falcons          | Austin-TX        | 165   | 23.57  |    |
+| 19 | Benshel Bright      | B-Quiz Kidz                 | Scotch Plains-NJ | 145   | 20.71  |    |
+| 19 | Nneka Eleogu        | B-Word of Life Lightbearers | Springfield-VA   | 145   | 20.71  |    |
+| 20 | Cristian Huix       | B-Sabia                     | Roswell-GA       | 140   | 20.00  |    |
+| 21 | Blessing Inyangson  | B-Word of Life Lightbearers | Springfield-VA   | 135   | 19.29  |    |
+| 22 | Samuel Birrell      | B-Faithful Falcons          | Austin-TX        | 130   | 18.57  | 1  |
+| 23 | Jonathan Robinson   | B-Men of Faith              | Sanford-FL       | 100   | 14.29  |    |
+| 24 | Zara Rethman        | B-Purple                    | Ozark-MO         | 80    | 11.43  |    |
+| 25 | Ben Rozelle         | B-S.P.Y. Kids 007           | Leesburg-VA      | 70    | 10.00  |    |
+| 26 | Michael Fletcher    | B-Quiz Kidz                 | Scotch Plains-NJ | 65    | 9.29   |    |
+| 27 | Hannah Stumper      | B-E=MC3                     | Dallas-TX        | 60    | 8.57   |    |
+| 28 | Stanley Thomas      | B-Quiz Kidz                 | Scotch Plains-NJ | 55    | 7.86   |    |
+| 29 | Abby Bennett        | B-E=MC3                     | Dallas-TX        | 40    | 5.71   |    |
+| 29 | Samuel Sundararaman | B-Faithful Falcons          | Austin-TX        | 40    | 5.71   |    |
+| 30 | Brenden Reeves      | B-Purple                    | Ozark-MO         | 35    | 5.00   |    |
+| 31 | Joe Cheeli          | B-Quiz Kidz                 | Scotch Plains-NJ | 30    | 4.29   |    |
+| 32 | Andrew Otchere      | B-S.P.Y. Kids 007           | Leesburg-VA      | 20    | 2.86   |    |
+| 33 | Debi Tariku         | B-Word of Life Lightbearers | Springfield-VA   | 15    | 2.14   |    |
+| 34 | Anna Schafhauser    | B-Quiz Kidz                 | Scotch Plains-NJ | 5     | .71    |    |
+| 35 | Rebekah Birrell     | B-Faithful Falcons          | Austin-TX        |       | .00    |    |
+| 35 | David Solomon       | B-Word of Life Lightbearers | Springfield-VA   |       | .00    |    |
+| 35 | Isabella Burt       | B-Word of Life Lightbearers | Springfield-VA   |       | .00    |    |
+| 35 | Grace Schafhauser   | B-Quiz Kidz                 | Scotch Plains-NJ |       | .00    |    |
+| 35 | Katherine Bozzay    | B-S.P.Y. Kids 007           | Leesburg-VA      |       | .00    |    |
+| 35 | Sarah Judd          | B-S.P.Y. Kids 007           | Leesburg-VA      |       | .00    |    |
+
+
+### Cream
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team               | Church            | W/L | Total | Avg    |
+|--:|--------------------|-------------------|-----|------:|-------:|
+| 1 | C-International #1 | Warren-MI         | 7/0 | 1330  | 190.00 |
+| 2 | C-Tongues of Fire  | Louisville-KY     | 5/2 | 1245  | 177.86 |
+| 3 | C-Naperville\'     | Naperville-IL     | 5/2 | 1530  | 218.57 |
+| 4 | C-Brightmoor       | Novi-MI           | 4/3 | 1145  | 163.57 |
+| 5 | C-Sonburst Alpha   | Mechanicsville-VA | 3/4 | 1150  | 164.29 |
+| 6 | C-Cedar Park       | Bothell-WA        | 2/5 | 780   | 111.43 |
+| 7 | C-Memphis Advanced | Cordova-TN        | 1/6 | 500   | 71.43  |
+| 8 | C-MARS             | Baxter-MN         | 1/6 | 660   | 94.29  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team               | Church            | Total | Avg    | QO |
+|---:|-------------------|--------------------|-------------------|------:|-------:|---:|
+| 1  | Shreanna Powell   | C-Naperville\'     | Naperville-IL     | 775   | 110.71 | 4  |
+| 2  | Jerrin George     | C-International #1 | Warren-MI         | 655   | 93.57  | 1  |
+| 3  | Noah Zook         | C-Sonburst Alpha   | Mechanicsville-VA | 570   | 81.43  | 2  |
+| 4  | Lauren Chapman    | C-Brightmoor       | Novi-MI           | 520   | 74.29  | 2  |
+| 5  | Luke Yantz        | C-Tongues of Fire  | Louisville-KY     | 500   | 71.43  | 2  |
+| 6  | Maxwell Holleman  | C-Brightmoor       | Novi-MI           | 485   | 69.29  | 4  |
+| 7  | Robert Laboy      | C-Naperville\'     | Naperville-IL     | 475   | 67.86  | 4  |
+| 8  | Nathaniel Walker  | C-Sonburst Alpha   | Mechanicsville-VA | 400   | 57.14  | 2  |
+| 9  | Sarah Jacob       | C-International #1 | Warren-MI         | 370   | 52.86  | 1  |
+| 10 | Lucie Price       | C-Tongues of Fire  | Louisville-KY     | 370   | 52.86  |    |
+| 11 | Jared Deppe       | C-Memphis Advanced | Cordova-TN        | 330   | 47.14  | 1  |
+| 12 | Sierra Smith      | C-Cedar Park       | Bothell-WA        | 285   | 40.71  | 1  |
+| 13 | Trea Webb         | C-Tongues of Fire  | Louisville-KY     | 275   | 39.29  | 2  |
+| 14 | Brant Dabill      | C-MARS             | Baxter-MN         | 245   | 35.00  | 1  |
+| 15 | Andreya Snyder    | C-Cedar Park       | Bothell-WA        | 230   | 32.86  | 1  |
+| 16 | Eric Loschko      | C-MARS             | Baxter-MN         | 220   | 31.43  | 1  |
+| 17 | Jake Wolfe        | C-Naperville\'     | Naperville-IL     | 210   | 30.00  |    |
+| 18 | Zachary John      | C-International #1 | Warren-MI         | 190   | 27.14  | 1  |
+| 19 | Lynne Borowicz    | C-MARS             | Baxter-MN         | 190   | 27.14  |    |
+| 20 | Anthony Webster   | C-Sonburst Alpha   | Mechanicsville-VA | 120   | 17.14  |    |
+| 21 | Jackson Houser    | C-Cedar Park       | Bothell-WA        | 115   | 16.43  | 1  |
+| 22 | Joshua Sam        | C-International #1 | Warren-MI         | 115   | 16.43  |    |
+| 23 | Jonathan Green    | C-Tongues of Fire  | Louisville-KY     | 100   | 14.29  |    |
+| 24 | Joshua Roberts    | C-Cedar Park       | Bothell-WA        | 95    | 13.57  |    |
+| 25 | Andrew Davenport  | C-Brightmoor       | Novi-MI           | 85    | 12.14  |    |
+| 26 | Erin Laboy        | C-Naperville\'     | Naperville-IL     | 70    | 10.00  |    |
+| 27 | Griffin Simpson   | C-Sonburst Alpha   | Mechanicsville-VA | 65    | 9.29   |    |
+| 28 | Nema Sarwar       | C-Memphis Advanced | Cordova-TN        | 60    | 8.57   |    |
+| 28 | Abbigail Vaughan  | C-Memphis Advanced | Cordova-TN        | 60    | 8.57   |    |
+| 29 | Johan West        | C-Cedar Park       | Bothell-WA        | 55    | 7.86   |    |
+| 30 | Madelyn Holleman  | C-Brightmoor       | Novi-MI           | 50    | 7.14   |    |
+| 30 | Julia Browning    | C-Memphis Advanced | Cordova-TN        | 50    | 7.14   |    |
+| 31 | Grace Riedel      | C-MARS             | Baxter-MN         | 10    | 1.43   |    |
+| 32 | Megan Holleman    | C-Brightmoor       | Novi-MI           | 5     | .71    |    |
+| 33 | Taylor Borowicz   | C-MARS             | Baxter-MN         |       | .00    |    |
+| 33 | Lynnae Chapman    | C-Brightmoor       | Novi-MI           |       | .00    |    |
+| 33 | Eva Dabill        | C-MARS             | Baxter-MN         |       | .00    |    |
+| 33 | Elisabeth Nelson  | C-Brightmoor       | Novi-MI           |       | .00    |    |
+| 33 | Emily Stevens     | C-MARS             | Baxter-MN         |       | .00    |    |
+| 33 | Landon Lundeby    | C-MARS             | Baxter-MN         |       | .00    |    |
+| 33 | Miranda Eggleston | C-Tongues of Fire  | Louisville-KY     |       | .00    |    |
+
+
+### Gray
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                 | Church          | W/L | Total | Avg    |
+|--:|----------------------|-----------------|-----|------:|-------:|
+| 1 | A-The Nerds          | Bismarck-ND     | 6/1 | 1105  | 157.86 |
+| 2 | A-TLC Thunder & co.  | Elk River-MN    | 5/2 | 1210  | 172.86 |
+| 3 | A-Greater Lansing    | East Lansing-MI | 4/3 | 1065  | 152.14 |
+| 4 | A-Tribulation Force  | Red Oak-TX      | 4/3 | 1140  | 162.86 |
+| 5 | A-Harrison Thrashers | Harrison-AR     | 3/4 | 970   | 138.57 |
+| 6 | A-Fire Starters      | Lawson-MO       | 2/5 | 925   | 132.14 |
+| 7 | A-OCCEC              | Irvine-CA       | 2/5 | 865   | 123.57 |
+| 8 | A-JAG                | Meriden-KS      | 2/5 | 800   | 114.29 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                 | Church          | Total | Avg    | QO |
+|---:|-------------------|----------------------|-----------------|------:|-------:|---:|
+| 1  | Thomas Stewart    | A-TLC Thunder & co.  | Elk River-MN    | 800   | 114.29 | 4  |
+| 2  | Joshua Sipes      | A-The Nerds          | Bismarck-ND     | 650   | 92.86  | 1  |
+| 3  | Tyler McCartney   | A-Greater Lansing    | East Lansing-MI | 635   | 90.71  | 4  |
+| 4  | Cameron Berta     | A-Tribulation Force  | Red Oak-TX      | 515   | 73.57  | 1  |
+| 5  | Brendan Ferguson  | A-Fire Starters      | Lawson-MO       | 470   | 67.14  |    |
+| 6  | Harrison Ku       | A-OCCEC              | Irvine-CA       | 450   | 64.29  | 1  |
+| 7  | Makenzie Bradshaw | A-Harrison Thrashers | Harrison-AR     | 370   | 52.86  | 1  |
+| 8  | Julia Rivera      | A-JAG                | Meriden-KS      | 350   | 50.00  |    |
+| 9  | Kerigan Bradshaw  | A-Harrison Thrashers | Harrison-AR     | 335   | 47.86  |    |
+| 10 | Harrison Hoggard  | A-Tribulation Force  | Red Oak-TX      | 320   | 45.71  | 3  |
+| 11 | Jeremy Wu         | A-OCCEC              | Irvine-CA       | 305   | 43.57  | 2  |
+| 12 | David Saunders    | A-Tribulation Force  | Red Oak-TX      | 305   | 43.57  |    |
+| 13 | Josiah Stewart    | A-TLC Thunder & co.  | Elk River-MN    | 300   | 42.86  | 1  |
+| 14 | Kyle Reichart     | A-JAG                | Meriden-KS      | 290   | 41.43  | 3  |
+| 15 | Chase Buher       | A-Greater Lansing    | East Lansing-MI | 250   | 35.71  | 1  |
+| 16 | Jayden Freyer     | A-The Nerds          | Bismarck-ND     | 230   | 32.86  | 1  |
+| 17 | Abby Bailey       | A-Harrison Thrashers | Harrison-AR     | 200   | 28.57  | 1  |
+| 18 | Jonathan Archer   | A-Fire Starters      | Lawson-MO       | 180   | 25.71  |    |
+| 19 | Connor Ferguson   | A-Fire Starters      | Lawson-MO       | 175   | 25.00  |    |
+| 20 | Darcie Harr       | A-Greater Lansing    | East Lansing-MI | 140   | 20.00  |    |
+| 21 | Elijah Sauer      | A-The Nerds          | Bismarck-ND     | 135   | 19.29  |    |
+| 22 | Calvin Lee        | A-OCCEC              | Irvine-CA       | 110   | 15.71  |    |
+| 22 | Jonathan Moore    | A-JAG                | Meriden-KS      | 110   | 15.71  |    |
+| 22 | David Swanson     | A-TLC Thunder & co.  | Elk River-MN    | 110   | 15.71  |    |
+| 23 | Zachary Ferguson  | A-Fire Starters      | Lawson-MO       | 100   | 14.29  |    |
+| 24 | Brianna Sipes     | A-The Nerds          | Bismarck-ND     | 90    | 12.86  |    |
+| 25 | Laura Henderson   | A-Harrison Thrashers | Harrison-AR     | 70    | 10.00  |    |
+| 26 | Toluwa Davies     | A-Greater Lansing    | East Lansing-MI | 55    | 7.86   |    |
+| 27 | James Harris      | A-JAG                | Meriden-KS      | 45    | 6.43   |    |
+| 28 | Colton Huffman    | A-JAG                | Meriden-KS      | 5     | .71    |    |
+| 29 | Jack Convis       | A-Greater Lansing    | East Lansing-MI |       | .00    |    |
+| 29 | Austin McCartney  | A-Greater Lansing    | East Lansing-MI |       | .00    |    |
+| 29 | Celah Convis      | A-Greater Lansing    | East Lansing-MI |       | .00    |    |
+| 29 | Reagan Warren     | A-Harrison Thrashers | Harrison-AR     |       | .00    |    |
+| 29 | Bethany Warren    | A-Harrison Thrashers | Harrison-AR     |       | .00    |    |
+| 30 | Joshua Davies     | A-Greater Lansing    | East Lansing-MI | -15   | -2.14  |    |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                          | Church           | W/L | Total | Avg    |
+|--:|-------------------------------|------------------|-----|------:|-------:|
+| 1 | G-Supernova                   | Springfield-MO   | 5/2 | 1190  | 170.00 |
+| 2 | G-Spicy Chicken Wings         | Louisville-KY    | 4/3 | 1040  | 148.57 |
+| 3 | G-Ashland, Al                 | Ashland-AL       | 4/3 | 940   | 134.29 |
+| 4 | G-CIA                         | Mustang-OK       | 4/3 | 935   | 133.57 |
+| 4 | G-Warriors in Training        | Columbiaville-MI | 4/3 | 935   | 133.57 |
+| 5 | G-The Praying Amigos          | Brookfield-WI    | 3/4 | 805   | 115.00 |
+| 6 | G-The Crossing Place Quizzers | Franklin-LA      | 2/5 | 885   | 126.43 |
+| 7 | G-Word Nerds                  | Des Moines-IA    | 2/5 | 880   | 125.71 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                          | Church           | Total | Avg   | QO |
+|---:|----------------------|-------------------------------|------------------|------:|------:|---:|
+| 1  | Jordan Landry        | G-The Crossing Place Quizzers | Franklin-LA      | 665   | 95.00 | 2  |
+| 2  | Hannah Quick         | G-Supernova                   | Springfield-MO   | 610   | 87.14 | 2  |
+| 3  | Paul Willis          | G-Ashland, Al                 | Ashland-AL       | 605   | 86.43 | 2  |
+| 4  | Alex Shell           | G-CIA                         | Mustang-OK       | 460   | 65.71 |    |
+| 5  | Noah Barnes          | G-Spicy Chicken Wings         | Louisville-KY    | 445   | 63.57 |    |
+| 6  | Hudson Hollin        | G-Warriors in Training        | Columbiaville-MI | 400   | 57.14 |    |
+| 7  | Elijah O\'Brien      | G-The Praying Amigos          | Brookfield-WI    | 395   | 56.43 |    |
+| 8  | Natalie Slater       | G-Supernova                   | Springfield-MO   | 365   | 52.14 | 1  |
+| 9  | Jacob Brechtel       | G-Word Nerds                  | Des Moines-IA    | 340   | 48.57 |    |
+| 10 | Warner Pool          | G-Word Nerds                  | Des Moines-IA    | 335   | 47.86 | 3  |
+| 11 | Isabel Gonzalez      | G-Spicy Chicken Wings         | Louisville-KY    | 315   | 45.00 |    |
+| 12 | Joey Huntley         | G-Warriors in Training        | Columbiaville-MI | 240   | 34.29 |    |
+| 13 | Brendon Sturgeon     | G-The Crossing Place Quizzers | Franklin-LA      | 220   | 31.43 | 2  |
+| 14 | Lucas Clark          | G-Supernova                   | Springfield-MO   | 220   | 31.43 | 1  |
+| 15 | Hunter Hollin        | G-Warriors in Training        | Columbiaville-MI | 215   | 30.71 | 1  |
+| 16 | Andrew Cox           | G-Spicy Chicken Wings         | Louisville-KY    | 205   | 29.29 | 1  |
+| 17 | Claire Roe           | G-Word Nerds                  | Des Moines-IA    | 195   | 27.86 |    |
+| 18 | Teddy Willis         | G-Ashland, Al                 | Ashland-AL       | 190   | 27.14 | 1  |
+| 19 | Esji Johnson         | G-The Praying Amigos          | Brookfield-WI    | 185   | 26.43 |    |
+| 20 | Landon Grisham       | G-CIA                         | Mustang-OK       | 180   | 25.71 | 1  |
+| 21 | Esther O\'Brien      | G-The Praying Amigos          | Brookfield-WI    | 170   | 24.29 |    |
+| 22 | Grace Catchings      | G-Ashland, Al                 | Ashland-AL       | 150   | 21.43 |    |
+| 23 | Lauren Grisham       | G-CIA                         | Mustang-OK       | 145   | 20.71 |    |
+| 24 | Kailan Weidner       | G-CIA                         | Mustang-OK       | 90    | 12.86 |    |
+| 25 | Alex Peters          | G-Warriors in Training        | Columbiaville-MI | 85    | 12.14 |    |
+| 26 | Trevor Webb          | G-Spicy Chicken Wings         | Louisville-KY    | 80    | 11.43 |    |
+| 27 | Esther Faiella       | G-CIA                         | Mustang-OK       | 60    | 8.57  |    |
+| 28 | Anthony Mikolajewski | G-The Praying Amigos          | Brookfield-WI    | 55    | 7.86  |    |
+| 29 | Annie Pool           | G-Word Nerds                  | Des Moines-IA    | 10    | 1.43  |    |
+| 30 | Lily Slater          | G-Supernova                   | Springfield-MO   |       | .00   |    |
+| 30 | Brandon Byers        | G-Warriors in Training        | Columbiaville-MI |       | .00   |    |
+| 30 | Olivia Cypcar        | G-The Praying Amigos          | Brookfield-WI    |       | .00   |    |
+| 31 | Landon Clark         | G-Supernova                   | Springfield-MO   | -5    | -0.71 |    |
+| 31 | Hailie Huntley       | G-Warriors in Training        | Columbiaville-MI | -5    | -0.71 |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                       | Church             | W/L | Total | Avg    |
+|--:|----------------------------|--------------------|-----|------:|-------:|
+| 1 | F-God\'s C.R.E.W.          | Oklahoma City-OK   | 6/1 | 1250  | 178.57 |
+| 2 | F-The Spirit\'s Swords     | Ozark-MO           | 6/1 | 1355  | 193.57 |
+| 3 | F-The Four-ce Unleashed    | Universal City-TX  | 5/2 | 1215  | 173.57 |
+| 4 | I-Lightening McQuizzers    | Dumas-TX           | 4/3 | 1075  | 153.57 |
+| 5 | F-Gideon\'s Army           | Huber Heights-OH   | 4/3 | 1275  | 182.14 |
+| 6 | F-Q\'s                     | Lexington-TN       | 2/5 | 990   | 141.43 |
+| 7 | F-Desert Joy Bible Buzzers | Litchfield Park-AZ | 1/6 | 575   | 82.14  |
+| 8 | F-Mighty Disciples         | Santa Ana-CA       | 0/7 | 600   | 85.71  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                       | Church             | Total | Avg    | QO |
+|---:|---------------------|----------------------------|--------------------|------:|-------:|---:|
+| 1  | Christina Baxter    | F-God\'s C.R.E.W.          | Oklahoma City-OK   | 885   | 126.43 | 5  |
+| 2  | Sean Jones          | F-Gideon\'s Army           | Huber Heights-OH   | 665   | 95.00  | 4  |
+| 3  | Maggie Akins        | I-Lightening McQuizzers    | Dumas-TX           | 615   | 87.86  | 2  |
+| 4  | Savannah Shannon    | F-The Spirit\'s Swords     | Ozark-MO           | 570   | 81.43  | 3  |
+| 5  | Reuben Savage       | F-Q\'s                     | Lexington-TN       | 525   | 75.00  | 1  |
+| 6  | Mary Frances Harris | F-The Four-ce Unleashed    | Universal City-TX  | 520   | 74.29  | 1  |
+| 7  | Gabriel Ison        | F-Gideon\'s Army           | Huber Heights-OH   | 395   | 56.43  | 4  |
+| 8  | Zach Wylie          | F-The Four-ce Unleashed    | Universal City-TX  | 375   | 53.57  |    |
+| 9  | Kelise Braithwaite  | F-The Spirit\'s Swords     | Ozark-MO           | 325   | 46.43  | 1  |
+| 10 | Kimber Cruz         | F-Mighty Disciples         | Santa Ana-CA       | 310   | 44.29  | 2  |
+| 11 | Seth Savage         | F-Q\'s                     | Lexington-TN       | 285   | 40.71  | 2  |
+| 12 | Joshua Kilian       | F-Desert Joy Bible Buzzers | Litchfield Park-AZ | 270   | 38.57  | 2  |
+| 13 | Jacob Kilian        | F-Desert Joy Bible Buzzers | Litchfield Park-AZ | 270   | 38.57  |    |
+| 14 | Travis Griessel     | F-The Spirit\'s Swords     | Ozark-MO           | 255   | 36.43  | 1  |
+| 15 | Nicholas Clemens    | I-Lightening McQuizzers    | Dumas-TX           | 245   | 35.00  | 1  |
+| 16 | Kelsey Cruz         | F-Mighty Disciples         | Santa Ana-CA       | 225   | 32.14  |    |
+| 17 | Noah Harris         | F-The Four-ce Unleashed    | Universal City-TX  | 215   | 30.71  |    |
+| 18 | Reagan Griessel     | F-The Spirit\'s Swords     | Ozark-MO           | 205   | 29.29  |    |
+| 19 | Jeannah Jones       | F-Gideon\'s Army           | Huber Heights-OH   | 185   | 26.43  | 1  |
+| 20 | Miken Melvin        | F-God\'s C.R.E.W.          | Oklahoma City-OK   | 165   | 23.57  | 1  |
+| 21 | Catherine Baxter    | F-God\'s C.R.E.W.          | Oklahoma City-OK   | 150   | 21.43  |    |
+| 21 | Eli Price           | F-Q\'s                     | Lexington-TN       | 150   | 21.43  |    |
+| 22 | Rudy Narvaez        | F-The Four-ce Unleashed    | Universal City-TX  | 105   | 15.00  |    |
+| 23 | Bella Wilkins       | I-Lightening McQuizzers    | Dumas-TX           | 95    | 13.57  | 1  |
+| 24 | Dugan Akins         | I-Lightening McQuizzers    | Dumas-TX           | 90    | 12.86  |    |
+| 25 | Bridgette Dupree    | F-Mighty Disciples         | Santa Ana-CA       | 65    | 9.29   |    |
+| 26 | Jonathan Burke      | F-God\'s C.R.E.W.          | Oklahoma City-OK   | 50    | 7.14   |    |
+| 27 | Jonathan Morales    | F-Desert Joy Bible Buzzers | Litchfield Park-AZ | 35    | 5.00   |    |
+| 28 | Ryleigh Jones       | F-Gideon\'s Army           | Huber Heights-OH   | 30    | 4.29   |    |
+| 28 | Ashlynn Price       | F-Q\'s                     | Lexington-TN       | 30    | 4.29   |    |
+| 28 | Ashli Sauer         | I-Lightening McQuizzers    | Dumas-TX           | 30    | 4.29   |    |
+| 29 | Naomi Kilian        | F-Desert Joy Bible Buzzers | Litchfield Park-AZ |       | .00    |    |
+| 29 | Jeremy Morales      | F-Desert Joy Bible Buzzers | Litchfield Park-AZ |       | .00    |    |
+| 29 | Nathan Burke        | F-God\'s C.R.E.W.          | Oklahoma City-OK   |       | .00    |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                | Church            | W/L | Total | Avg    |
+|--:|---------------------|-------------------|-----|------:|-------:|
+| 1 | H-Bethlehem Church  | Richmond Hill-NY  | 6/1 | 1170  | 167.14 |
+| 2 | H-Sonburst Omega    | Mechanicsville-VA | 5/2 | 1115  | 159.29 |
+| 3 | H-Calvary Champions | Chattanooga-TN    | 5/2 | 1145  | 163.57 |
+| 4 | H-FBI               | Lakeville-MN      | 4/3 | 1090  | 155.71 |
+| 5 | H-Karate Quizzers   | Bismarck-ND       | 3/4 | 860   | 122.86 |
+| 6 | H-Buzz Hogs         | Mabelvale-AR      | 3/4 | 975   | 139.29 |
+| 7 | H-Temple - Clanton  | Clanton-AL        | 2/5 | 870   | 124.29 |
+| 8 | H-Gospel Gang       | Amarillo-TX       | 0/7 | 425   | 60.71  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                | Church            | Total | Avg    | QO |
+|---:|----------------------|---------------------|-------------------|------:|-------:|---:|
+| 1  | Elijah Garmany       | H-Calvary Champions | Chattanooga-TN    | 790   | 112.86 | 5  |
+| 2  | Jared Minick         | H-Buzz Hogs         | Mabelvale-AR      | 520   | 74.29  | 2  |
+| 3  | Madison Doise        | H-Sonburst Omega    | Mechanicsville-VA | 510   | 72.86  |    |
+| 4  | Brandon Watley       | H-Temple - Clanton  | Clanton-AL        | 400   | 57.14  | 5  |
+| 5  | Bridge Biniakewitz   | H-Buzz Hogs         | Mabelvale-AR      | 380   | 54.29  | 3  |
+| 6  | Bailey Watley        | H-Temple - Clanton  | Clanton-AL        | 370   | 52.86  | 1  |
+| 7  | Sydney Ames          | H-FBI               | Lakeville-MN      | 360   | 51.43  |    |
+| 8  | Samuel Garmany       | H-Calvary Champions | Chattanooga-TN    | 355   | 50.71  | 2  |
+| 9  | Nicole DeSilva       | H-Bethlehem Church  | Richmond Hill-NY  | 350   | 50.00  | 2  |
+| 10 | Sara Ann Haimchand   | H-Bethlehem Church  | Richmond Hill-NY  | 340   | 48.57  | 3  |
+| 11 | Holly Bowen          | H-Sonburst Omega    | Mechanicsville-VA | 290   | 41.43  |    |
+| 12 | Sharon Morara        | H-FBI               | Lakeville-MN      | 270   | 38.57  |    |
+| 13 | Ashlyn Sipes         | H-Karate Quizzers   | Bismarck-ND       | 245   | 35.00  |    |
+| 14 | Derek Leingang       | H-Karate Quizzers   | Bismarck-ND       | 240   | 34.29  | 1  |
+| 15 | Jaret Williams       | H-Bethlehem Church  | Richmond Hill-NY  | 235   | 33.57  | 1  |
+| 16 | Seth Davis           | H-Karate Quizzers   | Bismarck-ND       | 200   | 28.57  | 2  |
+| 17 | Joy Okafor           | H-Bethlehem Church  | Richmond Hill-NY  | 200   | 28.57  |    |
+| 18 | Zach Morara          | H-FBI               | Lakeville-MN      | 190   | 27.14  | 1  |
+| 19 | Nathan Isner         | H-Sonburst Omega    | Mechanicsville-VA | 185   | 26.43  | 1  |
+| 20 | Ryan Chunn           | H-Gospel Gang       | Amarillo-TX       | 185   | 26.43  |    |
+| 21 | Andy Prazuch         | H-FBI               | Lakeville-MN      | 180   | 25.71  |    |
+| 22 | Nikki Rittenhouse    | H-Sonburst Omega    | Mechanicsville-VA | 130   | 18.57  |    |
+| 23 | Lucas Bender         | H-Karate Quizzers   | Bismarck-ND       | 125   | 17.86  |    |
+| 24 | Abigail Chunn        | H-Gospel Gang       | Amarillo-TX       | 120   | 17.14  | 1  |
+| 25 | Emma Cleckler        | H-Temple - Clanton  | Clanton-AL        | 100   | 14.29  |    |
+| 26 | Bryce Lofton         | H-FBI               | Lakeville-MN      | 90    | 12.86  |    |
+| 27 | Zachary Westmoreland | H-Gospel Gang       | Amarillo-TX       | 80    | 11.43  |    |
+| 28 | Danelle Ragains      | H-Karate Quizzers   | Bismarck-ND       | 50    | 7.14   |    |
+| 28 | Rebecca Ramnauth     | H-Bethlehem Church  | Richmond Hill-NY  | 50    | 7.14   |    |
+| 29 | Savanah Biniakewitz  | H-Buzz Hogs         | Mabelvale-AR      | 40    | 5.71   |    |
+| 30 | Levi Biniakewitz     | H-Buzz Hogs         | Mabelvale-AR      | 35    | 5.00   |    |
+| 31 | Elizabeth Chunn      | H-Gospel Gang       | Amarillo-TX       | 30    | 4.29   |    |
+| 32 | Brendan Marrow       | H-Gospel Gang       | Amarillo-TX       | 10    | 1.43   |    |
+| 33 | Dwayne Bacchus       | H-Bethlehem Church  | Richmond Hill-NY  |       | .00    |    |
+| 33 | Emily Singh          | H-Bethlehem Church  | Richmond Hill-NY  |       | .00    |    |
+| 33 | Katelyn Johnson      | H-Temple - Clanton  | Clanton-AL        |       | .00    |    |
+| 33 | Mattie Cleckler      | H-Temple - Clanton  | Clanton-AL        |       | .00    |    |
+| 34 | Sean Lori Umali      | H-Bethlehem Church  | Richmond Hill-NY  | -5    | -0.71  |    |
+
+
+### Purple
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                       | Church           | W/L | Total | Avg    |
+|--:|----------------------------|------------------|-----|------:|-------:|
+| 1 | D-Grace Assembly of God    | New Whiteland-IN | 5/2 | 1200  | 171.43 |
+| 2 | E-Soaring Eagles           | Poland-OH        | 5/2 | 1090  | 155.71 |
+| 3 | E-Blazing Swords           | Chesterfield-MO  | 4/3 | 905   | 129.29 |
+| 4 | E-Guardians of God\'s Word | Cincinnati-OH    | 4/3 | 1150  | 164.29 |
+| 5 | E-Bible Jammers            | Sanford-FL       | 3/4 | 1115  | 159.29 |
+| 6 | E-The CIA                  | Mendon-MA        | 3/4 | 1065  | 152.14 |
+| 7 | E-Awesome Answerers        | Billings-MT      | 3/4 | 705   | 100.71 |
+| 8 | E-Westgate A1              | Edmonds-WA       | 1/6 | 870   | 124.29 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer               | Team                       | Church           | Total | Avg   | QO |
+|---:|-----------------------|----------------------------|------------------|------:|------:|---:|
+| 1  | Peyton Goss           | E-Bible Jammers            | Sanford-FL       | 665   | 95.00 | 2  |
+| 2  | Jolia Madigan         | E-Soaring Eagles           | Poland-OH        | 595   | 85.00 |    |
+| 3  | Aidan Strain          | D-Grace Assembly of God    | New Whiteland-IN | 540   | 77.14 | 2  |
+| 4  | Brennan Dodds         | E-Guardians of God\'s Word | Cincinnati-OH    | 515   | 73.57 | 3  |
+| 5  | John Fugere           | E-The CIA                  | Mendon-MA        | 500   | 71.43 | 1  |
+| 6  | Cayden Wiggington     | D-Grace Assembly of God    | New Whiteland-IN | 470   | 67.14 | 1  |
+| 7  | Daniel Kinger         | E-Blazing Swords           | Chesterfield-MO  | 460   | 65.71 | 2  |
+| 8  | Ethan Smith           | E-Guardians of God\'s Word | Cincinnati-OH    | 450   | 64.29 | 1  |
+| 9  | Nicholas Tveit        | E-Westgate A1              | Edmonds-WA       | 365   | 52.14 | 5  |
+| 10 | Garrett Miyaoka       | E-Westgate A1              | Edmonds-WA       | 365   | 52.14 | 1  |
+| 11 | Olivia Madigan        | E-Soaring Eagles           | Poland-OH        | 355   | 50.71 | 2  |
+| 12 | Eliott Gathman        | E-Blazing Swords           | Chesterfield-MO  | 280   | 40.00 | 1  |
+| 12 | Tessa Houde           | E-Awesome Answerers        | Billings-MT      | 280   | 40.00 | 1  |
+| 13 | Tayla Vannelli        | E-The CIA                  | Mendon-MA        | 275   | 39.29 |    |
+| 14 | Shannon Morrill       | E-The CIA                  | Mendon-MA        | 270   | 38.57 | 1  |
+| 15 | Matthew Frick         | E-Awesome Answerers        | Billings-MT      | 260   | 37.14 | 1  |
+| 16 | Aubrey Goss           | E-Bible Jammers            | Sanford-FL       | 230   | 32.86 | 2  |
+| 17 | Cassidy Neal          | E-Bible Jammers            | Sanford-FL       | 220   | 31.43 |    |
+| 18 | Nick Richardson       | D-Grace Assembly of God    | New Whiteland-IN | 190   | 27.14 |    |
+| 19 | Kaleb Smith           | E-Blazing Swords           | Chesterfield-MO  | 165   | 23.57 | 1  |
+| 20 | Jack Titkemeyer       | E-Guardians of God\'s Word | Cincinnati-OH    | 165   | 23.57 |    |
+| 21 | Ben Harsha            | E-Awesome Answerers        | Billings-MT      | 140   | 20.00 |    |
+| 22 | Noah Ku               | E-Westgate A1              | Edmonds-WA       | 120   | 17.14 |    |
+| 23 | Will Homrighausen     | E-Soaring Eagles           | Poland-OH        | 100   | 14.29 |    |
+| 24 | Ty Homrighausen       | E-Soaring Eagles           | Poland-OH        | 40    | 5.71  |    |
+| 25 | Robbie Hurt           | E-Awesome Answerers        | Billings-MT      | 25    | 3.57  |    |
+| 26 | Bethany Perry         | E-The CIA                  | Mendon-MA        | 20    | 2.86  |    |
+| 26 | Anastasia Yevtushenko | E-Westgate A1              | Edmonds-WA       | 20    | 2.86  |    |
+| 26 | Gunnar Smart          | E-Guardians of God\'s Word | Cincinnati-OH    | 20    | 2.86  |    |
+| 26 | Henry Diller          | E-Guardians of God\'s Word | Cincinnati-OH    | 20    | 2.86  |    |
+| 27 | Alyssa Franklin       | D-Grace Assembly of God    | New Whiteland-IN |       | .00   |    |
+| 27 | Teighlor Darnall      | D-Grace Assembly of God    | New Whiteland-IN |       | .00   |    |
+| 27 | Jayda Houde           | E-Awesome Answerers        | Billings-MT      |       | .00   |    |
+| 28 | David Haynes          | E-Guardians of God\'s Word | Cincinnati-OH    | -20   | -2.86 |    |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team             | Church             | W/L | Total | Avg    |
+|--:|------------------|--------------------|-----|------:|-------:|
+| 1 | I-CRK Almighty   | Gloucester City-NJ | 6/1 | 1095  | 156.43 |
+| 2 | I-CLC            | Fort Lauderdale-FL | 5/2 | 1200  | 171.43 |
+| 3 | I-N 2 God Again  | Concord-NC         | 4/3 | 1180  | 168.57 |
+| 4 | F-Lightning      | Bonifay-FL         | 4/3 | 1025  | 146.43 |
+| 5 | I-Bethel Bereans | San Jose-CA        | 4/3 | 975   | 139.29 |
+| 6 | I-Transformed    | Huntington-WV      | 3/4 | 950   | 135.71 |
+| 7 | I-Fantastic Five | Des Moines-IA      | 1/6 | 760   | 108.57 |
+| 8 | I-ACOG           | Lawrenceville-GA   | 1/6 | 755   | 107.86 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team             | Church             | Total | Avg    | QO |
+|---:|-------------------|------------------|--------------------|------:|-------:|---:|
+| 1  | Ope Morakinyo     | I-CLC            | Fort Lauderdale-FL | 785   | 112.14 | 2  |
+| 2  | Bennett Thomas    | I-ACOG           | Lawrenceville-GA   | 570   | 81.43  | 3  |
+| 3  | Seth Hensley      | I-Transformed    | Huntington-WV      | 555   | 79.29  | 2  |
+| 4  | Elijah Abad       | I-CRK Almighty   | Gloucester City-NJ | 495   | 70.71  | 2  |
+| 5  | Andrew Warren     | F-Lightning      | Bonifay-FL         | 440   | 62.86  |    |
+| 6  | Stephen Cowan     | I-Fantastic Five | Des Moines-IA      | 420   | 60.00  | 1  |
+| 7  | Ida Ekuban        | I-N 2 God Again  | Concord-NC         | 410   | 58.57  |    |
+| 8  | Erin Clay         | I-N 2 God Again  | Concord-NC         | 405   | 57.86  |    |
+| 9  | Solomon Joseph    | I-Bethel Bereans | San Jose-CA        | 390   | 55.71  |    |
+| 10 | Will Zepp         | F-Lightning      | Bonifay-FL         | 315   | 45.00  |    |
+| 11 | Noah Hensley      | I-Transformed    | Huntington-WV      | 305   | 43.57  | 1  |
+| 12 | Russel Flores     | I-CRK Almighty   | Gloucester City-NJ | 260   | 37.14  | 1  |
+| 13 | Michael Notman    | I-CLC            | Fort Lauderdale-FL | 240   | 34.29  | 1  |
+| 14 | Max Fowler        | I-N 2 God Again  | Concord-NC         | 215   | 30.71  | 3  |
+| 15 | Jabez Williams    | I-Bethel Bereans | San Jose-CA        | 195   | 27.86  | 1  |
+| 16 | Dylan Clarkson    | I-Fantastic Five | Des Moines-IA      | 170   | 24.29  | 2  |
+| 17 | Jacob Flores      | I-CRK Almighty   | Gloucester City-NJ | 165   | 23.57  | 1  |
+| 18 | Jonathan Irizarry | I-CLC            | Fort Lauderdale-FL | 160   | 22.86  |    |
+| 19 | Kaitlyn Clarkson  | I-Fantastic Five | Des Moines-IA      | 150   | 21.43  |    |
+| 19 | Victoria Dahlman  | I-N 2 God Again  | Concord-NC         | 150   | 21.43  |    |
+| 19 | JJ Paul           | F-Lightning      | Bonifay-FL         | 150   | 21.43  |    |
+| 20 | Timothy Nirmal    | I-Bethel Bereans | San Jose-CA        | 135   | 19.29  | 1  |
+| 21 | David Daniel      | I-Bethel Bereans | San Jose-CA        | 130   | 18.57  | 1  |
+| 22 | Melvin Mathew     | I-ACOG           | Lawrenceville-GA   | 130   | 18.57  |    |
+| 23 | Jillian Angeles   | I-CRK Almighty   | Gloucester City-NJ | 115   | 16.43  |    |
+| 24 | Nick Stewart      | F-Lightning      | Bonifay-FL         | 105   | 15.00  |    |
+| 25 | Paul Daniel       | I-Bethel Bereans | San Jose-CA        | 80    | 11.43  |    |
+| 26 | Junny Jayme       | I-CRK Almighty   | Gloucester City-NJ | 60    | 8.57   |    |
+| 26 | Mark Ziegler      | I-Transformed    | Huntington-WV      | 60    | 8.57   |    |
+| 27 | Brennann Thomas   | I-ACOG           | Lawrenceville-GA   | 55    | 7.86   |    |
+| 28 | Caitlin Leedy     | I-Transformed    | Huntington-WV      | 30    | 4.29   |    |
+| 29 | Tabitha Nirmal    | I-Bethel Bereans | San Jose-CA        | 25    | 3.57   |    |
+| 30 | Gabriel Roberts   | I-Bethel Bereans | San Jose-CA        | 20    | 2.86   |    |
+| 30 | Libby Lorts       | I-Fantastic Five | Des Moines-IA      | 20    | 2.86   |    |
+| 31 | Rebecca Rodrigues | I-CLC            | Fort Lauderdale-FL | 15    | 2.14   |    |
+| 31 | Cameron Moore     | F-Lightning      | Bonifay-FL         | 15    | 2.14   |    |
+| 32 | Aaron Bopp        | I-Fantastic Five | Des Moines-IA      |       | .00    |    |
+| 32 | Annah Hensley     | I-Transformed    | Huntington-WV      |       | .00    |    |
+
+
+### White
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                           | Church         | W/L | Total | Avg    |
+|--:|--------------------------------|----------------|-----|------:|-------:|
+| 1 | J-Christ Runners               | Fargo-ND       | 6/1 | 1210  | 172.86 |
+| 2 | J-Family Life Christian Center | Federal Way-WA | 5/2 | 1145  | 163.57 |
+| 3 | J-Pillars of Fire              | Marlboro-NJ    | 4/3 | 1075  | 153.57 |
+| 4 | J-Earth Shakers                | Chandler-AZ    | 4/3 | 1060  | 151.43 |
+| 5 | J-SWAT                         | Lakeville-MN   | 4/3 | 855   | 122.14 |
+| 6 | Flamin\' Hot Buzzers           | Albuquerque-NM | 3/4 | 1020  | 145.71 |
+| 7 | J-BC United                    | Wyckoff-NJ     | 1/6 | 865   | 123.57 |
+| 8 | J-God\'s Girlz                 | Surprise-AZ    | 1/6 | 705   | 100.71 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                           | Church         | Total | Avg    | QO |
+|---:|--------------------|--------------------------------|----------------|------:|-------:|---:|
+| 1  | Feba Cherian       | J-Earth Shakers                | Chandler-AZ    | 710   | 101.43 | 2  |
+| 2  | Nicolas Boyce      | J-Family Life Christian Center | Federal Way-WA | 695   | 99.29  | 3  |
+| 3  | Jazmynn Wilson     | Flamin\' Hot Buzzers           | Albuquerque-NM | 620   | 88.57  | 2  |
+| 4  | Carson Nix         | J-Christ Runners               | Fargo-ND       | 500   | 71.43  | 2  |
+| 5  | Dylan Marmion      | J-Pillars of Fire              | Marlboro-NJ    | 485   | 69.29  | 1  |
+| 6  | Micah Marchand     | J-Christ Runners               | Fargo-ND       | 475   | 67.86  | 1  |
+| 7  | Madison Heath      | J-SWAT                         | Lakeville-MN   | 380   | 54.29  |    |
+| 8  | Maddie Hawkes      | J-Family Life Christian Center | Federal Way-WA | 290   | 41.43  | 1  |
+| 9  | Kenzie Brown       | J-God\'s Girlz                 | Surprise-AZ    | 285   | 40.71  |    |
+| 10 | Joel Valliath      | J-Pillars of Fire              | Marlboro-NJ    | 280   | 40.00  | 3  |
+| 11 | Faith Brown        | J-God\'s Girlz                 | Surprise-AZ    | 270   | 38.57  | 1  |
+| 12 | Emma Moorman       | J-BC United                    | Wyckoff-NJ     | 265   | 37.86  | 2  |
+| 13 | Cayla Brodeur      | J-BC United                    | Wyckoff-NJ     | 255   | 36.43  |    |
+| 14 | Madyson Theesfeld  | J-Earth Shakers                | Chandler-AZ    | 245   | 35.00  | 2  |
+| 15 | Drew Wilson        | Flamin\' Hot Buzzers           | Albuquerque-NM | 240   | 34.29  | 2  |
+| 16 | Kyle Ringley       | J-SWAT                         | Lakeville-MN   | 210   | 30.00  |    |
+| 17 | Gabby Ringley      | J-SWAT                         | Lakeville-MN   | 190   | 27.14  |    |
+| 18 | Rachel Girimonte   | J-BC United                    | Wyckoff-NJ     | 165   | 23.57  |    |
+| 19 | Jonathan Dambacher | J-Family Life Christian Center | Federal Way-WA | 160   | 22.86  |    |
+| 20 | McKenna Kollman    | J-God\'s Girlz                 | Surprise-AZ    | 150   | 21.43  |    |
+| 20 | Olivia May         | J-Pillars of Fire              | Marlboro-NJ    | 150   | 21.43  |    |
+| 21 | Aaron Marchand     | J-Christ Runners               | Fargo-ND       | 120   | 17.14  |    |
+| 22 | Michaela McLeod    | J-BC United                    | Wyckoff-NJ     | 110   | 15.71  |    |
+| 23 | Sarah Abel         | J-Pillars of Fire              | Marlboro-NJ    | 100   | 14.29  |    |
+| 23 | Jordan Nix         | J-Christ Runners               | Fargo-ND       | 100   | 14.29  |    |
+| 24 | Mandy Rydeski      | Flamin\' Hot Buzzers           | Albuquerque-NM | 90    | 12.86  |    |
+| 25 | Crystal Thomas     | J-Earth Shakers                | Chandler-AZ    | 80    | 11.43  |    |
+| 26 | Ashton Heath       | J-SWAT                         | Lakeville-MN   | 75    | 10.71  |    |
+| 27 | Andrew Mascillaro  | J-Pillars of Fire              | Marlboro-NJ    | 60    | 8.57   |    |
+| 28 | Gabriel Gonzales   | Flamin\' Hot Buzzers           | Albuquerque-NM | 40    | 5.71   |    |
+| 28 | Rachel Adelmann    | J-BC United                    | Wyckoff-NJ     | 40    | 5.71   |    |
+| 29 | Elian Gonzales     | Flamin\' Hot Buzzers           | Albuquerque-NM | 30    | 4.29   |    |
+| 29 | Todd Pettet        | J-BC United                    | Wyckoff-NJ     | 30    | 4.29   |    |
+| 30 | Rhea Nathaniel     | J-Earth Shakers                | Chandler-AZ    | 25    | 3.57   |    |
+| 31 | Hannah Nix         | J-Christ Runners               | Fargo-ND       | 15    | 2.14   |    |
+| 32 | Matthew Rydeski    | Flamin\' Hot Buzzers           | Albuquerque-NM |       | .00    |    |
+| 32 | Andrew Manske      | J-Christ Runners               | Fargo-ND       |       | .00    |    |
+| 32 | Natalie Salerno    | J-BC United                    | Wyckoff-NJ     |       | .00    |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                     | Church                  | W/L | Total | Avg    |
+|--:|--------------------------|-------------------------|-----|------:|-------:|
+| 1 | D-SPY Warriors           | Kent-WA                 | 6/1 | 1160  | 165.71 |
+| 2 | D-Bible Treasure Seekers | Greensboro-NC           | 5/2 | 1220  | 174.29 |
+| 3 | D-Naperville             | Naperville-IL           | 4/3 | 1060  | 151.43 |
+| 4 | D-Quadruple Threat       | Cedar Hill-TX           | 3/4 | 985   | 140.71 |
+| 5 | D-BBT Hayah              | Scottsdale-AZ           | 3/4 | 945   | 135.00 |
+| 6 | D-Called To Duty         | Omaha-NE                | 3/4 | 815   | 116.43 |
+| 7 | D-Askewville             | Windsor (Askewville)-NC | 2/5 | 870   | 124.29 |
+| 8 | D-Word Warriors          | Flower Mound-TX         | 2/5 | 890   | 127.14 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                     | Church                  | Total | Avg    | QO |
+|---:|------------------------|--------------------------|-------------------------|------:|-------:|---:|
+| 1  | Alecia Rajesh          | D-Bible Treasure Seekers | Greensboro-NC           | 780   | 111.43 | 1  |
+| 2  | Parker Frankiewicz     | D-Naperville             | Naperville-IL           | 630   | 90.00  | 3  |
+| 3  | Gabrielle Davy         | D-SPY Warriors           | Kent-WA                 | 570   | 81.43  | 2  |
+| 4  | Stephen Moses          | D-BBT Hayah              | Scottsdale-AZ           | 520   | 74.29  | 1  |
+| 5  | Kaitlyn Ballard        | D-Word Warriors          | Flower Mound-TX         | 475   | 67.86  |    |
+| 6  | Parker Lubbe           | D-Quadruple Threat       | Cedar Hill-TX           | 385   | 55.00  |    |
+| 7  | Elizabeth Kaffenberger | D-Called To Duty         | Omaha-NE                | 375   | 53.57  |    |
+| 8  | Will Bazemore          | D-Askewville             | Windsor (Askewville)-NC | 345   | 49.29  |    |
+| 9  | Lau McGill             | D-Quadruple Threat       | Cedar Hill-TX           | 340   | 48.57  | 2  |
+| 10 | Matthew Braham         | D-SPY Warriors           | Kent-WA                 | 330   | 47.14  | 5  |
+| 11 | Daniel Castello        | D-Askewville             | Windsor (Askewville)-NC | 280   | 40.00  |    |
+| 12 | Alex Rawlings          | D-Word Warriors          | Flower Mound-TX         | 255   | 36.43  | 2  |
+| 13 | Coby Calvery           | D-Quadruple Threat       | Cedar Hill-TX           | 240   | 34.29  | 1  |
+| 13 | David Moses            | D-BBT Hayah              | Scottsdale-AZ           | 240   | 34.29  | 1  |
+| 14 | Abigail Prejean        | D-Bible Treasure Seekers | Greensboro-NC           | 210   | 30.00  |    |
+| 15 | Will Wolfe             | D-Naperville             | Naperville-IL           | 175   | 25.00  |    |
+| 16 | Jessica McElwee        | D-Naperville             | Naperville-IL           | 170   | 24.29  |    |
+| 16 | Lydia Kidroske         | D-Bible Treasure Seekers | Greensboro-NC           | 170   | 24.29  |    |
+| 17 | Aaron Palensky         | D-Called To Duty         | Omaha-NE                | 160   | 22.86  |    |
+| 18 | Jackson Atwell         | D-Called To Duty         | Omaha-NE                | 145   | 20.71  |    |
+| 18 | Austin Shepherd        | D-SPY Warriors           | Kent-WA                 | 145   | 20.71  |    |
+| 19 | Colton Hoggard         | D-Askewville             | Windsor (Askewville)-NC | 140   | 20.00  |    |
+| 20 | Madie Rawlings         | D-Word Warriors          | Flower Mound-TX         | 130   | 18.57  |    |
+| 21 | Joanna Moses           | D-BBT Hayah              | Scottsdale-AZ           | 100   | 14.29  |    |
+| 22 | Sheldon Powell         | D-Naperville             | Naperville-IL           | 90    | 12.86  |    |
+| 23 | Holly Garrett          | D-BBT Hayah              | Scottsdale-AZ           | 85    | 12.14  |    |
+| 23 | Cody Younger           | D-Askewville             | Windsor (Askewville)-NC | 85    | 12.14  |    |
+| 24 | Leah Palensky          | D-Called To Duty         | Omaha-NE                | 70    | 10.00  |    |
+| 25 | Dillon Shores          | D-Called To Duty         | Omaha-NE                | 65    | 9.29   |    |
+| 26 | Julia Martello         | D-Bible Treasure Seekers | Greensboro-NC           | 60    | 8.57   |    |
+| 26 | Teddy Gutterud         | D-SPY Warriors           | Kent-WA                 | 60    | 8.57   |    |
+| 27 | Michaela Toole         | D-SPY Warriors           | Kent-WA                 | 55    | 7.86   |    |
+| 28 | Zeke Rashid            | D-Word Warriors          | Flower Mound-TX         | 35    | 5.00   |    |
+| 29 | Grace Todd             | D-Askewville             | Windsor (Askewville)-NC | 20    | 2.86   |    |
+| 29 | Ben Manoli             | D-Quadruple Threat       | Cedar Hill-TX           | 20    | 2.86   |    |
+| 30 | Kendal Calvery         | D-Quadruple Threat       | Cedar Hill-TX           |       | .00    |    |
+| 30 | Julia DeGraff          | D-Naperville             | Naperville-IL           |       | .00    |    |
+
+## Saturday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                           | Church             | W/L | Total | Avg    |
+|---:|--------------------------------|--------------------|-----|------:|-------:|
+| 1  | J-Family Life Christian Center | Federal Way-WA     | 7/2 | 1580  | 175.56 |
+| 2  | G-Supernova                    | Springfield-MO     | 6/3 | 1450  | 161.11 |
+| 3  | F-The Spirit\'s Swords         | Ozark-MO           | 5/4 | 1325  | 147.22 |
+| 4  | J-Christ Runners               | Fargo-ND           | 5/4 | 1260  | 140.00 |
+| 5  | I-CLC                          | Fort Lauderdale-FL | 5/4 | 1240  | 137.78 |
+| 6  | H-Sonburst Omega               | Mechanicsville-VA  | 5/4 | 1140  | 126.67 |
+| 7  | H-Bethlehem Church             | Richmond Hill-NY   | 4/5 | 1210  | 134.44 |
+| 8  | F-God\'s C.R.E.W.              | Oklahoma City-OK   | 4/5 | 1095  | 121.67 |
+| 9  | I-CRK Almighty                 | Gloucester City-NJ | 3/6 | 1140  | 126.67 |
+| 10 | G-Spicy Chicken Wings          | Louisville-KY      | 1/8 | 1100  | 122.22 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                           | Church             | Total | Avg    | QO |
+|---:|--------------------|--------------------------------|--------------------|------:|-------:|---:|
+| 1  | Nicolas Boyce      | J-Family Life Christian Center | Federal Way-WA     | 1025  | 113.89 | 5  |
+| 2  | Ope Morakinyo      | I-CLC                          | Fort Lauderdale-FL | 760   | 84.44  | 2  |
+| 3  | Hannah Quick       | G-Supernova                    | Springfield-MO     | 735   | 81.67  | 3  |
+| 4  | Christina Baxter   | F-God\'s C.R.E.W.              | Oklahoma City-OK   | 630   | 70.00  |    |
+| 5  | Jaret Williams     | H-Bethlehem Church             | Richmond Hill-NY   | 625   | 69.44  | 2  |
+| 6  | Russel Flores      | I-CRK Almighty                 | Gloucester City-NJ | 490   | 54.44  | 1  |
+| 7  | Micah Marchand     | J-Christ Runners               | Fargo-ND           | 480   | 53.33  | 1  |
+| 8  | Holly Bowen        | H-Sonburst Omega               | Mechanicsville-VA  | 470   | 52.22  |    |
+| 9  | Noah Barnes        | G-Spicy Chicken Wings          | Louisville-KY      | 465   | 51.67  |    |
+| 10 | Natalie Slater     | G-Supernova                    | Springfield-MO     | 450   | 50.00  | 1  |
+| 11 | Kelise Braithwaite | F-The Spirit\'s Swords         | Ozark-MO           | 445   | 49.44  | 2  |
+| 12 | Savannah Shannon   | F-The Spirit\'s Swords         | Ozark-MO           | 435   | 48.33  | 1  |
+| 13 | Maddie Hawkes      | J-Family Life Christian Center | Federal Way-WA     | 400   | 44.44  | 2  |
+| 14 | Carson Nix         | J-Christ Runners               | Fargo-ND           | 385   | 42.78  | 2  |
+| 15 | Michael Notman     | I-CLC                          | Fort Lauderdale-FL | 345   | 38.33  | 1  |
+| 16 | Madison Doise      | H-Sonburst Omega               | Mechanicsville-VA  | 330   | 36.67  |    |
+| 17 | Travis Griessel    | F-The Spirit\'s Swords         | Ozark-MO           | 315   | 35.00  | 2  |
+| 18 | Miken Melvin       | F-God\'s C.R.E.W.              | Oklahoma City-OK   | 270   | 30.00  | 1  |
+| 19 | Sara Ann Haimchand | H-Bethlehem Church             | Richmond Hill-NY   | 265   | 29.44  | 1  |
+| 20 | Lucas Clark        | G-Supernova                    | Springfield-MO     | 255   | 28.33  | 1  |
+| 21 | Isabel Gonzalez    | G-Spicy Chicken Wings          | Louisville-KY      | 255   | 28.33  |    |
+| 22 | Jillian Angeles    | I-CRK Almighty                 | Gloucester City-NJ | 240   | 26.67  |    |
+| 23 | Andrew Cox         | G-Spicy Chicken Wings          | Louisville-KY      | 230   | 25.56  | 2  |
+| 24 | Nathan Isner       | H-Sonburst Omega               | Mechanicsville-VA  | 225   | 25.00  |    |
+| 25 | Joy Okafor         | H-Bethlehem Church             | Richmond Hill-NY   | 180   | 20.00  |    |
+| 26 | Jordan Nix         | J-Christ Runners               | Fargo-ND           | 175   | 19.44  | 1  |
+| 27 | Aaron Marchand     | J-Christ Runners               | Fargo-ND           | 170   | 18.89  |    |
+| 28 | Junny Jayme        | I-CRK Almighty                 | Gloucester City-NJ | 160   | 17.78  | 1  |
+| 29 | Jonathan Dambacher | J-Family Life Christian Center | Federal Way-WA     | 155   | 17.22  |    |
+| 30 | Trevor Webb        | G-Spicy Chicken Wings          | Louisville-KY      | 150   | 16.67  |    |
+| 31 | Elijah Abad        | I-CRK Almighty                 | Gloucester City-NJ | 145   | 16.11  |    |
+| 32 | Reagan Griessel    | F-The Spirit\'s Swords         | Ozark-MO           | 130   | 14.44  |    |
+| 33 | Jonathan Irizarry  | I-CLC                          | Fort Lauderdale-FL | 125   | 13.89  |    |
+| 34 | Nikki Rittenhouse  | H-Sonburst Omega               | Mechanicsville-VA  | 115   | 12.78  |    |
+| 35 | Jacob Flores       | I-CRK Almighty                 | Gloucester City-NJ | 105   | 11.67  |    |
+| 35 | Catherine Baxter   | F-God\'s C.R.E.W.              | Oklahoma City-OK   | 105   | 11.67  |    |
+| 36 | Dwayne Bacchus     | H-Bethlehem Church             | Richmond Hill-NY   | 90    | 10.00  |    |
+| 37 | Jonathan Burke     | F-God\'s C.R.E.W.              | Oklahoma City-OK   | 70    | 7.78   |    |
+| 38 | Nicole DeSilva     | H-Bethlehem Church             | Richmond Hill-NY   | 65    | 7.22   |    |
+| 39 | Andrew Manske      | J-Christ Runners               | Fargo-ND           | 50    | 5.56   |    |
+| 40 | Nathan Burke       | F-God\'s C.R.E.W.              | Oklahoma City-OK   | 20    | 2.22   |    |
+| 41 | Rebecca Rodrigues  | I-CLC                          | Fort Lauderdale-FL | 10    | 1.11   |    |
+| 41 | Landon Clark       | G-Supernova                    | Springfield-MO     | 10    | 1.11   |    |
+| 42 | Lily Slater        | G-Supernova                    | Springfield-MO     |       | .00    |    |
+| 42 | Emily Singh        | H-Bethlehem Church             | Richmond Hill-NY   |       | .00    |    |
+| 42 | Hannah Nix         | J-Christ Runners               | Fargo-ND           |       | .00    |    |
+| 42 | Sean Lori Umali    | H-Bethlehem Church             | Richmond Hill-NY   |       | .00    |    |
+| 43 | Rebecca Ramnauth   | H-Bethlehem Church             | Richmond Hill-NY   | -10   | -1.11  |    |
+
+
+### Gray
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                          | Church             | W/L | Total | Avg    |
+|---:|-------------------------------|--------------------|-----|------:|-------:|
+| 1  | J-BC United                   | Wyckoff-NJ         | 8/1 | 1850  | 205.56 |
+| 2  | H-Temple - Clanton            | Clanton-AL         | 7/2 | 1455  | 161.67 |
+| 3  | G-The Crossing Place Quizzers | Franklin-LA        | 6/3 | 1565  | 173.89 |
+| 4  | F-Desert Joy Bible Buzzers    | Litchfield Park-AZ | 5/4 | 1200  | 133.33 |
+| 5  | G-Word Nerds                  | Des Moines-IA      | 5/4 | 1175  | 130.56 |
+| 6  | I-Fantastic Five              | Des Moines-IA      | 4/5 | 1215  | 135.00 |
+| 7  | I-ACOG                        | Lawrenceville-GA   | 4/5 | 1290  | 143.33 |
+| 8  | J-God\'s Girlz                | Surprise-AZ        | 3/6 | 1390  | 154.44 |
+| 9  | F-Mighty Disciples            | Santa Ana-CA       | 2/7 | 1050  | 116.67 |
+| 10 | H-Gospel Gang                 | Amarillo-TX        | 1/8 | 875   | 97.22  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                          | Church             | Total | Avg    | QO |
+|---:|----------------------|-------------------------------|--------------------|------:|-------:|---:|
+| 1  | Jordan Landry        | G-The Crossing Place Quizzers | Franklin-LA        | 1140  | 126.67 | 8  |
+| 2  | Bennett Thomas       | I-ACOG                        | Lawrenceville-GA   | 895   | 99.44  | 7  |
+| 3  | Bailey Watley        | H-Temple - Clanton            | Clanton-AL         | 835   | 92.78  | 4  |
+| 4  | Jacob Kilian         | F-Desert Joy Bible Buzzers    | Litchfield Park-AZ | 795   | 88.33  | 5  |
+| 5  | Kimber Cruz          | F-Mighty Disciples            | Santa Ana-CA       | 665   | 73.89  | 4  |
+| 6  | McKenna Kollman      | J-God\'s Girlz                | Surprise-AZ        | 665   | 73.89  | 1  |
+| 7  | Cayla Brodeur        | J-BC United                   | Wyckoff-NJ         | 615   | 68.33  |    |
+| 8  | Elizabeth Chunn      | H-Gospel Gang                 | Amarillo-TX        | 525   | 58.33  | 2  |
+| 9  | Stephen Cowan        | I-Fantastic Five              | Des Moines-IA      | 500   | 55.56  | 2  |
+| 10 | Warner Pool          | G-Word Nerds                  | Des Moines-IA      | 475   | 52.78  | 6  |
+| 11 | Brandon Watley       | H-Temple - Clanton            | Clanton-AL         | 435   | 48.33  | 5  |
+| 12 | Emma Moorman         | J-BC United                   | Wyckoff-NJ         | 430   | 47.78  | 5  |
+| 13 | Brendon Sturgeon     | G-The Crossing Place Quizzers | Franklin-LA        | 425   | 47.22  | 5  |
+| 14 | Kenzie Brown         | J-God\'s Girlz                | Surprise-AZ        | 395   | 43.89  | 2  |
+| 15 | Kelsey Cruz          | F-Mighty Disciples            | Santa Ana-CA       | 350   | 38.89  |    |
+| 16 | Faith Brown          | J-God\'s Girlz                | Surprise-AZ        | 330   | 36.67  |    |
+| 17 | Rachel Girimonte     | J-BC United                   | Wyckoff-NJ         | 315   | 35.00  | 1  |
+| 18 | Dylan Clarkson       | I-Fantastic Five              | Des Moines-IA      | 310   | 34.44  | 2  |
+| 19 | Claire Roe           | G-Word Nerds                  | Des Moines-IA      | 300   | 33.33  |    |
+| 19 | Jacob Brechtel       | G-Word Nerds                  | Des Moines-IA      | 300   | 33.33  |    |
+| 20 | Melvin Mathew        | I-ACOG                        | Lawrenceville-GA   | 290   | 32.22  | 2  |
+| 21 | Michaela McLeod      | J-BC United                   | Wyckoff-NJ         | 280   | 31.11  | 1  |
+| 22 | Joshua Kilian        | F-Desert Joy Bible Buzzers    | Litchfield Park-AZ | 260   | 28.89  | 2  |
+| 23 | Aaron Bopp           | I-Fantastic Five              | Des Moines-IA      | 230   | 25.56  |    |
+| 24 | Rachel Adelmann      | J-BC United                   | Wyckoff-NJ         | 220   | 24.44  |    |
+| 24 | Ryan Chunn           | H-Gospel Gang                 | Amarillo-TX        | 220   | 24.44  |    |
+| 25 | Emma Cleckler        | H-Temple - Clanton            | Clanton-AL         | 155   | 17.22  |    |
+| 26 | Annie Pool           | G-Word Nerds                  | Des Moines-IA      | 110   | 12.22  |    |
+| 27 | Kaitlyn Clarkson     | I-Fantastic Five              | Des Moines-IA      | 105   | 11.67  |    |
+| 27 | Brennann Thomas      | I-ACOG                        | Lawrenceville-GA   | 105   | 11.67  |    |
+| 28 | Jeremy Morales       | F-Desert Joy Bible Buzzers    | Litchfield Park-AZ | 75    | 8.33   |    |
+| 29 | Jonathan Morales     | F-Desert Joy Bible Buzzers    | Litchfield Park-AZ | 70    | 7.78   |    |
+| 29 | Libby Lorts          | I-Fantastic Five              | Des Moines-IA      | 70    | 7.78   |    |
+| 30 | Brendan Marrow       | H-Gospel Gang                 | Amarillo-TX        | 60    | 6.67   |    |
+| 30 | Zachary Westmoreland | H-Gospel Gang                 | Amarillo-TX        | 60    | 6.67   |    |
+| 31 | Bridgette Dupree     | F-Mighty Disciples            | Santa Ana-CA       | 35    | 3.89   |    |
+| 32 | Katelyn Johnson      | H-Temple - Clanton            | Clanton-AL         | 30    | 3.33   |    |
+| 33 | Abigail Chunn        | H-Gospel Gang                 | Amarillo-TX        | 10    | 1.11   |    |
+| 34 | Natalie Salerno      | J-BC United                   | Wyckoff-NJ         |       | .00    |    |
+| 34 | Naomi Kilian         | F-Desert Joy Bible Buzzers    | Litchfield Park-AZ |       | .00    |    |
+| 34 | Mattie Cleckler      | H-Temple - Clanton            | Clanton-AL         |       | .00    |    |
+| 35 | Todd Pettet          | J-BC United                   | Wyckoff-NJ         | -10   | -1.11  |    |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                   | Church           | W/L | Total | Avg    |
+|---:|------------------------|------------------|-----|------:|-------:|
+| 1  | G-Warriors in Training | Columbiaville-MI | 7/2 | 1580  | 175.56 |
+| 2  | F-Gideon\'s Army       | Huber Heights-OH | 6/3 | 1530  | 170.00 |
+| 3  | F-Q\'s                 | Lexington-TN     | 6/3 | 1500  | 166.67 |
+| 4  | H-Buzz Hogs            | Mabelvale-AR     | 5/4 | 1515  | 168.33 |
+| 5  | G-The Praying Amigos   | Brookfield-WI    | 5/4 | 1360  | 151.11 |
+| 6  | H-Karate Quizzers      | Bismarck-ND      | 5/4 | 1155  | 128.33 |
+| 7  | Flamin\' Hot Buzzers   | Albuquerque-NM   | 5/4 | 1135  | 126.11 |
+| 8  | I-Transformed          | Huntington-WV    | 3/6 | 980   | 108.89 |
+| 9  | I-Bethel Bereans       | San Jose-CA      | 2/7 | 865   | 96.11  |
+| 10 | J-SWAT                 | Lakeville-MN     | 1/8 | 895   | 99.44  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                   | Church           | Total | Avg    | QO |
+|---:|----------------------|------------------------|------------------|------:|-------:|---:|
+| 1  | Sean Jones           | F-Gideon\'s Army       | Huber Heights-OH | 965   | 107.22 | 5  |
+| 2  | Hudson Hollin        | G-Warriors in Training | Columbiaville-MI | 955   | 106.11 | 3  |
+| 3  | Jared Minick         | H-Buzz Hogs            | Mabelvale-AR     | 865   | 96.11  | 3  |
+| 4  | Elijah O\'Brien      | G-The Praying Amigos   | Brookfield-WI    | 745   | 82.78  |    |
+| 5  | Jazmynn Wilson       | Flamin\' Hot Buzzers   | Albuquerque-NM   | 735   | 81.67  | 3  |
+| 6  | Reuben Savage        | F-Q\'s                 | Lexington-TN     | 645   | 71.67  | 1  |
+| 7  | Bridge Biniakewitz   | H-Buzz Hogs            | Mabelvale-AR     | 555   | 61.67  | 6  |
+| 8  | Ashlyn Sipes         | H-Karate Quizzers      | Bismarck-ND      | 440   | 48.89  |    |
+| 9  | Noah Hensley         | I-Transformed          | Huntington-WV    | 415   | 46.11  | 1  |
+| 10 | Eli Price            | F-Q\'s                 | Lexington-TN     | 410   | 45.56  | 1  |
+| 11 | Seth Hensley         | I-Transformed          | Huntington-WV    | 380   | 42.22  |    |
+| 12 | Seth Savage          | F-Q\'s                 | Lexington-TN     | 375   | 41.67  | 4  |
+| 13 | Lucas Bender         | H-Karate Quizzers      | Bismarck-ND      | 370   | 41.11  | 2  |
+| 14 | Madison Heath        | J-SWAT                 | Lakeville-MN     | 305   | 33.89  |    |
+| 15 | Hunter Hollin        | G-Warriors in Training | Columbiaville-MI | 300   | 33.33  | 2  |
+| 16 | Jeannah Jones        | F-Gideon\'s Army       | Huber Heights-OH | 295   | 32.78  |    |
+| 17 | Derek Leingang       | H-Karate Quizzers      | Bismarck-ND      | 290   | 32.22  |    |
+| 18 | Gabriel Ison         | F-Gideon\'s Army       | Huber Heights-OH | 260   | 28.89  | 2  |
+| 19 | Solomon Joseph       | I-Bethel Bereans       | San Jose-CA      | 260   | 28.89  |    |
+| 20 | Drew Wilson          | Flamin\' Hot Buzzers   | Albuquerque-NM   | 245   | 27.22  | 1  |
+| 21 | Kyle Ringley         | J-SWAT                 | Lakeville-MN     | 210   | 23.33  |    |
+| 22 | Esji Johnson         | G-The Praying Amigos   | Brookfield-WI    | 205   | 22.78  |    |
+| 23 | Ashton Heath         | J-SWAT                 | Lakeville-MN     | 200   | 22.22  | 1  |
+| 24 | Anthony Mikolajewski | G-The Praying Amigos   | Brookfield-WI    | 190   | 21.11  |    |
+| 24 | Esther O\'Brien      | G-The Praying Amigos   | Brookfield-WI    | 190   | 21.11  |    |
+| 24 | Jabez Williams       | I-Bethel Bereans       | San Jose-CA      | 190   | 21.11  |    |
+| 24 | Joey Huntley         | G-Warriors in Training | Columbiaville-MI | 190   | 21.11  |    |
+| 25 | Gabby Ringley        | J-SWAT                 | Lakeville-MN     | 180   | 20.00  | 1  |
+| 26 | Mark Ziegler         | I-Transformed          | Huntington-WV    | 135   | 15.00  |    |
+| 27 | Alex Peters          | G-Warriors in Training | Columbiaville-MI | 115   | 12.78  |    |
+| 28 | David Daniel         | I-Bethel Bereans       | San Jose-CA      | 110   | 12.22  |    |
+| 29 | Timothy Nirmal       | I-Bethel Bereans       | San Jose-CA      | 100   | 11.11  |    |
+| 29 | Mandy Rydeski        | Flamin\' Hot Buzzers   | Albuquerque-NM   | 100   | 11.11  |    |
+| 30 | Paul Daniel          | I-Bethel Bereans       | San Jose-CA      | 95    | 10.56  | 1  |
+| 31 | Gabriel Roberts      | I-Bethel Bereans       | San Jose-CA      | 80    | 8.89   |    |
+| 32 | Ashlynn Price        | F-Q\'s                 | Lexington-TN     | 70    | 7.78   |    |
+| 33 | Savanah Biniakewitz  | H-Buzz Hogs            | Mabelvale-AR     | 65    | 7.22   |    |
+| 34 | Seth Davis           | H-Karate Quizzers      | Bismarck-ND      | 45    | 5.00   |    |
+| 35 | Olivia Cypcar        | G-The Praying Amigos   | Brookfield-WI    | 30    | 3.33   |    |
+| 35 | Tabitha Nirmal       | I-Bethel Bereans       | San Jose-CA      | 30    | 3.33   |    |
+| 35 | Caitlin Leedy        | I-Transformed          | Huntington-WV    | 30    | 3.33   |    |
+| 35 | Levi Biniakewitz     | H-Buzz Hogs            | Mabelvale-AR     | 30    | 3.33   |    |
+| 36 | Elian Gonzales       | Flamin\' Hot Buzzers   | Albuquerque-NM   | 25    | 2.78   |    |
+| 37 | Annah Hensley        | I-Transformed          | Huntington-WV    | 20    | 2.22   |    |
+| 37 | Gabriel Gonzales     | Flamin\' Hot Buzzers   | Albuquerque-NM   | 20    | 2.22   |    |
+| 38 | Matthew Rydeski      | Flamin\' Hot Buzzers   | Albuquerque-NM   | 10    | 1.11   |    |
+| 38 | Brandon Byers        | G-Warriors in Training | Columbiaville-MI | 10    | 1.11   |    |
+| 38 | Hailie Huntley       | G-Warriors in Training | Columbiaville-MI | 10    | 1.11   |    |
+| 38 | Ryleigh Jones        | F-Gideon\'s Army       | Huber Heights-OH | 10    | 1.11   |    |
+| 38 | Danelle Ragains      | H-Karate Quizzers      | Bismarck-ND      | 10    | 1.11   |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                 | Church            | W/L | Total | Avg    |
+|---:|----------------------|-------------------|-----|------:|-------:|
+| 1  | B-S.P.Y. Kids 007    | Leesburg-VA       | 7/2 | 1520  | 168.89 |
+| 2  | D-Called To Duty     | Omaha-NE          | 7/2 | 1390  | 154.44 |
+| 3  | D-BBT Hayah          | Scottsdale-AZ     | 6/3 | 1440  | 160.00 |
+| 4  | A-Fire Starters      | Lawson-MO         | 6/3 | 1380  | 153.33 |
+| 5  | A-Harrison Thrashers | Harrison-AR       | 5/4 | 1450  | 161.11 |
+| 6  | E-Bible Jammers      | Sanford-FL        | 4/5 | 1260  | 140.00 |
+| 7  | C-Cedar Park         | Bothell-WA        | 3/6 | 1205  | 133.89 |
+| 8  | E-The CIA            | Mendon-MA         | 3/6 | 1105  | 122.78 |
+| 9  | B-Purple             | Ozark-MO          | 3/6 | 970   | 107.78 |
+| 10 | C-Sonburst Alpha     | Mechanicsville-VA | 1/8 | 935   | 103.89 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                 | Church            | Total | Avg    | QO |
+|---:|------------------------|----------------------|-------------------|------:|-------:|---:|
+| 1  | Stephen Moses          | D-BBT Hayah          | Scottsdale-AZ     | 1020  | 113.33 | 3  |
+| 2  | Makenzie Bradshaw      | A-Harrison Thrashers | Harrison-AR       | 830   | 92.22  | 1  |
+| 3  | Peyton Goss            | E-Bible Jammers      | Sanford-FL        | 665   | 73.89  | 3  |
+| 4  | Josh Rozelle           | B-S.P.Y. Kids 007    | Leesburg-VA       | 595   | 66.11  |    |
+| 5  | Hayden Ballard         | B-Purple             | Ozark-MO          | 530   | 58.89  | 1  |
+| 6  | Matthew Bozzay         | B-S.P.Y. Kids 007    | Leesburg-VA       | 500   | 55.56  | 1  |
+| 7  | Aaron Palensky         | D-Called To Duty     | Omaha-NE          | 495   | 55.00  |    |
+| 8  | Connor Ferguson        | A-Fire Starters      | Lawson-MO         | 460   | 51.11  |    |
+| 9  | Brendan Ferguson       | A-Fire Starters      | Lawson-MO         | 450   | 50.00  | 1  |
+| 10 | Aubrey Goss            | E-Bible Jammers      | Sanford-FL        | 415   | 46.11  | 3  |
+| 11 | Noah Zook              | C-Sonburst Alpha     | Mechanicsville-VA | 410   | 45.56  |    |
+| 11 | Elizabeth Kaffenberger | D-Called To Duty     | Omaha-NE          | 410   | 45.56  |    |
+| 12 | Jonathan Archer        | A-Fire Starters      | Lawson-MO         | 380   | 42.22  | 2  |
+| 13 | Shannon Morrill        | E-The CIA            | Mendon-MA         | 365   | 40.56  | 2  |
+| 14 | Kerigan Bradshaw       | A-Harrison Thrashers | Harrison-AR       | 350   | 38.89  | 1  |
+| 15 | John Fugere            | E-The CIA            | Mendon-MA         | 350   | 38.89  |    |
+| 16 | David Moses            | D-BBT Hayah          | Scottsdale-AZ     | 335   | 37.22  |    |
+| 17 | Joshua Roberts         | C-Cedar Park         | Bothell-WA        | 305   | 33.89  | 1  |
+| 18 | Tayla Vannelli         | E-The CIA            | Mendon-MA         | 280   | 31.11  |    |
+| 19 | Luke Yoder             | B-S.P.Y. Kids 007    | Leesburg-VA       | 275   | 30.56  | 1  |
+| 20 | Jackson Atwell         | D-Called To Duty     | Omaha-NE          | 260   | 28.89  | 2  |
+| 21 | Sierra Smith           | C-Cedar Park         | Bothell-WA        | 260   | 28.89  |    |
+| 22 | Johan West             | C-Cedar Park         | Bothell-WA        | 240   | 26.67  | 1  |
+| 23 | Andreya Snyder         | C-Cedar Park         | Bothell-WA        | 240   | 26.67  |    |
+| 24 | Nathaniel Walker       | C-Sonburst Alpha     | Mechanicsville-VA | 235   | 26.11  |    |
+| 25 | Leah Palensky          | D-Called To Duty     | Omaha-NE          | 225   | 25.00  | 1  |
+| 26 | Victoriah Shook        | B-Purple             | Ozark-MO          | 215   | 23.89  | 1  |
+| 27 | Anthony Webster        | C-Sonburst Alpha     | Mechanicsville-VA | 200   | 22.22  |    |
+| 28 | Cassidy Neal           | E-Bible Jammers      | Sanford-FL        | 180   | 20.00  |    |
+| 29 | Abby Bailey            | A-Harrison Thrashers | Harrison-AR       | 170   | 18.89  |    |
+| 30 | Linsey Garrison        | B-Purple             | Ozark-MO          | 165   | 18.33  |    |
+| 31 | Jackson Houser         | C-Cedar Park         | Bothell-WA        | 160   | 17.78  |    |
+| 32 | Ben Rozelle            | B-S.P.Y. Kids 007    | Leesburg-VA       | 115   | 12.78  |    |
+| 33 | Bethany Perry          | E-The CIA            | Mendon-MA         | 110   | 12.22  |    |
+| 34 | Zachary Ferguson       | A-Fire Starters      | Lawson-MO         | 90    | 10.00  |    |
+| 34 | Griffin Simpson        | C-Sonburst Alpha     | Mechanicsville-VA | 90    | 10.00  |    |
+| 35 | Laura Henderson        | A-Harrison Thrashers | Harrison-AR       | 80    | 8.89   |    |
+| 36 | Zara Rethman           | B-Purple             | Ozark-MO          | 75    | 8.33   |    |
+| 37 | Holly Garrett          | D-BBT Hayah          | Scottsdale-AZ     | 65    | 7.22   |    |
+| 38 | Andrew Otchere         | B-S.P.Y. Kids 007    | Leesburg-VA       | 35    | 3.89   |    |
+| 39 | Joanna Moses           | D-BBT Hayah          | Scottsdale-AZ     | 20    | 2.22   |    |
+| 39 | Reagan Warren          | A-Harrison Thrashers | Harrison-AR       | 20    | 2.22   |    |
+| 40 | Sarah Judd             | B-S.P.Y. Kids 007    | Leesburg-VA       |       | .00    |    |
+| 40 | Katherine Bozzay       | B-S.P.Y. Kids 007    | Leesburg-VA       |       | .00    |    |
+| 40 | Bethany Warren         | A-Harrison Thrashers | Harrison-AR       |       | .00    |    |
+| 40 | Dillon Shores          | D-Called To Duty     | Omaha-NE          |       | .00    |    |
+| 41 | Brenden Reeves         | B-Purple             | Ozark-MO          | -15   | -1.67  |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                    | Church            | W/L | Total | Avg    |
+|---:|-------------------------|-------------------|-----|------:|-------:|
+| 1  | I-Lightening McQuizzers | Dumas-TX          | 7/2 | 1740  | 193.33 |
+| 2  | F-The Four-ce Unleashed | Universal City-TX | 6/3 | 1520  | 168.89 |
+| 3  | I-N 2 God Again         | Concord-NC        | 6/3 | 1310  | 145.56 |
+| 4  | H-Calvary Champions     | Chattanooga-TN    | 6/3 | 1230  | 136.67 |
+| 5  | G-Ashland, Al           | Ashland-AL        | 5/4 | 1270  | 141.11 |
+| 6  | J-Earth Shakers         | Chandler-AZ       | 4/5 | 1240  | 137.78 |
+| 7  | G-CIA                   | Mustang-OK        | 4/5 | 1120  | 124.44 |
+| 8  | J-Pillars of Fire       | Marlboro-NJ       | 4/5 | 1020  | 113.33 |
+| 9  | H-FBI                   | Lakeville-MN      | 3/6 | 1225  | 136.11 |
+| 10 | F-Lightning             | Bonifay-FL        | 0/9 | 800   | 88.89  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                    | Church            | Total | Avg    | QO |
+|---:|---------------------|-------------------------|-------------------|------:|-------:|---:|
+| 1  | Maggie Akins        | I-Lightening McQuizzers | Dumas-TX          | 970   | 107.78 | 4  |
+| 2  | Elijah Garmany      | H-Calvary Champions     | Chattanooga-TN    | 860   | 95.56  | 6  |
+| 3  | Feba Cherian        | J-Earth Shakers         | Chandler-AZ       | 805   | 89.44  | 3  |
+| 4  | Mary Frances Harris | F-The Four-ce Unleashed | Universal City-TX | 780   | 86.67  | 1  |
+| 5  | Paul Willis         | G-Ashland, Al           | Ashland-AL        | 670   | 74.44  | 4  |
+| 6  | Alex Shell          | G-CIA                   | Mustang-OK        | 580   | 64.44  | 1  |
+| 7  | Sydney Ames         | H-FBI                   | Lakeville-MN      | 505   | 56.11  |    |
+| 8  | Teddy Willis        | G-Ashland, Al           | Ashland-AL        | 480   | 53.33  | 5  |
+| 9  | Ida Ekuban          | I-N 2 God Again         | Concord-NC        | 460   | 51.11  | 1  |
+| 10 | Zach Wylie          | F-The Four-ce Unleashed | Universal City-TX | 405   | 45.00  |    |
+| 11 | Andrew Warren       | F-Lightning             | Bonifay-FL        | 385   | 42.78  |    |
+| 12 | Dylan Marmion       | J-Pillars of Fire       | Marlboro-NJ       | 380   | 42.22  | 1  |
+| 13 | Max Fowler          | I-N 2 God Again         | Concord-NC        | 375   | 41.67  | 3  |
+| 14 | Samuel Garmany      | H-Calvary Champions     | Chattanooga-TN    | 370   | 41.11  | 4  |
+| 15 | Erin Clay           | I-N 2 God Again         | Concord-NC        | 315   | 35.00  |    |
+| 16 | Madyson Theesfeld   | J-Earth Shakers         | Chandler-AZ       | 295   | 32.78  | 2  |
+| 17 | Bryce Lofton        | H-FBI                   | Lakeville-MN      | 290   | 32.22  | 2  |
+| 18 | Nicholas Clemens    | I-Lightening McQuizzers | Dumas-TX          | 285   | 31.67  | 2  |
+| 19 | Noah Harris         | F-The Four-ce Unleashed | Universal City-TX | 275   | 30.56  | 1  |
+| 20 | Lauren Grisham      | G-CIA                   | Mustang-OK        | 270   | 30.00  |    |
+| 21 | Joel Valliath       | J-Pillars of Fire       | Marlboro-NJ       | 220   | 24.44  | 1  |
+| 21 | Bella Wilkins       | I-Lightening McQuizzers | Dumas-TX          | 220   | 24.44  | 1  |
+| 22 | Sharon Morara       | H-FBI                   | Lakeville-MN      | 220   | 24.44  |    |
+| 23 | Landon Grisham      | G-CIA                   | Mustang-OK        | 215   | 23.89  |    |
+| 24 | Dugan Akins         | I-Lightening McQuizzers | Dumas-TX          | 210   | 23.33  |    |
+| 25 | Will Zepp           | F-Lightning             | Bonifay-FL        | 180   | 20.00  |    |
+| 26 | Olivia May          | J-Pillars of Fire       | Marlboro-NJ       | 175   | 19.44  |    |
+| 27 | Victoria Dahlman    | I-N 2 God Again         | Concord-NC        | 160   | 17.78  |    |
+| 28 | JJ Paul             | F-Lightning             | Bonifay-FL        | 145   | 16.11  |    |
+| 29 | Sarah Abel          | J-Pillars of Fire       | Marlboro-NJ       | 140   | 15.56  | 1  |
+| 30 | Grace Catchings     | G-Ashland, Al           | Ashland-AL        | 120   | 13.33  |    |
+| 31 | Andy Prazuch        | H-FBI                   | Lakeville-MN      | 110   | 12.22  |    |
+| 31 | Crystal Thomas      | J-Earth Shakers         | Chandler-AZ       | 110   | 12.22  |    |
+| 31 | Andrew Mascillaro   | J-Pillars of Fire       | Marlboro-NJ       | 110   | 12.22  |    |
+| 32 | Zach Morara         | H-FBI                   | Lakeville-MN      | 100   | 11.11  | 1  |
+| 33 | Nick Stewart        | F-Lightning             | Bonifay-FL        | 80    | 8.89   |    |
+| 34 | Rudy Narvaez        | F-The Four-ce Unleashed | Universal City-TX | 60    | 6.67   |    |
+| 35 | Ashli Sauer         | I-Lightening McQuizzers | Dumas-TX          | 55    | 6.11   |    |
+| 36 | Kailan Weidner      | G-CIA                   | Mustang-OK        | 40    | 4.44   |    |
+| 37 | Rhea Nathaniel      | J-Earth Shakers         | Chandler-AZ       | 30    | 3.33   |    |
+| 38 | Esther Faiella      | G-CIA                   | Mustang-OK        | 15    | 1.67   |    |
+| 39 | Cameron Moore       | F-Lightning             | Bonifay-FL        | 10    | 1.11   |    |
+
+
+### Purple
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                       | Church          | W/L | Total | Avg    |
+|---:|----------------------------|-----------------|-----|------:|-------:|
+| 1  | A-Tribulation Force        | Red Oak-TX      | 7/2 | 1660  | 184.44 |
+| 2  | C-Naperville\'             | Naperville-IL   | 6/3 | 1705  | 189.44 |
+| 3  | D-Naperville               | Naperville-IL   | 6/3 | 1510  | 167.78 |
+| 4  | B-Men of Faith             | Sanford-FL      | 5/4 | 1265  | 140.56 |
+| 5  | A-Greater Lansing          | East Lansing-MI | 4/5 | 1370  | 152.22 |
+| 6  | B-Sabia                    | Roswell-GA      | 4/5 | 1320  | 146.67 |
+| 7  | D-Quadruple Threat         | Cedar Hill-TX   | 4/5 | 1140  | 126.67 |
+| 8  | E-Guardians of God\'s Word | Cincinnati-OH   | 4/5 | 1130  | 125.56 |
+| 9  | C-Brightmoor               | Novi-MI         | 3/6 | 990   | 110.00 |
+| 10 | E-Blazing Swords           | Chesterfield-MO | 2/7 | 985   | 109.44 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                       | Church          | Total | Avg    | QO |
+|---:|--------------------|----------------------------|-----------------|------:|-------:|---:|
+| 1  | Parker Frankiewicz | D-Naperville               | Naperville-IL   | 930   | 103.33 | 6  |
+| 2  | Shreanna Powell    | C-Naperville\'             | Naperville-IL   | 860   | 95.56  | 4  |
+| 3  | Toby Robinson      | B-Men of Faith             | Sanford-FL      | 850   | 94.44  | 5  |
+| 4  | Daniel Ferreira    | B-Sabia                    | Roswell-GA      | 805   | 89.44  | 4  |
+| 5  | Tyler McCartney    | A-Greater Lansing          | East Lansing-MI | 735   | 81.67  | 4  |
+| 6  | Cameron Berta      | A-Tribulation Force        | Red Oak-TX      | 710   | 78.89  | 2  |
+| 7  | David Saunders     | A-Tribulation Force        | Red Oak-TX      | 675   | 75.00  | 2  |
+| 8  | Daniel Kinger      | E-Blazing Swords           | Chesterfield-MO | 655   | 72.78  | 3  |
+| 9  | Robert Laboy       | C-Naperville\'             | Naperville-IL   | 605   | 67.22  | 7  |
+| 10 | Brennan Dodds      | E-Guardians of God\'s Word | Cincinnati-OH   | 475   | 52.78  | 2  |
+| 11 | Maxwell Holleman   | C-Brightmoor               | Novi-MI         | 465   | 51.67  | 3  |
+| 12 | Parker Lubbe       | D-Quadruple Threat         | Cedar Hill-TX   | 430   | 47.78  |    |
+| 13 | Ethan Smith        | E-Guardians of God\'s Word | Cincinnati-OH   | 415   | 46.11  | 1  |
+| 14 | Lau McGill         | D-Quadruple Threat         | Cedar Hill-TX   | 395   | 43.89  | 1  |
+| 15 | Lauren Chapman     | C-Brightmoor               | Novi-MI         | 375   | 41.67  |    |
+| 16 | Sheldon Powell     | D-Naperville               | Naperville-IL   | 365   | 40.56  | 4  |
+| 17 | Grace Artis        | B-Sabia                    | Roswell-GA      | 345   | 38.33  |    |
+| 18 | Coby Calvery       | D-Quadruple Threat         | Cedar Hill-TX   | 335   | 37.22  | 2  |
+| 18 | Jonathan Huber     | B-Men of Faith             | Sanford-FL      | 335   | 37.22  | 2  |
+| 19 | Kaleb Smith        | E-Blazing Swords           | Chesterfield-MO | 330   | 36.67  | 1  |
+| 20 | Darcie Harr        | A-Greater Lansing          | East Lansing-MI | 305   | 33.89  |    |
+| 21 | Chase Buher        | A-Greater Lansing          | East Lansing-MI | 300   | 33.33  | 3  |
+| 22 | Harrison Hoggard   | A-Tribulation Force        | Red Oak-TX      | 275   | 30.56  |    |
+| 23 | Cristian Huix      | B-Sabia                    | Roswell-GA      | 170   | 18.89  |    |
+| 24 | Jack Titkemeyer    | E-Guardians of God\'s Word | Cincinnati-OH   | 145   | 16.11  | 1  |
+| 25 | Erin Laboy         | C-Naperville\'             | Naperville-IL   | 130   | 14.44  |    |
+| 25 | Jessica McElwee    | D-Naperville               | Naperville-IL   | 130   | 14.44  |    |
+| 26 | Jake Wolfe         | C-Naperville\'             | Naperville-IL   | 110   | 12.22  |    |
+| 27 | Andrew Davenport   | C-Brightmoor               | Novi-MI         | 100   | 11.11  | 1  |
+| 28 | Jonathan Robinson  | B-Men of Faith             | Sanford-FL      | 80    | 8.89   |    |
+| 29 | Will Wolfe         | D-Naperville               | Naperville-IL   | 65    | 7.22   |    |
+| 30 | Madelyn Holleman   | C-Brightmoor               | Novi-MI         | 50    | 5.56   |    |
+| 30 | Henry Diller       | E-Guardians of God\'s Word | Cincinnati-OH   | 50    | 5.56   |    |
+| 31 | David Haynes       | E-Guardians of God\'s Word | Cincinnati-OH   | 35    | 3.89   |    |
+| 32 | Julia DeGraff      | D-Naperville               | Naperville-IL   | 20    | 2.22   |    |
+| 32 | Lynnae Chapman     | C-Brightmoor               | Novi-MI         | 20    | 2.22   |    |
+| 33 | Austin McCartney   | A-Greater Lansing          | East Lansing-MI | 10    | 1.11   |    |
+| 33 | Celah Convis       | A-Greater Lansing          | East Lansing-MI | 10    | 1.11   |    |
+| 33 | Joshua Davies      | A-Greater Lansing          | East Lansing-MI | 10    | 1.11   |    |
+| 33 | Gunnar Smart       | E-Guardians of God\'s Word | Cincinnati-OH   | 10    | 1.11   |    |
+| 34 | Elisabeth Nelson   | C-Brightmoor               | Novi-MI         |       | .00    |    |
+| 34 | Kendal Calvery     | D-Quadruple Threat         | Cedar Hill-TX   |       | .00    |    |
+| 34 | Toluwa Davies      | A-Greater Lansing          | East Lansing-MI |       | .00    |    |
+| 34 | Jack Convis        | A-Greater Lansing          | East Lansing-MI |       | .00    |    |
+| 34 | Eliott Gathman     | E-Blazing Swords           | Chesterfield-MO |       | .00    |    |
+| 35 | Ben Manoli         | D-Quadruple Threat         | Cedar Hill-TX   | -20   | -2.22  |    |
+| 35 | Megan Holleman     | C-Brightmoor               | Novi-MI         | -20   | -2.22  |    |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                     | Church           | W/L | Total | Avg    |
+|---:|--------------------------|------------------|-----|------:|-------:|
+| 1  | E-Soaring Eagles         | Poland-OH        | 7/2 | 1455  | 161.67 |
+| 2  | B-Faithful Falcons       | Austin-TX        | 6/3 | 1310  | 145.56 |
+| 3  | A-The Nerds              | Bismarck-ND      | 5/4 | 1270  | 141.11 |
+| 4  | D-Bible Treasure Seekers | Greensboro-NC    | 5/4 | 1355  | 150.56 |
+| 5  | C-International #1       | Warren-MI        | 4/5 | 1655  | 183.89 |
+| 6  | D-Grace Assembly of God  | New Whiteland-IN | 4/5 | 1290  | 143.33 |
+| 7  | D-SPY Warriors           | Kent-WA          | 4/5 | 1235  | 137.22 |
+| 8  | A-TLC Thunder & co.      | Elk River-MN     | 4/5 | 1185  | 131.67 |
+| 9  | B-E=MC3                  | Dallas-TX        | 3/6 | 1250  | 138.89 |
+| 10 | C-Tongues of Fire        | Louisville-KY    | 3/6 | 1190  | 132.22 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                     | Church           | Total | Avg    | QO |
+|---:|---------------------|--------------------------|------------------|------:|-------:|---:|
+| 1  | Jolia Madigan       | E-Soaring Eagles         | Poland-OH        | 935   | 103.89 | 3  |
+| 2  | Thomas Stewart      | A-TLC Thunder & co.      | Elk River-MN     | 905   | 100.56 | 6  |
+| 3  | Joel James          | B-Faithful Falcons       | Austin-TX        | 860   | 95.56  | 5  |
+| 4  | Joshua Sipes        | A-The Nerds              | Bismarck-ND      | 850   | 94.44  | 1  |
+| 5  | Gabrielle Davy      | D-SPY Warriors           | Kent-WA          | 770   | 85.56  | 3  |
+| 6  | Alecia Rajesh       | D-Bible Treasure Seekers | Greensboro-NC    | 740   | 82.22  | 2  |
+| 7  | Isaac Grey          | B-E=MC3                  | Dallas-TX        | 700   | 77.78  | 4  |
+| 8  | Jerrin George       | C-International #1       | Warren-MI        | 635   | 70.56  | 1  |
+| 9  | Cayden Wiggington   | D-Grace Assembly of God  | New Whiteland-IN | 545   | 60.56  | 1  |
+| 10 | Sarah Jacob         | C-International #1       | Warren-MI        | 470   | 52.22  |    |
+| 11 | Steven Torres       | B-E=MC3                  | Dallas-TX        | 415   | 46.11  | 1  |
+| 12 | Nick Richardson     | D-Grace Assembly of God  | New Whiteland-IN | 380   | 42.22  | 3  |
+| 13 | Trea Webb           | C-Tongues of Fire        | Louisville-KY    | 370   | 41.11  | 4  |
+| 14 | Olivia Madigan      | E-Soaring Eagles         | Poland-OH        | 360   | 40.00  | 2  |
+| 15 | Aidan Strain        | D-Grace Assembly of God  | New Whiteland-IN | 355   | 39.44  | 2  |
+| 16 | Abigail Prejean     | D-Bible Treasure Seekers | Greensboro-NC    | 340   | 37.78  | 1  |
+| 17 | Zachary John        | C-International #1       | Warren-MI        | 315   | 35.00  | 3  |
+| 18 | Lucie Price         | C-Tongues of Fire        | Louisville-KY    | 300   | 33.33  |    |
+| 18 | Luke Yantz          | C-Tongues of Fire        | Louisville-KY    | 300   | 33.33  |    |
+| 19 | Matthew Braham      | D-SPY Warriors           | Kent-WA          | 275   | 30.56  | 3  |
+| 20 | Joshua Sam          | C-International #1       | Warren-MI        | 235   | 26.11  | 1  |
+| 21 | Jonathan Green      | C-Tongues of Fire        | Louisville-KY    | 220   | 24.44  |    |
+| 22 | Lydia Kidroske      | D-Bible Treasure Seekers | Greensboro-NC    | 215   | 23.89  |    |
+| 23 | Jayden Freyer       | A-The Nerds              | Bismarck-ND      | 185   | 20.56  | 1  |
+| 24 | Samuel Birrell      | B-Faithful Falcons       | Austin-TX        | 175   | 19.44  | 1  |
+| 25 | Jessica Emeodi      | B-Faithful Falcons       | Austin-TX        | 165   | 18.33  |    |
+| 26 | David Swanson       | A-TLC Thunder & co.      | Elk River-MN     | 155   | 17.22  |    |
+| 27 | Michaela Toole      | D-SPY Warriors           | Kent-WA          | 145   | 16.11  |    |
+| 27 | Elijah Sauer        | A-The Nerds              | Bismarck-ND      | 145   | 16.11  |    |
+| 28 | Josiah Stewart      | A-TLC Thunder & co.      | Elk River-MN     | 125   | 13.89  |    |
+| 29 | Will Homrighausen   | E-Soaring Eagles         | Poland-OH        | 100   | 11.11  |    |
+| 30 | Brianna Sipes       | A-The Nerds              | Bismarck-ND      | 90    | 10.00  |    |
+| 31 | Hannah Stumper      | B-E=MC3                  | Dallas-TX        | 75    | 8.33   |    |
+| 32 | Josh James          | B-Faithful Falcons       | Austin-TX        | 60    | 6.67   |    |
+| 32 | Julia Martello      | D-Bible Treasure Seekers | Greensboro-NC    | 60    | 6.67   |    |
+| 32 | Ty Homrighausen     | E-Soaring Eagles         | Poland-OH        | 60    | 6.67   |    |
+| 32 | Abby Bennett        | B-E=MC3                  | Dallas-TX        | 60    | 6.67   |    |
+| 33 | Teddy Gutterud      | D-SPY Warriors           | Kent-WA          | 45    | 5.00   |    |
+| 34 | Samuel Sundararaman | B-Faithful Falcons       | Austin-TX        | 40    | 4.44   |    |
+| 35 | Alyssa Franklin     | D-Grace Assembly of God  | New Whiteland-IN | 10    | 1.11   |    |
+| 35 | Rebekah Birrell     | B-Faithful Falcons       | Austin-TX        | 10    | 1.11   |    |
+| 36 | Miranda Eggleston   | C-Tongues of Fire        | Louisville-KY    |       | .00    |    |
+| 36 | Austin Shepherd     | D-SPY Warriors           | Kent-WA          |       | .00    |    |
+| 36 | Teighlor Darnall    | D-Grace Assembly of God  | New Whiteland-IN |       | .00    |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                        | Church                  | W/L | Total | Avg    |
+|---:|-----------------------------|-------------------------|-----|------:|-------:|
+| 1  | A-OCCEC                     | Irvine-CA               | 7/2 | 1420  | 157.78 |
+| 2  | E-Westgate A1               | Edmonds-WA              | 7/2 | 1565  | 173.89 |
+| 3  | D-Word Warriors             | Flower Mound-TX         | 6/3 | 1515  | 168.33 |
+| 4  | A-JAG                       | Meriden-KS              | 6/3 | 1505  | 167.22 |
+| 5  | B-Quiz Kidz                 | Scotch Plains-NJ        | 5/4 | 1325  | 147.22 |
+| 6  | D-Askewville                | Windsor (Askewville)-NC | 4/5 | 1135  | 126.11 |
+| 7  | E-Awesome Answerers         | Billings-MT             | 4/5 | 1320  | 146.67 |
+| 8  | B-Word of Life Lightbearers | Springfield-VA          | 3/6 | 1225  | 136.11 |
+| 9  | C-MARS                      | Baxter-MN               | 2/7 | 1025  | 113.89 |
+| 10 | C-Memphis Advanced          | Cordova-TN              | 1/8 | 830   | 92.22  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer               | Team                        | Church                  | Total | Avg    | QO |
+|---:|-----------------------|-----------------------------|-------------------------|------:|-------:|---:|
+| 1  | Garrett Miyaoka       | E-Westgate A1               | Edmonds-WA              | 910   | 101.11 | 5  |
+| 2  | Harrison Ku           | A-OCCEC                     | Irvine-CA               | 780   | 86.67  | 3  |
+| 3  | Benshel Bright        | B-Quiz Kidz                 | Scotch Plains-NJ        | 620   | 68.89  | 1  |
+| 4  | Kaitlyn Ballard       | D-Word Warriors             | Flower Mound-TX         | 595   | 66.11  |    |
+| 5  | Jared Deppe           | C-Memphis Advanced          | Cordova-TN              | 570   | 63.33  | 1  |
+| 6  | Julia Rivera          | A-JAG                       | Meriden-KS              | 560   | 62.22  | 1  |
+| 7  | Divya Mathews         | B-Word of Life Lightbearers | Springfield-VA          | 505   | 56.11  | 1  |
+| 8  | Jeremy Wu             | A-OCCEC                     | Irvine-CA               | 470   | 52.22  | 5  |
+| 9  | Jonathan Moore        | A-JAG                       | Meriden-KS              | 455   | 50.56  |    |
+| 10 | Tessa Houde           | E-Awesome Answerers         | Billings-MT             | 440   | 48.89  |    |
+| 11 | Daniel Castello       | D-Askewville                | Windsor (Askewville)-NC | 435   | 48.33  | 1  |
+| 12 | Madie Rawlings        | D-Word Warriors             | Flower Mound-TX         | 420   | 46.67  | 1  |
+| 13 | Matthew Frick         | E-Awesome Answerers         | Billings-MT             | 415   | 46.11  | 3  |
+| 14 | Alex Rawlings         | D-Word Warriors             | Flower Mound-TX         | 410   | 45.56  | 4  |
+| 15 | Ben Harsha            | E-Awesome Answerers         | Billings-MT             | 410   | 45.56  | 1  |
+| 16 | Leah Thomas           | B-Word of Life Lightbearers | Springfield-VA          | 375   | 41.67  | 1  |
+| 17 | Stanley Thomas        | B-Quiz Kidz                 | Scotch Plains-NJ        | 375   | 41.67  |    |
+| 18 | Kyle Reichart         | A-JAG                       | Meriden-KS              | 365   | 40.56  | 4  |
+| 19 | Lynne Borowicz        | C-MARS                      | Baxter-MN               | 360   | 40.00  | 1  |
+| 20 | Brant Dabill          | C-MARS                      | Baxter-MN               | 335   | 37.22  | 2  |
+| 21 | Nicholas Tveit        | E-Westgate A1               | Edmonds-WA              | 320   | 35.56  | 3  |
+| 22 | Noah Ku               | E-Westgate A1               | Edmonds-WA              | 315   | 35.00  |    |
+| 23 | Eric Loschko          | C-MARS                      | Baxter-MN               | 310   | 34.44  | 2  |
+| 24 | Will Bazemore         | D-Askewville                | Windsor (Askewville)-NC | 265   | 29.44  | 1  |
+| 25 | Colton Hoggard        | D-Askewville                | Windsor (Askewville)-NC | 255   | 28.33  | 2  |
+| 26 | Calvin Lee            | A-OCCEC                     | Irvine-CA               | 170   | 18.89  |    |
+| 27 | Blessing Inyangson    | B-Word of Life Lightbearers | Springfield-VA          | 165   | 18.33  |    |
+| 28 | Abbigail Vaughan      | C-Memphis Advanced          | Cordova-TN              | 145   | 16.11  |    |
+| 29 | Cody Younger          | D-Askewville                | Windsor (Askewville)-NC | 135   | 15.00  | 1  |
+| 30 | Debi Tariku           | B-Word of Life Lightbearers | Springfield-VA          | 130   | 14.44  |    |
+| 31 | Joe Cheeli            | B-Quiz Kidz                 | Scotch Plains-NJ        | 115   | 12.78  |    |
+| 32 | James Harris          | A-JAG                       | Meriden-KS              | 95    | 10.56  |    |
+| 33 | Zeke Rashid           | D-Word Warriors             | Flower Mound-TX         | 90    | 10.00  |    |
+| 33 | Michael Fletcher      | B-Quiz Kidz                 | Scotch Plains-NJ        | 90    | 10.00  |    |
+| 34 | Josiah Baik           | B-Quiz Kidz                 | Scotch Plains-NJ        | 75    | 8.33   |    |
+| 35 | Nema Sarwar           | C-Memphis Advanced          | Cordova-TN              | 60    | 6.67   |    |
+| 36 | Julia Browning        | C-Memphis Advanced          | Cordova-TN              | 55    | 6.11   |    |
+| 36 | Jayda Houde           | E-Awesome Answerers         | Billings-MT             | 55    | 6.11   |    |
+| 37 | Anna Schafhauser      | B-Quiz Kidz                 | Scotch Plains-NJ        | 50    | 5.56   |    |
+| 37 | Nneka Eleogu          | B-Word of Life Lightbearers | Springfield-VA          | 50    | 5.56   |    |
+| 38 | Grace Todd            | D-Askewville                | Windsor (Askewville)-NC | 45    | 5.00   |    |
+| 39 | Colton Huffman        | A-JAG                       | Meriden-KS              | 30    | 3.33   |    |
+| 40 | Eva Dabill            | C-MARS                      | Baxter-MN               | 20    | 2.22   |    |
+| 40 | Anastasia Yevtushenko | E-Westgate A1               | Edmonds-WA              | 20    | 2.22   |    |
+| 41 | Robbie Hurt           | E-Awesome Answerers         | Billings-MT             |       | .00    |    |
+| 41 | Isabella Burt         | B-Word of Life Lightbearers | Springfield-VA          |       | .00    |    |
+| 41 | Grace Schafhauser     | B-Quiz Kidz                 | Scotch Plains-NJ        |       | .00    |    |
+| 41 | Emily Stevens         | C-MARS                      | Baxter-MN               |       | .00    |    |
+| 41 | Grace Riedel          | C-MARS                      | Baxter-MN               |       | .00    |    |
+| 41 | David Solomon         | B-Word of Life Lightbearers | Springfield-VA          |       | .00    |    |
+| 41 | Landon Lundeby        | C-MARS                      | Baxter-MN               |       | .00    |    |
+| 41 | Taylor Borowicz       | C-MARS                      | Baxter-MN               |       | .00    |    |
+

--- a/_pages/jbq/2012/index.md
+++ b/_pages/jbq/2012/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2012 JBQ Season"
+permalink: /jbq/2012/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+<a href="{% link _pages/jbq/2012/nationals.md %}" class="button is-primary">National Finals</a>
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2012/nationals.md
+++ b/_pages/jbq/2012/nationals.md
@@ -1,0 +1,1821 @@
+---
+layout: page
+title: "2012 National Festival: Orlando, FL"
+permalink: /jbq/2012/nationals/
+date: "2015-06-10"
+toc_title: Results
+menubar_toc: true
+---
+
+## Friday (AM)
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                            | Church           | W/L | Total | Avg    |
+|--:|---------------------------------|------------------|-----|------:|-------:|
+| 1 | Grace Assembly of God           | New Whiteland-IN | 6/1 | 1515  | 216.43 |
+| 2 | S.P.Y. Kids 007                 | Leesburg-VA      | 6/1 | 1205  | 172.14 |
+| 3 | Wilmington Warriors             | Wilmington-NC    | 6/1 | 1175  | 167.86 |
+| 4 | River of Life                   | Kent-WA          | 4/3 | 1035  | 147.86 |
+| 5 | Kidtricity                      | Montgomery-AL    | 2/5 | 940   | 134.29 |
+| 6 | Chosen Ones                     | Houston-TX       | 2/5 | 785   | 112.14 |
+| 7 | DAG Church                      | Decatur-AR       | 1/6 | 720   | 102.86 |
+| 8 | Bismarck Boppin\' Bible Buzzers | Bismarck-ND      | 1/6 | 755   | 107.86 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                            | Church           | Total | Avg   | QO |
+|---:|--------------------|---------------------------------|------------------|------:|------:|---:|
+| 1  | Christian Hart     | Kidtricity                      | Montgomery-AL    | 550   | 78.57 | 2  |
+| 2  | Claire Richardson  | Grace Assembly of God           | New Whiteland-IN | 525   | 75.00 | 3  |
+| 3  | Elliott Murray     | Grace Assembly of God           | New Whiteland-IN | 510   | 72.86 | 1  |
+| 4  | Mateo Cuadros      | River of Life                   | Kent-WA          | 505   | 72.14 |    |
+| 5  | Christian Shelton  | Wilmington Warriors             | Wilmington-NC    | 425   | 60.71 |    |
+| 6  | Sarah Judd         | S.P.Y. Kids 007                 | Leesburg-VA      | 395   | 56.43 | 4  |
+| 7  | Diana Bozzay       | S.P.Y. Kids 007                 | Leesburg-VA      | 370   | 52.86 | 2  |
+| 8  | Kaden Sago         | Bismarck Boppin\' Bible Buzzers | Bismarck-ND      | 350   | 50.00 | 1  |
+| 9  | Nick Richardson    | Grace Assembly of God           | New Whiteland-IN | 315   | 45.00 | 2  |
+| 10 | Rachel Mgbeike     | Chosen Ones                     | Houston-TX       | 315   | 45.00 | 1  |
+| 11 | Amanda Duncan      | DAG Church                      | Decatur-AR       | 305   | 43.57 | 1  |
+| 12 | Brooke Leingang    | Bismarck Boppin\' Bible Buzzers | Bismarck-ND      | 275   | 39.29 | 1  |
+| 13 | Luke Yoder         | S.P.Y. Kids 007                 | Leesburg-VA      | 275   | 39.29 |    |
+| 14 | Johnathan Terrones | River of Life                   | Kent-WA          | 250   | 35.71 | 1  |
+| 15 | Zachary Leake      | Wilmington Warriors             | Wilmington-NC    | 250   | 35.71 |    |
+| 16 | Micah Brown        | Kidtricity                      | Montgomery-AL    | 240   | 34.29 |    |
+| 17 | Matt Anderson      | DAG Church                      | Decatur-AR       | 235   | 33.57 | 1  |
+| 18 | Jeffrey Gutterud   | River of Life                   | Kent-WA          | 190   | 27.14 |    |
+| 19 | Braden Cumbo       | Wilmington Warriors             | Wilmington-NC    | 185   | 26.43 | 2  |
+| 20 | Trey Anderson      | DAG Church                      | Decatur-AR       | 180   | 25.71 |    |
+| 21 | Chimezirim Nwogu   | Chosen Ones                     | Houston-TX       | 170   | 24.29 | 1  |
+| 22 | Jillian Garrett    | Grace Assembly of God           | New Whiteland-IN | 155   | 22.14 |    |
+| 23 | James Patterson    | Kidtricity                      | Montgomery-AL    | 150   | 21.43 |    |
+| 24 | Andy Boehling      | Wilmington Warriors             | Wilmington-NC    | 150   | 21.43 |    |
+| 25 | Katherine Bozzay   | S.P.Y. Kids 007                 | Leesburg-VA      | 140   | 20.00 |    |
+| 26 | Vistoria Wooten    | Chosen Ones                     | Houston-TX       | 135   | 19.29 | 1  |
+| 27 | Rylan Sago         | Bismarck Boppin\' Bible Buzzers | Bismarck-ND      | 135   | 19.29 |    |
+| 28 | Greyson Kerns      | Wilmington Warriors             | Wilmington-NC    | 120   | 17.14 | 2  |
+| 29 | Emily Bulger       | River of Life                   | Kent-WA          | 95    | 13.57 |    |
+| 30 | Chizaram Ajiwe     | Chosen Ones                     | Houston-TX       | 90    | 12.86 |    |
+| 31 | Michael Wooten     | Chosen Ones                     | Houston-TX       | 55    | 7.86  |    |
+| 32 | Kierstin Childs    | Wilmington Warriors             | Wilmington-NC    | 45    | 6.43  |    |
+| 33 | Wayne Ellis        | Chosen Ones                     | Houston-TX       | 30    | 4.29  |    |
+| 34 | Emily Walsh        | S.P.Y. Kids 007                 | Leesburg-VA      | 25    | 3.57  |    |
+| 35 | Stephanie Oyolu    | Chosen Ones                     | Houston-TX       | 20    | 2.86  |    |
+| 36 | Ryan Shover        | Grace Assembly of God           | New Whiteland-IN | 10    | 1.43  |    |
+
+
+### Cream
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team            | Church           | W/L | Total | Avg    |
+|--:|-----------------|------------------|-----|------:|-------:|
+| 1 | Super Q\'s      | Lexington-TN     | 7/0 | 1385  | 197.86 |
+| 2 | Naperville (S)  | Naperville-IL    | 5/2 | 1570  | 224.29 |
+| 3 | Firefighters    | Sanford-FL       | 5/2 | 1070  | 152.86 |
+| 4 | Quiz Kidz       | Scotch Plains-NJ | 4/3 | 1080  | 154.29 |
+| 5 | D.D.D.          | Mustang-OK       | 3/4 | 820   | 117.14 |
+| 6 | Bible Saints    | Princeton-MN     | 3/4 | 805   | 115.00 |
+| 7 | Smileys         | Huntington-WV    | 1/6 | 805   | 115.00 |
+| 8 | Westgate A Team | Edmonds-WA       | 0/7 | 550   | 78.57  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team            | Church           | Total | Avg    | QO |
+|---:|-------------------|-----------------|------------------|------:|-------:|---:|
+| 1  | Jake Wolfe        | Naperville (S)  | Naperville-IL    | 890   | 127.14 | 5  |
+| 2  | Reuben Savage     | Super Q\'s      | Lexington-TN     | 880   | 125.71 | 5  |
+| 3  | Toby Robinson     | Firefighters    | Sanford-FL       | 725   | 103.57 | 2  |
+| 4  | Noah Hensley      | Smileys         | Huntington-WV    | 620   | 88.57  | 1  |
+| 5  | Will Wolfe        | Naperville (S)  | Naperville-IL    | 525   | 75.00  | 7  |
+| 6  | Stanley Thomas    | Quiz Kidz       | Scotch Plains-NJ | 505   | 72.14  | 3  |
+| 7  | Seth Savage       | Super Q\'s      | Lexington-TN     | 430   | 61.43  | 5  |
+| 8  | Noah Ku           | Westgate A Team | Edmonds-WA       | 380   | 54.29  | 1  |
+| 9  | Gabriella Hamvas  | Bible Saints    | Princeton-MN     | 365   | 52.14  | 2  |
+| 10 | Landon Grisham    | D.D.D.          | Mustang-OK       | 350   | 50.00  | 4  |
+| 11 | Jonathan Robinson | Firefighters    | Sanford-FL       | 335   | 47.86  | 3  |
+| 12 | Naomi Hagstrom    | Bible Saints    | Princeton-MN     | 325   | 46.43  | 1  |
+| 13 | Lauren Grisham    | D.D.D.          | Mustang-OK       | 210   | 30.00  |    |
+| 14 | Josiah Baik       | Quiz Kidz       | Scotch Plains-NJ | 195   | 27.86  | 2  |
+| 15 | Anna Schafhauser  | Quiz Kidz       | Scotch Plains-NJ | 195   | 27.86  |    |
+| 16 | Caleb Horn        | D.D.D.          | Mustang-OK       | 190   | 27.14  |    |
+| 17 | Josiah Tveit      | Westgate A Team | Edmonds-WA       | 170   | 24.29  | 2  |
+| 18 | Noel Siony        | Naperville (S)  | Naperville-IL    | 155   | 22.14  |    |
+| 19 | Benshel Bright    | Quiz Kidz       | Scotch Plains-NJ | 135   | 19.29  |    |
+| 20 | Wyatt Lawrence    | Bible Saints    | Princeton-MN     | 100   | 14.29  |    |
+| 21 | Mark Ziegler      | Smileys         | Huntington-WV    | 95    | 13.57  |    |
+| 22 | Kailan Weidner    | D.D.D.          | Mustang-OK       | 70    | 10.00  |    |
+| 23 | Caitlyn Leedy     | Smileys         | Huntington-WV    | 50    | 7.14   |    |
+| 24 | Shelby Webb       | Super Q\'s      | Lexington-TN     | 45    | 6.43   |    |
+| 25 | Julia White       | Smileys         | Huntington-WV    | 40    | 5.71   |    |
+| 26 | Grace Schafhauser | Quiz Kidz       | Scotch Plains-NJ | 30    | 4.29   |    |
+| 27 | Kyle Moos         | Bible Saints    | Princeton-MN     | 25    | 3.57   |    |
+| 28 | Joe Cheeli        | Quiz Kidz       | Scotch Plains-NJ | 20    | 2.86   |    |
+| 29 | Jacob Webb        | Super Q\'s      | Lexington-TN     | 20    | 2.86   |    |
+| 30 | Dylan Cotham      | Super Q\'s      | Lexington-TN     | 10    | 1.43   |    |
+| 31 | Jordan Perez      | Firefighters    | Sanford-FL       | 10    | 1.43   |    |
+| 32 | Wade Lawrence     | Bible Saints    | Princeton-MN     | 10    | 1.43   |    |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team               | Church           | W/L | Total | Avg    |
+|--:|--------------------|------------------|-----|------:|-------:|
+| 1 | Gideon\'s Army     | Huber Heights-OH | 6/1 | 1285  | 183.57 |
+| 2 | Bible Jammers      | Sanford-FL       | 5/2 | 1290  | 184.29 |
+| 3 | Fireball Quizzers  | Waxahachie-TX    | 4/3 | 1235  | 176.43 |
+| 4 | God\'s Girlz       | Surprise-AZ      | 4/3 | 1035  | 147.86 |
+| 5 | Spirit Squadron    | West Mifflin -PA | 3/4 | 965   | 137.86 |
+| 6 | Searcy Fruit Loops | Searcy-AR        | 3/4 | 800   | 114.29 |
+| 7 | BC United          | Wyckoff-NJ       | 2/5 | 910   | 130.00 |
+| 8 | Comets             | New Richmond-WI  | 1/6 | 565   | 80.71  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team               | Church           | Total | Avg    | QO |
+|---:|--------------------|--------------------|------------------|------:|-------:|---:|
+| 1  | Peyton Goss        | Bible Jammers      | Sanford-FL       | 820   | 117.14 | 4  |
+| 2  | Sean Jones         | Gideon\'s Army     | Huber Heights-OH | 700   | 100.00 | 4  |
+| 3  | Faith Brown        | God\'s Girlz       | Surprise-AZ      | 535   | 76.43  | 4  |
+| 4  | Reuben Deemy       | Fireball Quizzers  | Waxahachie-TX    | 470   | 67.14  | 2  |
+| 5  | Vinton Deemy       | Fireball Quizzers  | Waxahachie-TX    | 390   | 55.71  | 2  |
+| 6  | LeeAnn Harris      | Spirit Squadron    | West Mifflin -PA | 370   | 52.86  | 2  |
+| 7  | David Blomberg     | Comets             | New Richmond-WI  | 340   | 48.57  | 1  |
+| 8  | Kenzie Brown       | God\'s Girlz       | Surprise-AZ      | 340   | 48.57  | 1  |
+| 9  | Gabriel Ison       | Gideon\'s Army     | Huber Heights-OH | 330   | 47.14  | 4  |
+| 10 | Allison Shipman    | Searcy Fruit Loops | Searcy-AR        | 330   | 47.14  | 1  |
+| 11 | Andrew Emberson    | Searcy Fruit Loops | Searcy-AR        | 285   | 40.71  |    |
+| 12 | Aubrey Goss        | Bible Jammers      | Sanford-FL       | 265   | 37.86  | 1  |
+| 13 | Jeannah Jones      | Gideon\'s Army     | Huber Heights-OH | 235   | 33.57  |    |
+| 14 | Cayla Brodeur      | BC United          | Wyckoff-NJ       | 235   | 33.57  |    |
+| 15 | Cassidy Neal       | Bible Jammers      | Sanford-FL       | 205   | 29.29  |    |
+| 16 | Jaqueline Martinez | Fireball Quizzers  | Waxahachie-TX    | 190   | 27.14  | 1  |
+| 17 | Rachel Adelmann    | BC United          | Wyckoff-NJ       | 190   | 27.14  |    |
+| 18 | Reagan McCreary    | Spirit Squadron    | West Mifflin -PA | 170   | 24.29  | 2  |
+| 19 | Hannah Brown       | Spirit Squadron    | West Mifflin -PA | 170   | 24.29  |    |
+| 20 | Brennan McCreary   | Spirit Squadron    | West Mifflin -PA | 160   | 22.86  | 2  |
+| 21 | Todd Pettet        | BC United          | Wyckoff-NJ       | 160   | 22.86  |    |
+| 22 | Emanuel Lewis      | BC United          | Wyckoff-NJ       | 145   | 20.71  | 1  |
+| 23 | Kelsey McCafferty  | Spirit Squadron    | West Mifflin -PA | 130   | 18.57  |    |
+| 24 | Caleb Blomberg     | Comets             | New Richmond-WI  | 120   | 17.14  |    |
+| 25 | Michael Shipman    | Searcy Fruit Loops | Searcy-AR        | 105   | 15.00  |    |
+| 26 | McKenna Kollman    | God\'s Girlz       | Surprise-AZ      | 100   | 14.29  |    |
+| 27 | Emma Moorman       | BC United          | Wyckoff-NJ       | 100   | 14.29  |    |
+| 28 | Joelle Rapp        | Comets             | New Richmond-WI  | 95    | 13.57  |    |
+| 29 | Noah Saenz         | Fireball Quizzers  | Waxahachie-TX    | 85    | 12.14  |    |
+| 30 | Dakota Marsh       | Searcy Fruit Loops | Searcy-AR        | 80    | 11.43  |    |
+| 31 | Garrett Adelmann   | BC United          | Wyckoff-NJ       | 80    | 11.43  |    |
+| 32 | Maribel Castaneda  | Fireball Quizzers  | Waxahachie-TX    | 80    | 11.43  |    |
+| 33 | Hannah Smith       | God\'s Girlz       | Surprise-AZ      | 40    | 5.71   |    |
+| 34 | Ryleigh Jones      | Gideon\'s Army     | Huber Heights-OH | 20    | 2.86   |    |
+| 35 | Eli Saenz          | Fireball Quizzers  | Waxahachie-TX    | 20    | 2.86   |    |
+| 36 | Abigail Deshais    | God\'s Girlz       | Surprise-AZ      | 20    | 2.86   |    |
+| 37 | Mitchell Covey     | Comets             | New Richmond-WI  | 15    | 2.14   |    |
+
+
+### Mint
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                  | Church          | W/L | Total | Avg    |
+|--:|-----------------------|-----------------|-----|------:|-------:|
+| 1 | Naperville (C)        | Naperville-IL   | 6/1 | 1325  | 189.29 |
+| 2 | Team-LakeShore Church | Rockwall-TX     | 5/2 | 1185  | 169.29 |
+| 3 | Now-n-Laters          | Springfield-MO  | 5/2 | 1105  | 157.86 |
+| 4 | The Illuminators      | Lawson-MO       | 4/3 | 960   | 137.14 |
+| 5 | Freedom Fighters      | Collierville-TN | 3/4 | 810   | 115.71 |
+| 6 | Bethel Flames         | San Jose-CA     | 2/5 | 915   | 130.71 |
+| 7 | SALT                  | Greensboro-NC   | 2/5 | 885   | 126.43 |
+| 8 | CIA - Special Agents  | Mendon-MA       | 1/6 | 675   | 96.43  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                  | Church          | Total | Avg    | QO |
+|---:|-------------------|-----------------------|-----------------|------:|-------:|---:|
+| 1  | Shreanna Powell   | Naperville (C)        | Naperville-IL   | 890   | 127.14 | 5  |
+| 2  | Lily Slater       | Now-n-Laters          | Springfield-MO  | 690   | 98.57  | 6  |
+| 3  | Jonathan Archer   | The Illuminators      | Lawson-MO       | 565   | 80.71  | 1  |
+| 4  | Samy Gunaraj      | Freedom Fighters      | Collierville-TN | 560   | 80.00  | 2  |
+| 5  | Samuel Galloway   | Team-LakeShore Church | Rockwall-TX     | 510   | 72.86  | 3  |
+| 6  | Connor Patterson  | SALT                  | Greensboro-NC   | 490   | 70.00  | 1  |
+| 7  | Gabriel Roberts   | Bethel Flames         | San Jose-CA     | 490   | 70.00  | 1  |
+| 8  | Hannah Moer       | Team-LakeShore Church | Rockwall-TX     | 445   | 63.57  | 7  |
+| 9  | Sheldon Powell    | Naperville (C)        | Naperville-IL   | 330   | 47.14  | 4  |
+| 10 | Tayla Vannelli    | CIA - Special Agents  | Mendon-MA       | 290   | 41.43  |    |
+| 11 | Breanna Cole      | The Illuminators      | Lawson-MO       | 270   | 38.57  |    |
+| 12 | Samuel Jebaraj    | Bethel Flames         | San Jose-CA     | 245   | 35.00  |    |
+| 13 | Emma Moer         | Team-LakeShore Church | Rockwall-TX     | 220   | 31.43  | 1  |
+| 14 | Landon Clark      | Now-n-Laters          | Springfield-MO  | 210   | 30.00  |    |
+| 15 | John Georgiades   | Now-n-Laters          | Springfield-MO  | 195   | 27.86  |    |
+| 16 | Paul Daniel       | Bethel Flames         | San Jose-CA     | 180   | 25.71  | 2  |
+| 17 | Karina Settles    | SALT                  | Greensboro-NC   | 180   | 25.71  |    |
+| 18 | Shannon Morrill   | CIA - Special Agents  | Mendon-MA       | 175   | 25.00  | 1  |
+| 19 | Danielle Hanks    | Freedom Fighters      | Collierville-TN | 160   | 22.86  |    |
+| 20 | Fatih Caughey     | CIA - Special Agents  | Mendon-MA       | 155   | 22.14  | 1  |
+| 21 | Sarah Settles     | SALT                  | Greensboro-NC   | 145   | 20.71  |    |
+| 22 | Nick Cook         | The Illuminators      | Lawson-MO       | 125   | 17.86  |    |
+| 23 | Shaymis Powell    | Naperville (C)        | Naperville-IL   | 105   | 15.00  |    |
+| 24 | Trey Hanks        | Freedom Fighters      | Collierville-TN | 95    | 13.57  |    |
+| 25 | Isaiah Madonia    | SALT                  | Greensboro-NC   | 70    | 10.00  | 1  |
+| 26 | Michelle Vannelli | CIA - Special Agents  | Mendon-MA       | 55    | 7.86   |    |
+| 27 | Caleb Horsch      | Now-n-Laters          | Springfield-MO  | 10    | 1.43   |    |
+| 28 | Grant Fisher      | Team-LakeShore Church | Rockwall-TX     | 10    | 1.43   |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                       | Church        | W/L | Total | Avg    |
+|--:|----------------------------|---------------|-----|------:|-------:|
+| 1 | Guardians Of God\'s Word   | Cincinnati-OH | 6/1 | 1270  | 181.43 |
+| 2 | Bible Treasure Seekers     | Greensboro-NC | 6/1 | 1365  | 195.00 |
+| 3 | Harrison Thrashers         | Harrison-AR   | 5/2 | 1110  | 158.57 |
+| 4 | New Life Renton            | Renton-WA     | 5/2 | 1295  | 185.00 |
+| 5 | North Scottsdale Christian | Scottsdale-AZ | 2/5 | 875   | 125.00 |
+| 6 | S.O.S.                     | Mikwaukee-WI  | 2/5 | 865   | 123.57 |
+| 7 | Binghamton                 | Binghamton-NY | 1/6 | 575   | 82.14  |
+| 8 | Salt Shakers               | Lubbock-TX    | 1/6 | 680   | 97.14  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                 | Team                       | Church        | Total | Avg    | QO |
+|---:|-------------------------|----------------------------|---------------|------:|-------:|---:|
+| 1  | Russell Cook            | New Life Renton            | Renton-WA     | 845   | 120.71 | 5  |
+| 2  | Alecia Rajesh           | Bible Treasure Seekers     | Greensboro-NC | 740   | 105.71 | 2  |
+| 3  | Kerigan Bradshaw        | Harrison Thrashers         | Harrison-AR   | 645   | 92.14  | 5  |
+| 4  | Nathaniel Duncan        | S.O.S.                     | Mikwaukee-WI  | 595   | 85.00  | 3  |
+| 5  | Gunnar Smart            | Guardians Of God\'s Word   | Cincinnati-OH | 555   | 79.29  | 3  |
+| 6  | David Haynes            | Guardians Of God\'s Word   | Cincinnati-OH | 470   | 67.14  | 2  |
+| 7  | Abigail Prejean         | Bible Treasure Seekers     | Greensboro-NC | 390   | 55.71  | 3  |
+| 8  | David Moses             | North Scottsdale Christian | Scottsdale-AZ | 385   | 55.00  | 1  |
+| 9  | Holly Garrett           | North Scottsdale Christian | Scottsdale-AZ | 355   | 50.71  | 3  |
+| 10 | Brendon Johnson         | Salt Shakers               | Lubbock-TX    | 330   | 47.14  |    |
+| 11 | Nathan Jacobs           | New Life Renton            | Renton-WA     | 325   | 46.43  | 4  |
+| 12 | Angel McNeil            | Salt Shakers               | Lubbock-TX    | 305   | 43.57  |    |
+| 13 | Nicholas Dillon         | Harrison Thrashers         | Harrison-AR   | 290   | 41.43  |    |
+| 14 | Caleb Gerhart           | Binghamton                 | Binghamton-NY | 230   | 32.86  | 2  |
+| 15 | Lydia Kidroske          | Bible Treasure Seekers     | Greensboro-NC | 225   | 32.14  |    |
+| 16 | Nick Congdon            | Binghamton                 | Binghamton-NY | 195   | 27.86  | 1  |
+| 17 | Jessica Kyzer           | S.O.S.                     | Mikwaukee-WI  | 175   | 25.00  |    |
+| 18 | Josh Kiefer             | Guardians Of God\'s Word   | Cincinnati-OH | 155   | 22.14  |    |
+| 19 | Andrew Scarinzi         | Binghamton                 | Binghamton-NY | 150   | 21.43  |    |
+| 20 | Joanna Moses            | North Scottsdale Christian | Scottsdale-AZ | 125   | 17.86  |    |
+| 21 | Bethany Warren          | Harrison Thrashers         | Harrison-AR   | 115   | 16.43  |    |
+| 22 | Jack Titkemeyer         | Guardians Of God\'s Word   | Cincinnati-OH | 90    | 12.86  |    |
+| 23 | Caleb O\'Neil           | S.O.S.                     | Mikwaukee-WI  | 75    | 10.71  |    |
+| 24 | Ellen Jacobs            | New Life Renton            | Renton-WA     | 70    | 10.00  |    |
+| 25 | Kelton Johnson          | Salt Shakers               | Lubbock-TX    | 45    | 6.43   |    |
+| 26 | Isabel Paul             | Harrison Thrashers         | Harrison-AR   | 40    | 5.71   |    |
+| 27 | Shanessa Pooranampillai | New Life Renton            | Renton-WA     | 40    | 5.71   |    |
+| 28 | Micayla Herring         | Harrison Thrashers         | Harrison-AR   | 20    | 2.86   |    |
+| 29 | Samantha Pieper         | S.O.S.                     | Mikwaukee-WI  | 20    | 2.86   |    |
+| 30 | Gideon Jennings         | New Life Renton            | Renton-WA     | 15    | 2.14   |    |
+| 31 | Carmen Schmidt          | North Scottsdale Christian | Scottsdale-AZ | 10    | 1.43   |    |
+| 32 | Hannah Weagerle         | Bible Treasure Seekers     | Greensboro-NC | 10    | 1.43   |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team               | Church        | W/L | Total | Avg    |
+|--:|--------------------|---------------|-----|------:|-------:|
+| 1 | Naperville (J)     | Naperville-IL | 6/1 | 1515  | 216.43 |
+| 2 | Bible Boyz         | Orlando-FL    | 5/2 | 1175  | 167.86 |
+| 3 | Cedar Park Eagles  | Bothell-WA    | 4/3 | 1180  | 168.57 |
+| 4 | Truth Seekers      | Kearney-NE    | 4/3 | 1035  | 147.86 |
+| 5 | Double-Edged Sword | Irvine-CA     | 4/3 | 1020  | 145.71 |
+| 6 | Buzz Hogs          | Mabelvale-AR  | 3/4 | 690   | 98.57  |
+| 7 | Kansas Jayhawks    | Great Bend-KS | 2/5 | 725   | 103.57 |
+| 8 | Vailsburg Victors  | Newark-NJ     | 0/7 | 710   | 101.43 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team               | Church        | Total | Avg    | QO |
+|---:|---------------------|--------------------|---------------|------:|-------:|---:|
+| 1  | Jessica McElwee     | Naperville (J)     | Naperville-IL | 950   | 135.71 | 5  |
+| 2  | Moriah Johnson      | Truth Seekers      | Kearney-NE    | 605   | 86.43  | 2  |
+| 3  | Reid Jarrell        | Cedar Park Eagles  | Bothell-WA    | 575   | 82.14  | 4  |
+| 4  | Jonathan Haung      | Double-Edged Sword | Irvine-CA     | 530   | 75.71  | 3  |
+| 5  | Brooklyne Sederwall | Vailsburg Victors  | Newark-NJ     | 420   | 60.00  |    |
+| 6  | Jonah Woodbine      | Bible Boyz         | Orlando-FL    | 365   | 52.14  | 1  |
+| 7  | Ty Silas            | Naperville (J)     | Naperville-IL | 345   | 49.29  | 5  |
+| 8  | Grant Gorc          | Cedar Park Eagles  | Bothell-WA    | 340   | 48.57  | 3  |
+| 9  | Nathan Henderson    | Bible Boyz         | Orlando-FL    | 330   | 47.14  | 3  |
+| 10 | Jared Minick        | Buzz Hogs          | Mabelvale-AR  | 330   | 47.14  |    |
+| 11 | Korbin Widiger      | Kansas Jayhawks    | Great Bend-KS | 320   | 45.71  |    |
+| 12 | Savanah Biniakewitz | Buzz Hogs          | Mabelvale-AR  | 285   | 40.71  | 2  |
+| 13 | Jordan Woodbine     | Bible Boyz         | Orlando-FL    | 280   | 40.00  |    |
+| 14 | Tykus Gans          | Truth Seekers      | Kearney-NE    | 225   | 32.14  | 1  |
+| 15 | Jorge Suarez        | Bible Boyz         | Orlando-FL    | 200   | 28.57  |    |
+| 16 | Abby MacKinney      | Kansas Jayhawks    | Great Bend-KS | 180   | 25.71  |    |
+| 17 | Fran-jec Makoule    | Vailsburg Victors  | Newark-NJ     | 175   | 25.00  | 1  |
+| 18 | Kellen Fairfield    | Cedar Park Eagles  | Bothell-WA    | 175   | 25.00  |    |
+| 19 | Calvin Lee          | Double-Edged Sword | Irvine-CA     | 175   | 25.00  |    |
+| 20 | Erin Laboy          | Naperville (J)     | Naperville-IL | 145   | 20.71  |    |
+| 21 | Elijah Wentz        | Truth Seekers      | Kearney-NE    | 125   | 17.86  |    |
+| 22 | Christopher Yen     | Double-Edged Sword | Irvine-CA     | 110   | 15.71  |    |
+| 23 | Robby Brining       | Kansas Jayhawks    | Great Bend-KS | 100   | 14.29  |    |
+| 24 | Sierra Waugh        | Truth Seekers      | Kearney-NE    | 80    | 11.43  |    |
+| 25 | Joshua Zhang        | Double-Edged Sword | Irvine-CA     | 75    | 10.71  | 1  |
+| 26 | Justiss Silas       | Naperville (J)     | Naperville-IL | 75    | 10.71  |    |
+| 27 | Joshua Zou          | Double-Edged Sword | Irvine-CA     | 65    | 9.29   |    |
+| 28 | Andrew Li           | Double-Edged Sword | Irvine-CA     | 65    | 9.29   |    |
+| 29 | Lisa Marlow         | Kansas Jayhawks    | Great Bend-KS | 65    | 9.29   |    |
+| 30 | Mia Howell          | Vailsburg Victors  | Newark-NJ     | 60    | 8.57   |    |
+| 31 | Cecily Houser       | Cedar Park Eagles  | Bothell-WA    | 55    | 7.86   |    |
+| 32 | Acacia Todd         | Vailsburg Victors  | Newark-NJ     | 55    | 7.86   |    |
+| 33 | Levi Biniakewitz    | Buzz Hogs          | Mabelvale-AR  | 50    | 7.14   |    |
+| 34 | Joshuah Muiruri     | Kansas Jayhawks    | Great Bend-KS | 45    | 6.43   |    |
+| 35 | Gabe Waggoner       | Cedar Park Eagles  | Bothell-WA    | 40    | 5.71   |    |
+| 36 | Darius Crawford     | Buzz Hogs          | Mabelvale-AR  | 25    | 3.57   |    |
+| 37 | Skyler Mayhan       | Kansas Jayhawks    | Great Bend-KS | 20    | 2.86   |    |
+
+
+### Silver
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                                                | Church             | W/L | Total | Avg    |
+|--:|-----------------------------------------------------|--------------------|-----|------:|-------:|
+| 1 | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO         | 6/1 | 1225  | 175.00 |
+| 2 | MCC Sonburst Bible Stars                            | Mechanicsville,-VA | 5/2 | 1110  | 158.57 |
+| 3 | 3 Men & A Lady                                      | Gahanna-OH         | 5/2 | 1070  | 152.86 |
+| 4 | Lightning on Sundae                                 | Bonifay-FL         | 3/4 | 975   | 139.29 |
+| 5 | TNT                                                 | Louisville-KY      | 3/4 | 1030  | 147.14 |
+| 6 | Brickmasters                                        | Racine-WI          | 2/5 | 935   | 133.57 |
+| 7 | JAG                                                 | Meriden-KS         | 2/5 | 855   | 122.14 |
+| 8 | IAG Soaring Eagles                                  | Gilbert-AZ         | 2/5 | 855   | 122.14 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer          | Team                                                | Church             | Total | Avg    | QO |
+|---:|------------------|-----------------------------------------------------|--------------------|------:|-------:|---:|
+| 1  | Megumi Sinniah   | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO         | 850   | 121.43 | 5  |
+| 2  | Brenden Kent     | 3 Men & A Lady                                      | Gahanna-OH         | 845   | 120.71 | 3  |
+| 3  | Noah Barnes      | TNT                                                 | Louisville-KY      | 540   | 77.14  | 2  |
+| 4  | Rebekah Toeller  | Brickmasters                                        | Racine-WI          | 505   | 72.14  | 1  |
+| 5  | Jomi Malayil     | IAG Soaring Eagles                                  | Gilbert-AZ         | 420   | 60.00  | 2  |
+| 6  | Andrew Warren    | Lightning on Sundae                                 | Bonifay-FL         | 405   | 57.86  |    |
+| 7  | Griffin Simpson  | MCC Sonburst Bible Stars                            | Mechanicsville,-VA | 365   | 52.14  | 4  |
+| 8  | Nathan Kuenzi    | JAG                                                 | Meriden-KS         | 350   | 50.00  | 4  |
+| 9  | Julia Rivera     | JAG                                                 | Meriden-KS         | 350   | 50.00  | 1  |
+| 10 | Holly Bowen      | MCC Sonburst Bible Stars                            | Mechanicsville,-VA | 280   | 40.00  |    |
+| 11 | Joanne Sinniah   | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO         | 265   | 37.86  |    |
+| 12 | Trevor Webb      | TNT                                                 | Louisville-KY      | 255   | 36.43  |    |
+| 13 | JJ Paul          | Lightning on Sundae                                 | Bonifay-FL         | 245   | 35.00  | 2  |
+| 14 | Trea Webb        | TNT                                                 | Louisville-KY      | 235   | 33.57  | 3  |
+| 15 | Reanna Toeller   | Brickmasters                                        | Racine-WI          | 235   | 33.57  |    |
+| 16 | Nathaniel Walker | MCC Sonburst Bible Stars                            | Mechanicsville,-VA | 235   | 33.57  |    |
+| 17 | Noah Zook        | MCC Sonburst Bible Stars                            | Mechanicsville,-VA | 230   | 32.86  |    |
+| 18 | Jacob Smith      | 3 Men & A Lady                                      | Gahanna-OH         | 230   | 32.86  |    |
+| 19 | Michelle Koshy   | IAG Soaring Eagles                                  | Gilbert-AZ         | 225   | 32.14  |    |
+| 20 | Madison Ealum    | Lightning on Sundae                                 | Bonifay-FL         | 160   | 22.86  |    |
+| 21 | Jayden Garrison  | Brickmasters                                        | Racine-WI          | 145   | 20.71  | 1  |
+| 22 | Jonathan Moore   | JAG                                                 | Meriden-KS         | 130   | 18.57  |    |
+| 23 | Emilie Justice   | Lightning on Sundae                                 | Bonifay-FL         | 120   | 17.14  |    |
+| 24 | Landon Holloway  | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO         | 110   | 15.71  | 1  |
+| 25 | Gavin Kuruvilla  | IAG Soaring Eagles                                  | Gilbert-AZ         | 80    | 11.43  |    |
+| 26 | Albin Mathew     | IAG Soaring Eagles                                  | Gilbert-AZ         | 70    | 10.00  |    |
+| 27 | Joel Joseph      | IAG Soaring Eagles                                  | Gilbert-AZ         | 70    | 10.00  |    |
+| 28 | Morgan Zepp      | Lightning on Sundae                                 | Bonifay-FL         | 45    | 6.43   |    |
+| 29 | Sam David        | Brickmasters                                        | Racine-WI          | 35    | 5.00   |    |
+| 30 | Joshua Wearne    | JAG                                                 | Meriden-KS         | 25    | 3.57   |    |
+| 31 | Brandon Baer     | Brickmasters                                        | Racine-WI          | 20    | 2.86   |    |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                     | Church             | W/L | Total | Avg    |
+|--:|--------------------------|--------------------|-----|------:|-------:|
+| 1 | CRK Almighty             | Gloucester City-NJ | 7/0 | 1285  | 183.57 |
+| 2 | Tribulation Force        | Red Oak-TX         | 5/2 | 1170  | 167.14 |
+| 3 | Fort Wayne: Team Solomon | Fort Wayne-IN      | 5/2 | 1285  | 183.57 |
+| 4 | First Responders         | Ozark-MO           | 3/4 | 785   | 112.14 |
+| 5 | FIRE                     | Norcross-GA        | 3/4 | 945   | 135.00 |
+| 6 | Torches of Truth         | Humble-TX          | 2/5 | 655   | 93.57  |
+| 7 | Bethel Eagles            | San Jose-CA        | 2/5 | 835   | 119.29 |
+| 8 | XBOX                     | Lakeville-MN       | 1/6 | 880   | 125.71 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                    | Team                     | Church             | Total | Avg    | QO |
+|---:|----------------------------|--------------------------|--------------------|------:|-------:|---:|
+| 1  | Landin Jacquay             | Fort Wayne: Team Solomon | Fort Wayne-IN      | 725   | 103.57 | 4  |
+| 2  | Sydney Ames                | XBOX                     | Lakeville-MN       | 545   | 77.86  | 1  |
+| 3  | David Hipshire             | Tribulation Force        | Red Oak-TX         | 520   | 74.29  | 1  |
+| 4  | Ronald George              | FIRE                     | Norcross-GA        | 500   | 71.43  | 1  |
+| 5  | Jillian Angeles            | CRK Almighty             | Gloucester City-NJ | 455   | 65.00  |    |
+| 6  | Timothy Nirmal             | Bethel Eagles            | San Jose-CA        | 405   | 57.86  | 1  |
+| 7  | Gunnar Bundrick            | Tribulation Force        | Red Oak-TX         | 390   | 55.71  | 6  |
+| 8  | Micah Tonsing              | First Responders         | Ozark-MO           | 355   | 50.71  | 1  |
+| 9  | Elijah Abad                | CRK Almighty             | Gloucester City-NJ | 320   | 45.71  | 1  |
+| 10 | Dylan Stewart              | Fort Wayne: Team Solomon | Fort Wayne-IN      | 285   | 40.71  | 4  |
+| 11 | Kelise Bratihwaite         | First Responders         | Ozark-MO           | 275   | 39.29  | 1  |
+| 12 | Russell Flores             | CRK Almighty             | Gloucester City-NJ | 265   | 37.86  |    |
+| 13 | Joseph Raines              | Torches of Truth         | Humble-TX          | 250   | 35.71  |    |
+| 14 | Jacob Flores               | CRK Almighty             | Gloucester City-NJ | 245   | 35.00  | 1  |
+| 15 | Alvin Johann Vasanthakumar | FIRE                     | Norcross-GA        | 235   | 33.57  | 1  |
+| 16 | David Daniel               | Bethel Eagles            | San Jose-CA        | 215   | 30.71  | 1  |
+| 17 | Joseph Nguyen              | Torches of Truth         | Humble-TX          | 200   | 28.57  | 1  |
+| 18 | Emmanuel Joshua Yesudasan  | FIRE                     | Norcross-GA        | 200   | 28.57  |    |
+| 19 | Jonathan Turner            | Torches of Truth         | Humble-TX          | 175   | 25.00  |    |
+| 20 | Tabitha Nirmal             | Bethel Eagles            | San Jose-CA        | 165   | 23.57  | 1  |
+| 21 | Grant Hoggard              | Tribulation Force        | Red Oak-TX         | 165   | 23.57  |    |
+| 22 | Kyle Ringley               | XBOX                     | Lakeville-MN       | 150   | 21.43  |    |
+| 23 | Seth King                  | Fort Wayne: Team Solomon | Fort Wayne-IN      | 120   | 17.14  |    |
+| 24 | Gabby Ringley              | XBOX                     | Lakeville-MN       | 120   | 17.14  |    |
+| 25 | Brady Coleman              | Tribulation Force        | Red Oak-TX         | 95    | 13.57  |    |
+| 26 | Grayson Vestergaard        | Fort Wayne: Team Solomon | Fort Wayne-IN      | 90    | 12.86  |    |
+| 27 | Josiah Tonsing             | First Responders         | Ozark-MO           | 85    | 12.14  |    |
+| 28 | Braden Shinn               | Fort Wayne: Team Solomon | Fort Wayne-IN      | 55    | 7.86   |    |
+| 29 | Jabez Williams             | Bethel Eagles            | San Jose-CA        | 50    | 7.14   |    |
+| 30 | Kambria Braithwaite        | First Responders         | Ozark-MO           | 50    | 7.14   |    |
+| 31 | Zach Morara                | XBOX                     | Lakeville-MN       | 40    | 5.71   |    |
+| 32 | Kaitlyn Mohr               | XBOX                     | Lakeville-MN       | 30    | 4.29   |    |
+| 33 | Johnny Nguyen              | Torches of Truth         | Humble-TX          | 30    | 4.29   |    |
+| 34 | Kosette Braithwaite        | First Responders         | Ozark-MO           | 20    | 2.86   |    |
+| 35 | Sierra Jacquay             | Fort Wayne: Team Solomon | Fort Wayne-IN      | 10    | 1.43   |    |
+| 36 | Eunice Stephen             | FIRE                     | Norcross-GA        | 10    | 1.43   |    |
+
+
+### White
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church           | W/L | Total | Avg    |
+|--:|---------------------------|------------------|-----|------:|-------:|
+| 1 | Red Sea                   | Yorkville-IL     | 6/1 | 1225  | 175.00 |
+| 2 | Word of Life Lightbearers | Springfield-VA   | 5/2 | 1085  | 155.00 |
+| 3 | Two boys n the Houdes     | Billings-MT      | 5/2 | 1295  | 185.00 |
+| 4 | Bethlehem Church          | Richmond Hill-NY | 4/3 | 995   | 142.14 |
+| 5 | Word Warriors             | Flower Mound-TX  | 3/4 | 1000  | 142.86 |
+| 6 | 105                       | Wesley Chapel-FL | 2/5 | 865   | 123.57 |
+| 7 | Masters                   | Dodson-LA        | 2/5 | 455   | 65.00  |
+| 8 | DSI                       | Lakeville-MN     | 1/6 | 655   | 93.57  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                      | Church           | Total | Avg    | QO |
+|---:|--------------------|---------------------------|------------------|------:|-------:|---:|
+| 1  | Tanner Laffey      | Red Sea                   | Yorkville-IL     | 720   | 102.86 | 4  |
+| 2  | Matthew Frick      | Two boys n the Houdes     | Billings-MT      | 465   | 66.43  | 5  |
+| 3  | Madie Rawlings     | Word Warriors             | Flower Mound-TX  | 450   | 64.29  |    |
+| 4  | Tessa Houde        | Two boys n the Houdes     | Billings-MT      | 430   | 61.43  |    |
+| 5  | Debie Tariku       | Word of Life Lightbearers | Springfield-VA   | 395   | 56.43  | 3  |
+| 6  | Sara Ann Haimchand | Bethlehem Church          | Richmond Hill-NY | 380   | 54.29  | 4  |
+| 7  | Catrina Palmer     | 105                       | Wesley Chapel-FL | 365   | 52.14  |    |
+| 8  | Ben Harsha         | Two boys n the Houdes     | Billings-MT      | 335   | 47.86  |    |
+| 9  | Helyn Dunn         | 105                       | Wesley Chapel-FL | 325   | 46.43  | 1  |
+| 10 | My\'Randa Tolar    | Masters                   | Dodson-LA        | 305   | 43.57  | 1  |
+| 11 | Trinity Garza      | Red Sea                   | Yorkville-IL     | 295   | 42.14  | 2  |
+| 12 | Joy Okafor         | Bethlehem Church          | Richmond Hill-NY | 285   | 40.71  |    |
+| 13 | Alex Rawlings      | Word Warriors             | Flower Mound-TX  | 280   | 40.00  | 2  |
+| 14 | Ashton Heath       | DSI                       | Lakeville-MN     | 260   | 37.14  |    |
+| 15 | Blessing Inyangson | Word of Life Lightbearers | Springfield-VA   | 245   | 35.00  |    |
+| 16 | Lauren Oliver      | Word Warriors             | Flower Mound-TX  | 240   | 34.29  |    |
+| 17 | Bryce Lofton       | DSI                       | Lakeville-MN     | 235   | 33.57  | 2  |
+| 18 | Joshua Persad      | Bethlehem Church          | Richmond Hill-NY | 195   | 27.86  |    |
+| 19 | Gigi Palmer        | 105                       | Wesley Chapel-FL | 175   | 25.00  | 1  |
+| 20 | Isabella Burt      | Word of Life Lightbearers | Springfield-VA   | 175   | 25.00  |    |
+| 21 | Jonathan Ogebe     | Word of Life Lightbearers | Springfield-VA   | 135   | 19.29  | 1  |
+| 22 | Omrane Ouedraogo   | Word of Life Lightbearers | Springfield-VA   | 135   | 19.29  | 1  |
+| 23 | Kaylen Williams    | Masters                   | Dodson-LA        | 110   | 15.71  |    |
+| 24 | Sharon Morara      | DSI                       | Lakeville-MN     | 90    | 12.86  |    |
+| 25 | Emily Singh        | Bethlehem Church          | Richmond Hill-NY | 75    | 10.71  |    |
+| 26 | Savannah Reid      | DSI                       | Lakeville-MN     | 70    | 10.00  |    |
+| 27 | Trey Madsen        | Red Sea                   | Yorkville-IL     | 70    | 10.00  |    |
+| 28 | Jayda Houde        | Two boys n the Houdes     | Billings-MT      | 65    | 9.29   |    |
+| 29 | Destiny Garza      | Red Sea                   | Yorkville-IL     | 55    | 7.86   |    |
+| 30 | Dwayne Bacchus     | Bethlehem Church          | Richmond Hill-NY | 50    | 7.14   |    |
+| 31 | Trenton Miller     | Red Sea                   | Yorkville-IL     | 45    | 6.43   |    |
+| 32 | Peter Graunke      | Red Sea                   | Yorkville-IL     | 40    | 5.71   |    |
+| 33 | Skyla Walker       | Masters                   | Dodson-LA        | 40    | 5.71   |    |
+| 34 | Jonny Parker       | Word Warriors             | Flower Mound-TX  | 30    | 4.29   |    |
+| 35 | Joshua Gangaram    | Bethlehem Church          | Richmond Hill-NY | 10    | 1.43   |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church           | W/L | Total | Avg    |
+|--:|---------------------------|------------------|-----|------:|-------:|
+| 1 | Kids for Christ           | Fergus Falls-MN  | 6/1 | 1305  | 186.43 |
+| 2 | Quadruple Threat + 2      | Cedar Hill-TX    | 6/1 | 1225  | 175.00 |
+| 3 | NERDS                     | Bismarck-ND      | 6/1 | 1090  | 155.71 |
+| 4 | Warriors in Training      | Columbiaville-MI | 4/3 | 1040  | 148.57 |
+| 5 | New Life Pineville        | Waxhaw-NC        | 3/4 | 845   | 120.71 |
+| 6 | Knights in Shining Armour | Springfield-MO   | 2/5 | 990   | 141.43 |
+| 7 | PCC Giant Slayers         | Portland-OR      | 1/6 | 715   | 102.14 |
+| 8 | Eternal Eight             | Hamburg-PA       | 0/7 | 600   | 85.71  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                      | Church           | Total | Avg   | QO |
+|---:|-------------------|---------------------------|------------------|------:|------:|---:|
+| 1  | Joshua Sipes      | NERDS                     | Bismarck-ND      | 595   | 85.00 | 2  |
+| 2  | Parker Lubbe      | Quadruple Threat + 2      | Cedar Hill-TX    | 570   | 81.43 | 2  |
+| 3  | Hudson Hollin     | Warriors in Training      | Columbiaville-MI | 545   | 77.86 | 1  |
+| 4  | Emma Wolfe        | Knights in Shining Armour | Springfield-MO   | 445   | 63.57 | 3  |
+| 5  | Daniel Duran Jr.  | PCC Giant Slayers         | Portland-OR      | 395   | 56.43 |    |
+| 6  | Benjamin Beekman  | New Life Pineville        | Waxhaw-NC        | 395   | 56.43 |    |
+| 7  | Micah Demmer      | Kids for Christ           | Fergus Falls-MN  | 380   | 54.29 | 3  |
+| 8  | Hunter Hollin     | Warriors in Training      | Columbiaville-MI | 350   | 50.00 | 3  |
+| 9  | Jamison Price     | Quadruple Threat + 2      | Cedar Hill-TX    | 345   | 49.29 | 5  |
+| 10 | Celestine Demmer  | Kids for Christ           | Fergus Falls-MN  | 340   | 48.57 |    |
+| 11 | Levi Cooper       | Knights in Shining Armour | Springfield-MO   | 335   | 47.86 | 1  |
+| 12 | Elizabeth Beekman | New Life Pineville        | Waxhaw-NC        | 325   | 46.43 | 3  |
+| 13 | RuthAnn Demmer    | Kids for Christ           | Fergus Falls-MN  | 315   | 45.00 |    |
+| 14 | Jayden Freyer     | NERDS                     | Bismarck-ND      | 310   | 44.29 | 4  |
+| 15 | Mariah Seidel     | Kids for Christ           | Fergus Falls-MN  | 260   | 37.14 |    |
+| 16 | Kendall Calvery   | Quadruple Threat + 2      | Cedar Hill-TX    | 240   | 34.29 |    |
+| 17 | Trey Crowley      | Eternal Eight             | Hamburg-PA       | 225   | 32.14 | 1  |
+| 18 | Gabe Loper        | Knights in Shining Armour | Springfield-MO   | 200   | 28.57 |    |
+| 19 | Ashlyn Sipes      | NERDS                     | Bismarck-ND      | 175   | 25.00 | 1  |
+| 20 | Joey Huntley      | Warriors in Training      | Columbiaville-MI | 145   | 20.71 |    |
+| 21 | Evan Llafet       | PCC Giant Slayers         | Portland-OR      | 135   | 19.29 | 1  |
+| 22 | Isaac Wuerffel    | New Life Pineville        | Waxhaw-NC        | 125   | 17.86 |    |
+| 23 | Sierra Fisher     | Eternal Eight             | Hamburg-PA       | 120   | 17.14 |    |
+| 24 | Abigail Bartynski | Eternal Eight             | Hamburg-PA       | 100   | 14.29 |    |
+| 25 | Emiliano Duran    | PCC Giant Slayers         | Portland-OR      | 100   | 14.29 |    |
+| 26 | Ari Lauthner      | PCC Giant Slayers         | Portland-OR      | 90    | 12.86 |    |
+| 27 | Timothy Crowley   | Eternal Eight             | Hamburg-PA       | 60    | 8.57  |    |
+| 28 | Gabriella Keim    | Eternal Eight             | Hamburg-PA       | 40    | 5.71  |    |
+| 29 | Thomas Pospisil   | Eternal Eight             | Hamburg-PA       | 30    | 4.29  |    |
+| 30 | Emma Miller       | Quadruple Threat + 2      | Cedar Hill-TX    | 30    | 4.29  |    |
+| 31 | Carley Cox        | Eternal Eight             | Hamburg-PA       | 30    | 4.29  |    |
+| 32 | Triston Rosario   | Quadruple Threat + 2      | Cedar Hill-TX    | 20    | 2.86  |    |
+| 33 | Joshua Baragas    | Quadruple Threat + 2      | Cedar Hill-TX    | 20    | 2.86  |    |
+| 34 | Hannah Eckhardt   | Kids for Christ           | Fergus Falls-MN  | 10    | 1.43  |    |
+| 35 | Zeke Loper        | Knights in Shining Armour | Springfield-MO   | 10    | 1.43  |    |
+| 36 | Derek Leingang    | NERDS                     | Bismarck-ND      | 10    | 1.43  |    |
+
+
+## Friday (PM)
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                  | Church        | W/L | Total | Avg    |
+|--:|-----------------------|---------------|-----|------:|-------:|
+| 1 | Super Q\'s            | Lexington-TN  | 5/2 | 1045  | 149.29 |
+| 2 | Bible Jammers         | Sanford-FL    | 4/3 | 1055  | 150.71 |
+| 3 | Team-LakeShore Church | Rockwall-TX   | 4/3 | 990   | 141.43 |
+| 4 | Wilmington Warriors   | Wilmington-NC | 4/3 | 905   | 129.29 |
+| 5 | Cedar Park Eagles     | Bothell-WA    | 4/3 | 755   | 107.86 |
+| 6 | Red Sea               | Yorkville-IL  | 3/4 | 1065  | 152.14 |
+| 7 | New Life Renton       | Renton-WA     | 3/4 | 875   | 125.00 |
+| 8 | Lightning on Sundae   | Bonifay-FL    | 1/6 | 735   | 105.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                  | Church        | Total | Avg    | QO |
+|---:|-------------------|-----------------------|---------------|------:|-------:|---:|
+| 1  | Reuben Savage     | Super Q\'s            | Lexington-TN  | 790   | 112.86 | 4  |
+| 2  | Tanner Laffey     | Red Sea               | Yorkville-IL  | 640   | 91.43  | 4  |
+| 3  | Russell Cook      | New Life Renton       | Renton-WA     | 565   | 80.71  | 3  |
+| 4  | Peyton Goss       | Bible Jammers         | Sanford-FL    | 540   | 77.14  | 1  |
+| 5  | Samuel Galloway   | Team-LakeShore Church | Rockwall-TX   | 430   | 61.43  | 1  |
+| 6  | Christian Shelton | Wilmington Warriors   | Wilmington-NC | 380   | 54.29  |    |
+| 7  | Hannah Moer       | Team-LakeShore Church | Rockwall-TX   | 355   | 50.71  | 4  |
+| 8  | Reid Jarrell      | Cedar Park Eagles     | Bothell-WA    | 300   | 42.86  | 1  |
+| 9  | Aubrey Goss       | Bible Jammers         | Sanford-FL    | 280   | 40.00  | 3  |
+| 10 | Andrew Warren     | Lightning on Sundae   | Bonifay-FL    | 275   | 39.29  |    |
+| 11 | Trinity Garza     | Red Sea               | Yorkville-IL  | 250   | 35.71  | 2  |
+| 12 | Cassidy Neal      | Bible Jammers         | Sanford-FL    | 235   | 33.57  |    |
+| 13 | Zachary Leake     | Wilmington Warriors   | Wilmington-NC | 205   | 29.29  |    |
+| 14 | Seth Savage       | Super Q\'s            | Lexington-TN  | 185   | 26.43  | 3  |
+| 15 | Nathan Jacobs     | New Life Renton       | Renton-WA     | 180   | 25.71  | 2  |
+| 16 | Cecily Houser     | Cedar Park Eagles     | Bothell-WA    | 180   | 25.71  |    |
+| 17 | Greyson Kerns     | Wilmington Warriors   | Wilmington-NC | 175   | 25.00  | 1  |
+| 18 | Grant Gorc        | Cedar Park Eagles     | Bothell-WA    | 170   | 24.29  | 1  |
+| 19 | Emma Moer         | Team-LakeShore Church | Rockwall-TX   | 165   | 23.57  |    |
+| 20 | Emilie Justice    | Lightning on Sundae   | Bonifay-FL    | 160   | 22.86  |    |
+| 21 | Ellen Jacobs      | New Life Renton       | Renton-WA     | 125   | 17.86  |    |
+| 22 | JJ Paul           | Lightning on Sundae   | Bonifay-FL    | 120   | 17.14  | 1  |
+| 23 | Madison Ealum     | Lightning on Sundae   | Bonifay-FL    | 105   | 15.00  |    |
+| 24 | Braden Cumbo      | Wilmington Warriors   | Wilmington-NC | 95    | 13.57  | 1  |
+| 25 | Trey Madsen       | Red Sea               | Yorkville-IL  | 85    | 12.14  | 1  |
+| 26 | Kellen Fairfield  | Cedar Park Eagles     | Bothell-WA    | 80    | 11.43  |    |
+| 27 | Morgan Zepp       | Lightning on Sundae   | Bonifay-FL    | 75    | 10.71  |    |
+| 28 | Destiny Garza     | Red Sea               | Yorkville-IL  | 65    | 9.29   |    |
+| 29 | Dylan Cotham      | Super Q\'s            | Lexington-TN  | 50    | 7.14   |    |
+| 30 | Grant Fisher      | Team-LakeShore Church | Rockwall-TX   | 40    | 5.71   |    |
+| 31 | Andy Boehling     | Wilmington Warriors   | Wilmington-NC | 30    | 4.29   |    |
+| 32 | Jacob Webb        | Super Q\'s            | Lexington-TN  | 30    | 4.29   |    |
+| 33 | Gabe Waggoner     | Cedar Park Eagles     | Bothell-WA    | 25    | 3.57   |    |
+| 34 | Kierstin Childs   | Wilmington Warriors   | Wilmington-NC | 20    | 2.86   |    |
+| 35 | Peter Graunke     | Red Sea               | Yorkville-IL  | 20    | 2.86   |    |
+| 36 | Tyler Benson      | Red Sea               | Yorkville-IL  | 10    | 1.43   |    |
+| 37 | Gideon Jennings   | New Life Renton       | Renton-WA     | 5     | .71    |    |
+
+
+### Cream
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                                                | Church             | W/L | Total | Avg    |
+|--:|-----------------------------------------------------|--------------------|-----|------:|-------:|
+| 1 | NERDS                                               | Bismarck-ND        | 7/0 | 1400  | 200.00 |
+| 2 | The Illuminators                                    | Lawson-MO          | 4/3 | 1030  | 147.14 |
+| 3 | CRK Almighty                                        | Gloucester City-NJ | 4/3 | 1030  | 147.14 |
+| 4 | Quiz Kidz                                           | Scotch Plains-NJ   | 4/3 | 1010  | 144.29 |
+| 5 | Harrison Thrashers                                  | Harrison-AR        | 4/3 | 930   | 132.86 |
+| 6 | S.P.Y. Kids 007                                     | Leesburg-VA        | 3/4 | 970   | 138.57 |
+| 7 | Bible Boyz                                          | Orlando-FL         | 2/5 | 1045  | 149.29 |
+| 8 | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO         | 0/7 | 680   | 97.14  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                                                | Church             | Total | Avg    | QO |
+|---:|-------------------|-----------------------------------------------------|--------------------|------:|-------:|---:|
+| 1  | Joshua Sipes      | NERDS                                               | Bismarck-ND        | 890   | 127.14 | 3  |
+| 2  | Megumi Sinniah    | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO         | 600   | 85.71  | 3  |
+| 3  | Jonathan Archer   | The Illuminators                                    | Lawson-MO          | 530   | 75.71  | 1  |
+| 4  | Luke Yoder        | S.P.Y. Kids 007                                     | Leesburg-VA        | 520   | 74.29  |    |
+| 5  | Jonah Woodbine    | Bible Boyz                                          | Orlando-FL         | 500   | 71.43  | 1  |
+| 6  | Kerigan Bradshaw  | Harrison Thrashers                                  | Harrison-AR        | 495   | 70.71  | 4  |
+| 7  | Elijah Abad       | CRK Almighty                                        | Gloucester City-NJ | 395   | 56.43  | 2  |
+| 8  | Stanley Thomas    | Quiz Kidz                                           | Scotch Plains-NJ   | 385   | 55.00  | 2  |
+| 9  | Breanna Cole      | The Illuminators                                    | Lawson-MO          | 325   | 46.43  | 1  |
+| 10 | Jayden Freyer     | NERDS                                               | Bismarck-ND        | 295   | 42.14  | 2  |
+| 11 | Jillian Angeles   | CRK Almighty                                        | Gloucester City-NJ | 265   | 37.86  |    |
+| 12 | Nicholas Dillon   | Harrison Thrashers                                  | Harrison-AR        | 240   | 34.29  |    |
+| 13 | Sarah Judd        | S.P.Y. Kids 007                                     | Leesburg-VA        | 225   | 32.14  | 1  |
+| 14 | Jorge Suarez      | Bible Boyz                                          | Orlando-FL         | 225   | 32.14  |    |
+| 15 | Jacob Flores      | CRK Almighty                                        | Gloucester City-NJ | 210   | 30.00  | 1  |
+| 16 | Nathan Henderson  | Bible Boyz                                          | Orlando-FL         | 180   | 25.71  | 2  |
+| 17 | Bethany Warren    | Harrison Thrashers                                  | Harrison-AR        | 180   | 25.71  |    |
+| 18 | Nick Cook         | The Illuminators                                    | Lawson-MO          | 160   | 22.86  | 1  |
+| 19 | Russell Flores    | CRK Almighty                                        | Gloucester City-NJ | 160   | 22.86  |    |
+| 20 | Joe Cheeli        | Quiz Kidz                                           | Scotch Plains-NJ   | 160   | 22.86  |    |
+| 21 | Ashlyn Sipes      | NERDS                                               | Bismarck-ND        | 145   | 20.71  | 1  |
+| 22 | Jordan Woodbine   | Bible Boyz                                          | Orlando-FL         | 140   | 20.00  |    |
+| 23 | Grace Schafhauser | Quiz Kidz                                           | Scotch Plains-NJ   | 135   | 19.29  | 1  |
+| 24 | Anna Schafhauser  | Quiz Kidz                                           | Scotch Plains-NJ   | 135   | 19.29  | 1  |
+| 25 | Benshel Bright    | Quiz Kidz                                           | Scotch Plains-NJ   | 110   | 15.71  |    |
+| 26 | Diana Bozzay      | S.P.Y. Kids 007                                     | Leesburg-VA        | 90    | 12.86  |    |
+| 27 | Josiah Baik       | Quiz Kidz                                           | Scotch Plains-NJ   | 90    | 12.86  |    |
+| 28 | Emily Walsh       | S.P.Y. Kids 007                                     | Leesburg-VA        | 75    | 10.71  |    |
+| 29 | Derek Leingang    | NERDS                                               | Bismarck-ND        | 70    | 10.00  |    |
+| 30 | Katherine Bozzay  | S.P.Y. Kids 007                                     | Leesburg-VA        | 60    | 8.57   |    |
+| 31 | Joanne Sinniah    | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO         | 55    | 7.86   |    |
+| 32 | Landon Holloway   | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO         | 40    | 5.71   |    |
+| 33 | Seth Archer       | The Illuminators                                    | Lawson-MO          | 20    | 2.86   |    |
+| 34 | Isabel Paul       | Harrison Thrashers                                  | Harrison-AR        | 20    | 2.86   |    |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                     | Church             | W/L | Total | Avg    |
+|--:|--------------------------|--------------------|-----|------:|-------:|
+| 1 | Naperville (S)           | Naperville-IL      | 6/1 | 1280  | 182.86 |
+| 2 | Two boys n the Houdes    | Billings-MT        | 5/2 | 950   | 135.71 |
+| 3 | MCC Sonburst Bible Stars | Mechanicsville,-VA | 4/3 | 1025  | 146.43 |
+| 4 | Grace Assembly of God    | New Whiteland-IN   | 4/3 | 1205  | 172.14 |
+| 5 | Warriors in Training     | Columbiaville-MI   | 3/4 | 1005  | 143.57 |
+| 6 | Guardians Of God\'s Word | Cincinnati-OH      | 2/5 | 870   | 124.29 |
+| 7 | Fireball Quizzers        | Waxahachie-TX      | 2/5 | 805   | 115.00 |
+| 8 | First Responders         | Ozark-MO           | 2/5 | 750   | 107.14 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                     | Church             | Total | Avg    | QO |
+|---:|---------------------|--------------------------|--------------------|------:|-------:|---:|
+| 1  | Jake Wolfe          | Naperville (S)           | Naperville-IL      | 705   | 100.71 | 4  |
+| 2  | Hudson Hollin       | Warriors in Training     | Columbiaville-MI   | 530   | 75.71  | 1  |
+| 3  | Elliott Murray      | Grace Assembly of God    | New Whiteland-IN   | 510   | 72.86  |    |
+| 4  | Will Wolfe          | Naperville (S)           | Naperville-IL      | 445   | 63.57  | 6  |
+| 5  | Kelise Bratihwaite  | First Responders         | Ozark-MO           | 430   | 61.43  |    |
+| 6  | David Haynes        | Guardians Of God\'s Word | Cincinnati-OH      | 425   | 60.71  | 1  |
+| 7  | Noah Zook           | MCC Sonburst Bible Stars | Mechanicsville,-VA | 365   | 52.14  |    |
+| 8  | Matthew Frick       | Two boys n the Houdes    | Billings-MT        | 350   | 50.00  | 2  |
+| 9  | Holly Bowen         | MCC Sonburst Bible Stars | Mechanicsville,-VA | 320   | 45.71  |    |
+| 10 | Gunnar Smart        | Guardians Of God\'s Word | Cincinnati-OH      | 320   | 45.71  |    |
+| 11 | Reuben Deemy        | Fireball Quizzers        | Waxahachie-TX      | 310   | 44.29  | 1  |
+| 12 | Ben Harsha          | Two boys n the Houdes    | Billings-MT        | 310   | 44.29  |    |
+| 13 | Claire Richardson   | Grace Assembly of God    | New Whiteland-IN   | 275   | 39.29  |    |
+| 14 | Nick Richardson     | Grace Assembly of God    | New Whiteland-IN   | 250   | 35.71  | 1  |
+| 15 | Hunter Hollin       | Warriors in Training     | Columbiaville-MI   | 240   | 34.29  | 3  |
+| 16 | Joey Huntley        | Warriors in Training     | Columbiaville-MI   | 235   | 33.57  | 1  |
+| 17 | Tessa Houde         | Two boys n the Houdes    | Billings-MT        | 230   | 32.86  |    |
+| 18 | Vinton Deemy        | Fireball Quizzers        | Waxahachie-TX      | 210   | 30.00  |    |
+| 19 | Micah Tonsing       | First Responders         | Ozark-MO           | 205   | 29.29  | 1  |
+| 20 | Griffin Simpson     | MCC Sonburst Bible Stars | Mechanicsville,-VA | 180   | 25.71  |    |
+| 21 | Nathaniel Walker    | MCC Sonburst Bible Stars | Mechanicsville,-VA | 165   | 23.57  |    |
+| 22 | Jillian Garrett     | Grace Assembly of God    | New Whiteland-IN   | 150   | 21.43  |    |
+| 23 | Jaqueline Martinez  | Fireball Quizzers        | Waxahachie-TX      | 135   | 19.29  |    |
+| 24 | Noel Siony          | Naperville (S)           | Naperville-IL      | 130   | 18.57  |    |
+| 25 | Maribel Castaneda   | Fireball Quizzers        | Waxahachie-TX      | 100   | 14.29  |    |
+| 26 | Jack Titkemeyer     | Guardians Of God\'s Word | Cincinnati-OH      | 90    | 12.86  |    |
+| 27 | Josiah Tonsing      | First Responders         | Ozark-MO           | 75    | 10.71  |    |
+| 28 | Jayda Houde         | Two boys n the Houdes    | Billings-MT        | 60    | 8.57   |    |
+| 29 | Kambria Braithwaite | First Responders         | Ozark-MO           | 40    | 5.71   |    |
+| 30 | Josh Kiefer         | Guardians Of God\'s Word | Cincinnati-OH      | 35    | 5.00   |    |
+| 31 | Eli Saenz           | Fireball Quizzers        | Waxahachie-TX      | 35    | 5.00   |    |
+| 32 | Ryan Shover         | Grace Assembly of God    | New Whiteland-IN   | 20    | 2.86   |    |
+| 33 | Noah Saenz          | Fireball Quizzers        | Waxahachie-TX      | 15    | 2.14   |    |
+
+
+### Mint
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                 | Church           | W/L | Total | Avg    |
+|--:|----------------------|------------------|-----|------:|-------:|
+| 1 | Naperville (J)       | Naperville-IL    | 7/0 | 1305  | 186.43 |
+| 2 | Gideon\'s Army       | Huber Heights-OH | 6/1 | 1430  | 204.29 |
+| 3 | Quadruple Threat + 2 | Cedar Hill-TX    | 3/4 | 1010  | 144.29 |
+| 4 | Tribulation Force    | Red Oak-TX       | 3/4 | 950   | 135.71 |
+| 5 | Firefighters         | Sanford-FL       | 3/4 | 855   | 122.14 |
+| 6 | River of Life        | Kent-WA          | 2/5 | 995   | 142.14 |
+| 7 | Bethlehem Church     | Richmond Hill-NY | 2/5 | 855   | 122.14 |
+| 8 | Now-n-Laters         | Springfield-MO   | 2/5 | 810   | 115.71 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                 | Church           | Total | Avg    | QO |
+|---:|--------------------|----------------------|------------------|------:|-------:|---:|
+| 1  | Sean Jones         | Gideon\'s Army       | Huber Heights-OH | 980   | 140.00 | 6  |
+| 2  | Jessica McElwee    | Naperville (J)       | Naperville-IL    | 865   | 123.57 | 5  |
+| 3  | Toby Robinson      | Firefighters         | Sanford-FL       | 665   | 95.00  | 3  |
+| 4  | Lily Slater        | Now-n-Laters         | Springfield-MO   | 550   | 78.57  | 4  |
+| 5  | Sara Ann Haimchand | Bethlehem Church     | Richmond Hill-NY | 390   | 55.71  | 3  |
+| 6  | Parker Lubbe       | Quadruple Threat + 2 | Cedar Hill-TX    | 390   | 55.71  |    |
+| 7  | Ty Silas           | Naperville (J)       | Naperville-IL    | 385   | 55.00  | 5  |
+| 8  | Gabriel Ison       | Gideon\'s Army       | Huber Heights-OH | 375   | 53.57  | 4  |
+| 9  | David Hipshire     | Tribulation Force    | Red Oak-TX       | 350   | 50.00  |    |
+| 10 | Kendall Calvery    | Quadruple Threat + 2 | Cedar Hill-TX    | 345   | 49.29  |    |
+| 11 | Johnathan Terrones | River of Life        | Kent-WA          | 320   | 45.71  | 2  |
+| 12 | Gunnar Bundrick    | Tribulation Force    | Red Oak-TX       | 315   | 45.00  | 2  |
+| 13 | Mateo Cuadros      | River of Life        | Kent-WA          | 300   | 42.86  | 1  |
+| 14 | Jeffrey Gutterud   | River of Life        | Kent-WA          | 300   | 42.86  |    |
+| 15 | Dwayne Bacchus     | Bethlehem Church     | Richmond Hill-NY | 245   | 35.00  |    |
+| 16 | Grant Hoggard      | Tribulation Force    | Red Oak-TX       | 240   | 34.29  |    |
+| 17 | Jamison Price      | Quadruple Threat + 2 | Cedar Hill-TX    | 235   | 33.57  | 2  |
+| 18 | Landon Clark       | Now-n-Laters         | Springfield-MO   | 220   | 31.43  |    |
+| 19 | Jonathan Robinson  | Firefighters         | Sanford-FL       | 170   | 24.29  | 1  |
+| 20 | Joy Okafor         | Bethlehem Church     | Richmond Hill-NY | 135   | 19.29  |    |
+| 21 | Emily Bulger       | River of Life        | Kent-WA          | 75    | 10.71  |    |
+| 22 | Erin Laboy         | Naperville (J)       | Naperville-IL    | 55    | 7.86   |    |
+| 23 | Jeannah Jones      | Gideon\'s Army       | Huber Heights-OH | 55    | 7.86   |    |
+| 24 | Joshua Persad      | Bethlehem Church     | Richmond Hill-NY | 50    | 7.14   |    |
+| 25 | Brady Coleman      | Tribulation Force    | Red Oak-TX       | 45    | 6.43   |    |
+| 26 | Emma Miller        | Quadruple Threat + 2 | Cedar Hill-TX    | 40    | 5.71   |    |
+| 27 | John Georgiades    | Now-n-Laters         | Springfield-MO   | 40    | 5.71   |    |
+| 28 | Ryleigh Jones      | Gideon\'s Army       | Huber Heights-OH | 20    | 2.86   |    |
+| 29 | Jordan Perez       | Firefighters         | Sanford-FL       | 20    | 2.86   |    |
+| 30 | Emily Singh        | Bethlehem Church     | Richmond Hill-NY | 15    | 2.14   |    |
+| 31 | Christian Boodram  | Bethlehem Church     | Richmond Hill-NY | 10    | 1.43   |    |
+| 32 | Joshua Gangaram    | Bethlehem Church     | Richmond Hill-NY | 10    | 1.43   |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church          | W/L | Total | Avg    |
+|--:|---------------------------|-----------------|-----|------:|-------:|
+| 1 | Naperville (C)            | Naperville-IL   | 6/1 | 1645  | 235.00 |
+| 2 | Bible Treasure Seekers    | Greensboro-NC   | 6/1 | 1370  | 195.71 |
+| 3 | Kids for Christ           | Fergus Falls-MN | 4/3 | 1010  | 144.29 |
+| 4 | Word of Life Lightbearers | Springfield-VA  | 3/4 | 690   | 98.57  |
+| 5 | Fort Wayne: Team Solomon  | Fort Wayne-IN   | 3/4 | 910   | 130.00 |
+| 6 | Truth Seekers             | Kearney-NE      | 2/5 | 940   | 134.29 |
+| 7 | God\'s Girlz              | Surprise-AZ     | 2/5 | 815   | 116.43 |
+| 8 | 3 Men & A Lady            | Gahanna-OH      | 2/5 | 705   | 100.71 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                      | Church          | Total | Avg    | QO |
+|---:|---------------------|---------------------------|-----------------|------:|-------:|---:|
+| 1  | Shreanna Powell     | Naperville (C)            | Naperville-IL   | 960   | 137.14 | 6  |
+| 2  | Alecia Rajesh       | Bible Treasure Seekers    | Greensboro-NC   | 620   | 88.57  | 1  |
+| 3  | Sheldon Powell      | Naperville (C)            | Naperville-IL   | 520   | 74.29  | 7  |
+| 4  | Moriah Johnson      | Truth Seekers             | Kearney-NE      | 510   | 72.86  | 2  |
+| 5  | Kenzie Brown        | God\'s Girlz              | Surprise-AZ     | 495   | 70.71  | 3  |
+| 6  | Abigail Prejean     | Bible Treasure Seekers    | Greensboro-NC   | 485   | 69.29  | 3  |
+| 7  | Landin Jacquay      | Fort Wayne: Team Solomon  | Fort Wayne-IN   | 375   | 53.57  | 2  |
+| 8  | Celestine Demmer    | Kids for Christ           | Fergus Falls-MN | 350   | 50.00  |    |
+| 9  | Brenden Kent        | 3 Men & A Lady            | Gahanna-OH      | 335   | 47.86  | 2  |
+| 10 | RuthAnn Demmer      | Kids for Christ           | Fergus Falls-MN | 270   | 38.57  |    |
+| 11 | Dylan Stewart       | Fort Wayne: Team Solomon  | Fort Wayne-IN   | 260   | 37.14  | 3  |
+| 12 | Micah Demmer        | Kids for Christ           | Fergus Falls-MN | 240   | 34.29  | 1  |
+| 13 | Faith Brown         | God\'s Girlz              | Surprise-AZ     | 240   | 34.29  |    |
+| 14 | Lydia Kidroske      | Bible Treasure Seekers    | Greensboro-NC   | 225   | 32.14  |    |
+| 15 | Elijah Wentz        | Truth Seekers             | Kearney-NE      | 215   | 30.71  |    |
+| 16 | Jacob Smith         | 3 Men & A Lady            | Gahanna-OH      | 205   | 29.29  | 1  |
+| 17 | Jonathan Ogebe      | Word of Life Lightbearers | Springfield-VA  | 185   | 26.43  | 1  |
+| 18 | Shaymis Powell      | Naperville (C)            | Naperville-IL   | 165   | 23.57  |    |
+| 19 | Katie Mair          | 3 Men & A Lady            | Gahanna-OH      | 165   | 23.57  |    |
+| 20 | Debie Tariku        | Word of Life Lightbearers | Springfield-VA  | 160   | 22.86  | 1  |
+| 21 | Blessing Inyangson  | Word of Life Lightbearers | Springfield-VA  | 160   | 22.86  |    |
+| 22 | Mariah Seidel       | Kids for Christ           | Fergus Falls-MN | 140   | 20.00  |    |
+| 23 | Tykus Gans          | Truth Seekers             | Kearney-NE      | 140   | 20.00  |    |
+| 24 | Isabella Burt       | Word of Life Lightbearers | Springfield-VA  | 130   | 18.57  |    |
+| 25 | Seth King           | Fort Wayne: Team Solomon  | Fort Wayne-IN   | 120   | 17.14  | 1  |
+| 26 | Braden Shinn        | Fort Wayne: Team Solomon  | Fort Wayne-IN   | 105   | 15.00  |    |
+| 27 | Omrane Ouedraogo    | Word of Life Lightbearers | Springfield-VA  | 55    | 7.86   |    |
+| 28 | Brennan Hanson      | Truth Seekers             | Kearney-NE      | 45    | 6.43   |    |
+| 29 | McKenna Kollman     | God\'s Girlz              | Surprise-AZ     | 40    | 5.71   |    |
+| 30 | Grayson Vestergaard | Fort Wayne: Team Solomon  | Fort Wayne-IN   | 30    | 4.29   |    |
+| 31 | Hannah Smith        | God\'s Girlz              | Surprise-AZ     | 30    | 4.29   |    |
+| 32 | Sierra Waugh        | Truth Seekers             | Kearney-NE      | 30    | 4.29   |    |
+| 33 | Madison Jacquay     | Fort Wayne: Team Solomon  | Fort Wayne-IN   | 20    | 2.86   |    |
+| 34 | Hannah Weagerle     | Bible Treasure Seekers    | Greensboro-NC   | 20    | 2.86   |    |
+| 35 | Aidan Rajesh        | Bible Treasure Seekers    | Greensboro-NC   | 20    | 2.86   |    |
+| 36 | Sierra Jacquay      | Fort Wayne: Team Solomon  | Fort Wayne-IN   | 10    | 1.43   |    |
+| 37 | Hannah Eckhardt     | Kids for Christ           | Fergus Falls-MN | 10    | 1.43   |    |
+| 38 | Abigail Deshais     | God\'s Girlz              | Surprise-AZ     | 10    | 1.43   |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                       | Church         | W/L | Total | Avg    |
+|--:|----------------------------|----------------|-----|------:|-------:|
+| 1 | IAG Soaring Eagles         | Gilbert-AZ     | 6/1 | 1115  | 159.29 |
+| 2 | Bethel Eagles              | San Jose-CA    | 5/2 | 970   | 138.57 |
+| 3 | Bethel Flames              | San Jose-CA    | 5/2 | 1200  | 171.43 |
+| 4 | Double-Edged Sword         | Irvine-CA      | 4/3 | 1045  | 149.29 |
+| 5 | North Scottsdale Christian | Scottsdale-AZ  | 3/4 | 1160  | 165.71 |
+| 6 | Knights in Shining Armour  | Springfield-MO | 3/4 | 725   | 103.57 |
+| 7 | Masters                    | Dodson-LA      | 1/6 | 505   | 72.14  |
+| 8 | Westgate A Team            | Edmonds-WA     | 1/6 | 640   | 91.43  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer         | Team                       | Church         | Total | Avg    | QO |
+|---:|-----------------|----------------------------|----------------|------:|-------:|---:|
+| 1  | David Moses     | North Scottsdale Christian | Scottsdale-AZ  | 705   | 100.71 | 2  |
+| 2  | Samuel Jebaraj  | Bethel Flames              | San Jose-CA    | 645   | 92.14  | 1  |
+| 3  | Michelle Koshy  | IAG Soaring Eagles         | Gilbert-AZ     | 595   | 85.00  |    |
+| 4  | Jonathan Haung  | Double-Edged Sword         | Irvine-CA      | 585   | 83.57  | 3  |
+| 5  | Noah Ku         | Westgate A Team            | Edmonds-WA     | 510   | 72.86  |    |
+| 6  | Emma Wolfe      | Knights in Shining Armour  | Springfield-MO | 385   | 55.00  | 1  |
+| 7  | Paul Daniel     | Bethel Flames              | San Jose-CA    | 325   | 46.43  | 3  |
+| 8  | Timothy Nirmal  | Bethel Eagles              | San Jose-CA    | 320   | 45.71  |    |
+| 9  | Gabe Loper      | Knights in Shining Armour  | Springfield-MO | 275   | 39.29  | 3  |
+| 10 | Kaylen Williams | Masters                    | Dodson-LA      | 275   | 39.29  |    |
+| 11 | David Daniel    | Bethel Eagles              | San Jose-CA    | 255   | 36.43  | 1  |
+| 12 | Jabez Williams  | Bethel Eagles              | San Jose-CA    | 235   | 33.57  |    |
+| 13 | Holly Garrett   | North Scottsdale Christian | Scottsdale-AZ  | 230   | 32.86  | 1  |
+| 14 | Gabriel Roberts | Bethel Flames              | San Jose-CA    | 230   | 32.86  |    |
+| 15 | My\'Randa Tolar | Masters                    | Dodson-LA      | 210   | 30.00  |    |
+| 16 | Tabitha Nirmal  | Bethel Eagles              | San Jose-CA    | 160   | 22.86  |    |
+| 17 | Gavin Kuruvilla | IAG Soaring Eagles         | Gilbert-AZ     | 160   | 22.86  |    |
+| 18 | Joanna Moses    | North Scottsdale Christian | Scottsdale-AZ  | 155   | 22.14  |    |
+| 19 | Joshua Zhang    | Double-Edged Sword         | Irvine-CA      | 150   | 21.43  |    |
+| 20 | Joel Joseph     | IAG Soaring Eagles         | Gilbert-AZ     | 135   | 19.29  |    |
+| 21 | Josiah Tveit    | Westgate A Team            | Edmonds-WA     | 130   | 18.57  | 1  |
+| 22 | Andrew Li       | Double-Edged Sword         | Irvine-CA      | 130   | 18.57  |    |
+| 23 | Jomi Malayil    | IAG Soaring Eagles         | Gilbert-AZ     | 115   | 16.43  |    |
+| 24 | Albin Mathew    | IAG Soaring Eagles         | Gilbert-AZ     | 110   | 15.71  |    |
+| 25 | Christopher Yen | Double-Edged Sword         | Irvine-CA      | 75    | 10.71  |    |
+| 26 | Levi Cooper     | Knights in Shining Armour  | Springfield-MO | 65    | 9.29   |    |
+| 27 | Calvin Lee      | Double-Edged Sword         | Irvine-CA      | 60    | 8.57   |    |
+| 28 | Joshua Zou      | Double-Edged Sword         | Irvine-CA      | 45    | 6.43   |    |
+| 29 | Lacey Leebrick  | North Scottsdale Christian | Scottsdale-AZ  | 40    | 5.71   |    |
+| 30 | Skyla Walker    | Masters                    | Dodson-LA      | 10    | 1.43   |    |
+| 31 | Talitha Weedon  | North Scottsdale Christian | Scottsdale-AZ  | 10    | 1.43   |    |
+| 32 | Carmen Schmidt  | North Scottsdale Christian | Scottsdale-AZ  | 10    | 1.43   |    |
+| 33 | Tia Willett     | North Scottsdale Christian | Scottsdale-AZ  | 10    | 1.43   |    |
+| 34 | Ethan Walker    | Masters                    | Dodson-LA      | 10    | 1.43   |    |
+
+
+### Silver
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team             | Church          | W/L | Total | Avg    |
+|--:|------------------|-----------------|-----|------:|-------:|
+| 1 | Buzz Hogs        | Mabelvale-AR    | 6/1 | 1145  | 163.57 |
+| 2 | BC United        | Wyckoff-NJ      | 5/2 | 1375  | 196.43 |
+| 3 | Eternal Eight    | Hamburg-PA      | 5/2 | 1190  | 170.00 |
+| 4 | S.O.S.           | Mikwaukee-WI    | 4/3 | 1175  | 167.86 |
+| 5 | XBOX             | Lakeville-MN    | 3/4 | 1055  | 150.71 |
+| 6 | Smileys          | Huntington-WV   | 3/4 | 820   | 117.14 |
+| 7 | Freedom Fighters | Collierville-TN | 2/5 | 680   | 97.14  |
+| 8 | Kidtricity       | Montgomery-AL   | 0/7 | 705   | 100.71 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team             | Church          | Total | Avg   | QO |
+|---:|---------------------|------------------|-----------------|------:|------:|---:|
+| 1  | Jared Minick        | Buzz Hogs        | Mabelvale-AR    | 675   | 96.43 | 2  |
+| 2  | Noah Hensley        | Smileys          | Huntington-WV   | 665   | 95.00 | 3  |
+| 3  | Nathaniel Duncan    | S.O.S.           | Mikwaukee-WI    | 610   | 87.14 | 2  |
+| 4  | Samy Gunaraj        | Freedom Fighters | Collierville-TN | 560   | 80.00 | 3  |
+| 5  | Trey Crowley        | Eternal Eight    | Hamburg-PA      | 465   | 66.43 | 1  |
+| 6  | Sydney Ames         | XBOX             | Lakeville-MN    | 455   | 65.00 | 1  |
+| 7  | Cayla Brodeur       | BC United        | Wyckoff-NJ      | 450   | 64.29 | 2  |
+| 8  | Jessica Kyzer       | S.O.S.           | Mikwaukee-WI    | 420   | 60.00 | 5  |
+| 9  | Savanah Biniakewitz | Buzz Hogs        | Mabelvale-AR    | 370   | 52.86 | 3  |
+| 10 | Emma Moorman        | BC United        | Wyckoff-NJ      | 340   | 48.57 | 2  |
+| 11 | Rachel Adelmann     | BC United        | Wyckoff-NJ      | 330   | 47.14 |    |
+| 12 | Kyle Ringley        | XBOX             | Lakeville-MN    | 250   | 35.71 | 1  |
+| 13 | Christian Hart      | Kidtricity       | Montgomery-AL   | 245   | 35.00 |    |
+| 14 | Micah Brown         | Kidtricity       | Montgomery-AL   | 240   | 34.29 | 1  |
+| 15 | Abigail Bartynski   | Eternal Eight    | Hamburg-PA      | 235   | 33.57 | 2  |
+| 16 | James Patterson     | Kidtricity       | Montgomery-AL   | 200   | 28.57 |    |
+| 17 | Zach Morara         | XBOX             | Lakeville-MN    | 180   | 25.71 | 1  |
+| 18 | Sierra Fisher       | Eternal Eight    | Hamburg-PA      | 180   | 25.71 |    |
+| 19 | Emanuel Lewis       | BC United        | Wyckoff-NJ      | 160   | 22.86 | 1  |
+| 20 | Gabby Ringley       | XBOX             | Lakeville-MN    | 150   | 21.43 | 1  |
+| 21 | Thomas Pospisil     | Eternal Eight    | Hamburg-PA      | 150   | 21.43 |    |
+| 22 | Mark Ziegler        | Smileys          | Huntington-WV   | 145   | 20.71 |    |
+| 23 | Trey Hanks          | Freedom Fighters | Collierville-TN | 105   | 15.00 |    |
+| 24 | Timothy Crowley     | Eternal Eight    | Hamburg-PA      | 95    | 13.57 |    |
+| 25 | Garrett Adelmann    | BC United        | Wyckoff-NJ      | 85    | 12.14 |    |
+| 26 | Levi Biniakewitz    | Buzz Hogs        | Mabelvale-AR    | 80    | 11.43 |    |
+| 27 | Caleb O\'Neil       | S.O.S.           | Mikwaukee-WI    | 65    | 9.29  |    |
+| 28 | Carley Cox          | Eternal Eight    | Hamburg-PA      | 40    | 5.71  |    |
+| 29 | Victoria Weidner    | S.O.S.           | Mikwaukee-WI    | 40    | 5.71  |    |
+| 30 | Samantha Pieper     | S.O.S.           | Mikwaukee-WI    | 40    | 5.71  |    |
+| 31 | Gabriella Keim      | Eternal Eight    | Hamburg-PA      | 25    | 3.57  |    |
+| 32 | Jessie Lipska       | Kidtricity       | Montgomery-AL   | 20    | 2.86  |    |
+| 33 | Darius Crawford     | Buzz Hogs        | Mabelvale-AR    | 20    | 2.86  |    |
+| 34 | Kaitlyn Mohr        | XBOX             | Lakeville-MN    | 20    | 2.86  |    |
+| 35 | Danielle Hanks      | Freedom Fighters | Collierville-TN | 15    | 2.14  |    |
+| 36 | Todd Pettet         | BC United        | Wyckoff-NJ      | 10    | 1.43  |    |
+| 37 | Olivia Lowe         | Smileys          | Huntington-WV   | 10    | 1.43  |    |
+| 38 | Caitlyn Leedy       | Smileys          | Huntington-WV   | 5     | .71   |    |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                            | Church           | W/L | Total | Avg    |
+|--:|---------------------------------|------------------|-----|------:|-------:|
+| 1 | SALT                            | Greensboro-NC    | 7/0 | 1185  | 169.29 |
+| 2 | 105                             | Wesley Chapel-FL | 5/2 | 1115  | 159.29 |
+| 3 | TNT                             | Louisville-KY    | 4/3 | 1110  | 158.57 |
+| 4 | Vailsburg Victors               | Newark-NJ        | 3/4 | 1070  | 152.86 |
+| 5 | Searcy Fruit Loops              | Searcy-AR        | 3/4 | 1005  | 143.57 |
+| 6 | D.D.D.                          | Mustang-OK       | 3/4 | 875   | 125.00 |
+| 7 | Bismarck Boppin\' Bible Buzzers | Bismarck-ND      | 2/5 | 845   | 120.71 |
+| 8 | PCC Giant Slayers               | Portland-OR      | 1/6 | 495   | 70.71  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                            | Church           | Total | Avg   | QO |
+|---:|---------------------|---------------------------------|------------------|------:|------:|---:|
+| 1  | Connor Patterson    | SALT                            | Greensboro-NC    | 570   | 81.43 | 1  |
+| 2  | Brooklyne Sederwall | Vailsburg Victors               | Newark-NJ        | 525   | 75.00 | 1  |
+| 3  | Kaden Sago          | Bismarck Boppin\' Bible Buzzers | Bismarck-ND      | 520   | 74.29 | 1  |
+| 4  | Catrina Palmer      | 105                             | Wesley Chapel-FL | 520   | 74.29 | 1  |
+| 5  | Noah Barnes         | TNT                             | Louisville-KY    | 455   | 65.00 | 2  |
+| 6  | Isaiah Madonia      | SALT                            | Greensboro-NC    | 390   | 55.71 | 5  |
+| 7  | Trevor Webb         | TNT                             | Louisville-KY    | 355   | 50.71 | 1  |
+| 8  | Caleb Horn          | D.D.D.                          | Mustang-OK       | 355   | 50.71 |    |
+| 9  | Andrew Emberson     | Searcy Fruit Loops              | Searcy-AR        | 345   | 49.29 |    |
+| 10 | Helyn Dunn          | 105                             | Wesley Chapel-FL | 345   | 49.29 |    |
+| 11 | Allison Shipman     | Searcy Fruit Loops              | Searcy-AR        | 330   | 47.14 |    |
+| 12 | Trea Webb           | TNT                             | Louisville-KY    | 300   | 42.86 | 4  |
+| 13 | Lauren Grisham      | D.D.D.                          | Mustang-OK       | 285   | 40.71 |    |
+| 14 | Fran-jec Makoule    | Vailsburg Victors               | Newark-NJ        | 265   | 37.86 | 1  |
+| 15 | Gigi Palmer         | 105                             | Wesley Chapel-FL | 250   | 35.71 | 1  |
+| 16 | Rylan Sago          | Bismarck Boppin\' Bible Buzzers | Bismarck-ND      | 245   | 35.00 | 2  |
+| 17 | Acacia Todd         | Vailsburg Victors               | Newark-NJ        | 230   | 32.86 |    |
+| 18 | Dakota Marsh        | Searcy Fruit Loops              | Searcy-AR        | 185   | 26.43 |    |
+| 19 | Karina Settles      | SALT                            | Greensboro-NC    | 180   | 25.71 |    |
+| 20 | Daniel Duran Jr.    | PCC Giant Slayers               | Portland-OR      | 165   | 23.57 | 1  |
+| 21 | Landon Grisham      | D.D.D.                          | Mustang-OK       | 165   | 23.57 |    |
+| 22 | Ari Lauthner        | PCC Giant Slayers               | Portland-OR      | 155   | 22.14 |    |
+| 23 | Michael Shipman     | Searcy Fruit Loops              | Searcy-AR        | 145   | 20.71 | 1  |
+| 24 | Emiliano Duran      | PCC Giant Slayers               | Portland-OR      | 125   | 17.86 |    |
+| 25 | Brooke Leingang     | Bismarck Boppin\' Bible Buzzers | Bismarck-ND      | 80    | 11.43 |    |
+| 26 | Kailan Weidner      | D.D.D.                          | Mustang-OK       | 70    | 10.00 |    |
+| 27 | Sarah Settles       | SALT                            | Greensboro-NC    | 45    | 6.43  |    |
+| 28 | Marvelous Ekeh      | Vailsburg Victors               | Newark-NJ        | 40    | 5.71  |    |
+| 29 | Katya Brodsky       | PCC Giant Slayers               | Portland-OR      | 30    | 4.29  |    |
+| 30 | Evan Llafet         | PCC Giant Slayers               | Portland-OR      | 20    | 2.86  |    |
+| 31 | Mia Howell          | Vailsburg Victors               | Newark-NJ        | 20    | 2.86  |    |
+
+
+### White
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team               | Church          | W/L | Total | Avg    |
+|--:|--------------------|-----------------|-----|------:|-------:|
+| 1 | Word Warriors      | Flower Mound-TX | 7/0 | 1395  | 199.29 |
+| 2 | New Life Pineville | Waxhaw-NC       | 5/2 | 1145  | 163.57 |
+| 3 | Brickmasters       | Racine-WI       | 4/3 | 1350  | 192.86 |
+| 4 | Torches of Truth   | Humble-TX       | 4/3 | 845   | 120.71 |
+| 5 | Comets             | New Richmond-WI | 3/4 | 990   | 141.43 |
+| 6 | Kansas Jayhawks    | Great Bend-KS   | 3/4 | 850   | 121.43 |
+| 7 | Salt Shakers       | Lubbock-TX      | 1/6 | 855   | 122.14 |
+| 8 | DAG Church         | Decatur-AR      | 1/6 | 790   | 112.86 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team               | Church          | Total | Avg   | QO |
+|---:|-------------------|--------------------|-----------------|------:|------:|---:|
+| 1  | Madie Rawlings    | Word Warriors      | Flower Mound-TX | 680   | 97.14 | 2  |
+| 2  | Rebekah Toeller   | Brickmasters       | Racine-WI       | 610   | 87.14 |    |
+| 3  | Reanna Toeller    | Brickmasters       | Racine-WI       | 560   | 80.00 | 5  |
+| 4  | Brendon Johnson   | Salt Shakers       | Lubbock-TX      | 500   | 71.43 |    |
+| 5  | Benjamin Beekman  | New Life Pineville | Waxhaw-NC       | 495   | 70.71 |    |
+| 6  | Joseph Raines     | Torches of Truth   | Humble-TX       | 430   | 61.43 | 2  |
+| 7  | Korbin Widiger    | Kansas Jayhawks    | Great Bend-KS   | 430   | 61.43 | 1  |
+| 8  | David Blomberg    | Comets             | New Richmond-WI | 420   | 60.00 | 3  |
+| 9  | Lauren Oliver     | Word Warriors      | Flower Mound-TX | 405   | 57.86 |    |
+| 10 | Isaac Wuerffel    | New Life Pineville | Waxhaw-NC       | 330   | 47.14 |    |
+| 11 | Elizabeth Beekman | New Life Pineville | Waxhaw-NC       | 320   | 45.71 | 2  |
+| 12 | Amanda Duncan     | DAG Church         | Decatur-AR      | 320   | 45.71 |    |
+| 13 | Matt Anderson     | DAG Church         | Decatur-AR      | 290   | 41.43 | 2  |
+| 14 | Angel McNeil      | Salt Shakers       | Lubbock-TX      | 285   | 40.71 | 1  |
+| 15 | Alex Rawlings     | Word Warriors      | Flower Mound-TX | 260   | 37.14 | 1  |
+| 16 | Caleb Blomberg    | Comets             | New Richmond-WI | 250   | 35.71 |    |
+| 17 | Jonathan Turner   | Torches of Truth   | Humble-TX       | 235   | 33.57 |    |
+| 18 | Joelle Rapp       | Comets             | New Richmond-WI | 195   | 27.86 |    |
+| 19 | Robby Brining     | Kansas Jayhawks    | Great Bend-KS   | 190   | 27.14 | 1  |
+| 20 | Trey Anderson     | DAG Church         | Decatur-AR      | 160   | 22.86 |    |
+| 21 | Joseph Nguyen     | Torches of Truth   | Humble-TX       | 150   | 21.43 |    |
+| 22 | Abby MacKinney    | Kansas Jayhawks    | Great Bend-KS   | 135   | 19.29 |    |
+| 23 | Sam David         | Brickmasters       | Racine-WI       | 110   | 15.71 |    |
+| 24 | Mitchell Covey    | Comets             | New Richmond-WI | 80    | 11.43 |    |
+| 25 | Kelton Johnson    | Salt Shakers       | Lubbock-TX      | 70    | 10.00 |    |
+| 26 | Lisa Marlow       | Kansas Jayhawks    | Great Bend-KS   | 65    | 9.29  |    |
+| 27 | Jonny Parker      | Word Warriors      | Flower Mound-TX | 50    | 7.14  |    |
+| 28 | Owen Covey        | Comets             | New Richmond-WI | 45    | 6.43  |    |
+| 29 | Johnny Nguyen     | Torches of Truth   | Humble-TX       | 30    | 4.29  |    |
+| 30 | Jayden Garrison   | Brickmasters       | Racine-WI       | 30    | 4.29  |    |
+| 31 | Naomi Lewis       | Brickmasters       | Racine-WI       | 20    | 2.86  |    |
+| 32 | Brandon Baer      | Brickmasters       | Racine-WI       | 20    | 2.86  |    |
+| 33 | Joshuah Muiruri   | Kansas Jayhawks    | Great Bend-KS   | 15    | 2.14  |    |
+| 34 | Skyler Mayhan     | Kansas Jayhawks    | Great Bend-KS   | 15    | 2.14  |    |
+| 35 | Amber Lydon       | DAG Church         | Decatur-AR      | 10    | 1.43  |    |
+| 36 | Johanna Day       | DAG Church         | Decatur-AR      | 10    | 1.43  |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                 | Church           | W/L | Total | Avg    |
+|--:|----------------------|------------------|-----|------:|-------:|
+| 1 | Bible Saints         | Princeton-MN     | 6/1 | 1115  | 159.29 |
+| 2 | JAG                  | Meriden-KS       | 5/2 | 1255  | 179.29 |
+| 3 | FIRE                 | Norcross-GA      | 5/2 | 1225  | 175.00 |
+| 4 | Spirit Squadron      | West Mifflin -PA | 4/3 | 995   | 142.14 |
+| 5 | Binghamton           | Binghamton-NY    | 3/4 | 840   | 120.00 |
+| 6 | DSI                  | Lakeville-MN     | 3/4 | 930   | 132.86 |
+| 7 | Chosen Ones          | Houston-TX       | 1/6 | 675   | 96.43  |
+| 8 | CIA - Special Agents | Mendon-MA        | 1/6 | 700   | 100.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                    | Team                 | Church           | Total | Avg    | QO |
+|---:|----------------------------|----------------------|------------------|------:|-------:|---:|
+| 1  | Ronald George              | FIRE                 | Norcross-GA      | 745   | 106.43 | 3  |
+| 2  | Julia Rivera               | JAG                  | Meriden-KS       | 620   | 88.57  | 2  |
+| 3  | Naomi Hagstrom             | Bible Saints         | Princeton-MN     | 550   | 78.57  | 2  |
+| 4  | Gabriella Hamvas           | Bible Saints         | Princeton-MN     | 375   | 53.57  | 2  |
+| 5  | Ashton Heath               | DSI                  | Lakeville-MN     | 365   | 52.14  | 1  |
+| 6  | Nick Congdon               | Binghamton           | Binghamton-NY    | 350   | 50.00  | 1  |
+| 7  | Tayla Vannelli             | CIA - Special Agents | Mendon-MA        | 350   | 50.00  |    |
+| 8  | Reagan McCreary            | Spirit Squadron      | West Mifflin -PA | 320   | 45.71  | 3  |
+| 9  | Nathan Kuenzi              | JAG                  | Meriden-KS       | 315   | 45.00  | 2  |
+| 10 | Caleb Gerhart              | Binghamton           | Binghamton-NY    | 305   | 43.57  | 2  |
+| 11 | Rachel Mgbeike             | Chosen Ones          | Houston-TX       | 295   | 42.14  | 1  |
+| 12 | LeeAnn Harris              | Spirit Squadron      | West Mifflin -PA | 295   | 42.14  |    |
+| 13 | Sharon Morara              | DSI                  | Lakeville-MN     | 265   | 37.86  |    |
+| 14 | Jonathan Moore             | JAG                  | Meriden-KS       | 255   | 36.43  |    |
+| 15 | Bryce Lofton               | DSI                  | Lakeville-MN     | 240   | 34.29  | 2  |
+| 16 | Alvin Johann Vasanthakumar | FIRE                 | Norcross-GA      | 240   | 34.29  |    |
+| 17 | Emmanuel Joshua Yesudasan  | FIRE                 | Norcross-GA      | 235   | 33.57  |    |
+| 18 | Shannon Morrill            | CIA - Special Agents | Mendon-MA        | 225   | 32.14  | 1  |
+| 19 | Andrew Scarinzi            | Binghamton           | Binghamton-NY    | 190   | 27.14  |    |
+| 20 | Wyatt Lawrence             | Bible Saints         | Princeton-MN     | 175   | 25.00  | 1  |
+| 21 | Kelsey McCafferty          | Spirit Squadron      | West Mifflin -PA | 165   | 23.57  |    |
+| 22 | Hannah Brown               | Spirit Squadron      | West Mifflin -PA | 150   | 21.43  |    |
+| 23 | Stephanie Oyolu            | Chosen Ones          | Houston-TX       | 145   | 20.71  |    |
+| 24 | Chimezirim Nwogu           | Chosen Ones          | Houston-TX       | 100   | 14.29  | 1  |
+| 25 | Fatih Caughey              | CIA - Special Agents | Mendon-MA        | 100   | 14.29  |    |
+| 26 | Joshua Wearne              | JAG                  | Meriden-KS       | 65    | 9.29   |    |
+| 27 | Savannah Reid              | DSI                  | Lakeville-MN     | 60    | 8.57   |    |
+| 28 | Vistoria Wooten            | Chosen Ones          | Houston-TX       | 55    | 7.86   |    |
+| 29 | Wayne Ellis                | Chosen Ones          | Houston-TX       | 50    | 7.14   |    |
+| 30 | Brennan McCreary           | Spirit Squadron      | West Mifflin -PA | 45    | 6.43   |    |
+| 31 | Michael Wooten             | Chosen Ones          | Houston-TX       | 35    | 5.00   |    |
+| 32 | Michelle Vannelli          | CIA - Special Agents | Mendon-MA        | 30    | 4.29   |    |
+| 33 | Will Brugos                | Spirit Squadron      | West Mifflin -PA | 20    | 2.86   |    |
+| 34 | Wade Lawrence              | Bible Saints         | Princeton-MN     | 10    | 1.43   |    |
+| 35 | Jake Hagstrom              | Bible Saints         | Princeton-MN     | 10    | 1.43   |    |
+| 36 | Eunice Stephen             | FIRE                 | Norcross-GA      | 5     | .71    |    |
+| 37 | Nicole Ellis               | Chosen Ones          | Houston-TX       | 5     | .71    |    |
+
+
+## Saturday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                   | Church           | W/L | Total | Avg    |
+|---:|------------------------|------------------|-----|------:|-------:|
+| 1  | Two boys n the Houdes  | Billings-MT      | 7/2 | 1490  | 165.56 |
+| 2  | Bible Treasure Seekers | Greensboro-NC    | 6/3 | 1540  | 171.11 |
+| 3  | Naperville (C)         | Naperville-IL    | 6/3 | 1585  | 176.11 |
+| 4  | NERDS                  | Bismarck-ND      | 5/4 | 1360  | 151.11 |
+| 5  | Bible Jammers          | Sanford-FL       | 5/4 | 1350  | 150.00 |
+| 6  | Naperville (S)         | Naperville-IL    | 5/4 | 1315  | 146.11 |
+| 7  | The Illuminators       | Lawson-MO        | 4/5 | 1170  | 130.00 |
+| 8  | Gideon\'s Army         | Huber Heights-OH | 4/5 | 1215  | 135.00 |
+| 9  | Naperville (J)         | Naperville-IL    | 3/6 | 1320  | 146.67 |
+| 10 | Super Q\'s             | Lexington-TN     | 0/9 | 920   | 102.22 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer         | Team                   | Church           | Total | Avg    | QO |
+|---:|-----------------|------------------------|------------------|------:|-------:|---:|
+| 1  | Shreanna Powell | Naperville (C)         | Naperville-IL    | 1160  | 128.89 | 6  |
+| 2  | Joshua Sipes    | NERDS                  | Bismarck-ND      | 935   | 103.89 | 4  |
+| 3  | Sean Jones      | Gideon\'s Army         | Huber Heights-OH | 915   | 101.67 | 4  |
+| 4  | Jessica McElwee | Naperville (J)         | Naperville-IL    | 855   | 95.00  | 3  |
+| 5  | Peyton Goss     | Bible Jammers          | Sanford-FL       | 850   | 94.44  | 4  |
+| 6  | Jake Wolfe      | Naperville (S)         | Naperville-IL    | 835   | 92.78  | 2  |
+| 7  | Alecia Rajesh   | Bible Treasure Seekers | Greensboro-NC    | 730   | 81.11  | 1  |
+| 8  | Abigail Prejean | Bible Treasure Seekers | Greensboro-NC    | 585   | 65.00  | 3  |
+| 9  | Jonathan Archer | The Illuminators       | Lawson-MO        | 585   | 65.00  | 1  |
+| 10 | Matthew Frick   | Two boys n the Houdes  | Billings-MT      | 550   | 61.11  | 3  |
+| 11 | Breanna Cole    | The Illuminators       | Lawson-MO        | 480   | 53.33  | 4  |
+| 12 | Reuben Savage   | Super Q\'s             | Lexington-TN     | 460   | 51.11  |    |
+| 13 | Ben Harsha      | Two boys n the Houdes  | Billings-MT      | 450   | 50.00  |    |
+| 14 | Will Wolfe      | Naperville (S)         | Naperville-IL    | 440   | 48.89  | 4  |
+| 15 | Ty Silas        | Naperville (J)         | Naperville-IL    | 410   | 45.56  | 5  |
+| 16 | Tessa Houde     | Two boys n the Houdes  | Billings-MT      | 410   | 45.56  |    |
+| 17 | Sheldon Powell  | Naperville (C)         | Naperville-IL    | 390   | 43.33  | 4  |
+| 18 | Seth Savage     | Super Q\'s             | Lexington-TN     | 385   | 42.78  | 5  |
+| 19 | Jayden Freyer   | NERDS                  | Bismarck-ND      | 280   | 31.11  | 1  |
+| 20 | Aubrey Goss     | Bible Jammers          | Sanford-FL       | 255   | 28.33  | 1  |
+| 21 | Cassidy Neal    | Bible Jammers          | Sanford-FL       | 245   | 27.22  |    |
+| 22 | Lydia Kidroske  | Bible Treasure Seekers | Greensboro-NC    | 220   | 24.44  | 1  |
+| 23 | Gabriel Ison    | Gideon\'s Army         | Huber Heights-OH | 215   | 23.89  | 1  |
+| 24 | Nick Cook       | The Illuminators       | Lawson-MO        | 105   | 11.67  |    |
+| 24 | Ashlyn Sipes    | NERDS                  | Bismarck-ND      | 105   | 11.67  |    |
+| 25 | Jayda Houde     | Two boys n the Houdes  | Billings-MT      | 80    | 8.89   |    |
+| 26 | Jeannah Jones   | Gideon\'s Army         | Huber Heights-OH | 55    | 6.11   |    |
+| 27 | Noel Siony      | Naperville (S)         | Naperville-IL    | 40    | 4.44   |    |
+| 27 | Jacob Webb      | Super Q\'s             | Lexington-TN     | 40    | 4.44   |    |
+| 27 | Derek Leingang  | NERDS                  | Bismarck-ND      | 40    | 4.44   |    |
+| 28 | Ryleigh Jones   | Gideon\'s Army         | Huber Heights-OH | 35    | 3.89   |    |
+| 28 | Shaymis Powell  | Naperville (C)         | Naperville-IL    | 35    | 3.89   |    |
+| 28 | Erin Laboy      | Naperville (J)         | Naperville-IL    | 35    | 3.89   |    |
+| 29 | Justiss Silas   | Naperville (J)         | Naperville-IL    | 20    | 2.22   |    |
+| 29 | Dylan Cotham    | Super Q\'s             | Lexington-TN     | 20    | 2.22   |    |
+| 30 | Shelby Webb     | Super Q\'s             | Lexington-TN     | 15    | 1.67   |    |
+| 31 | Hannah Weagerle | Bible Treasure Seekers | Greensboro-NC    | 5     | .56    |    |
+| 32 | Julia Martello  | Bible Treasure Seekers | Greensboro-NC    |       | .00    |    |
+| 32 | Seth Archer     | The Illuminators       | Lawson-MO        |       | .00    |    |
+| 32 | Aidan Rajesh    | Bible Treasure Seekers | Greensboro-NC    |       | .00    |    |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                      | Church             | W/L | Total | Avg    |
+|---:|---------------------------|--------------------|-----|------:|-------:|
+| 1  | Grace Assembly of God     | New Whiteland-IN   | 9/0 | 1810  | 201.11 |
+| 2  | Kids for Christ           | Fergus Falls-MN    | 8/1 | 1355  | 150.56 |
+| 3  | Word of Life Lightbearers | Springfield-VA     | 7/2 | 1220  | 135.56 |
+| 4  | Team-LakeShore Church     | Rockwall-TX        | 4/5 | 1315  | 146.11 |
+| 5  | Quiz Kidz                 | Scotch Plains-NJ   | 4/5 | 1105  | 122.78 |
+| 6  | CRK Almighty              | Gloucester City-NJ | 4/5 | 1045  | 116.11 |
+| 7  | Quadruple Threat + 2      | Cedar Hill-TX      | 3/6 | 1160  | 128.89 |
+| 8  | Wilmington Warriors       | Wilmington-NC      | 3/6 | 1125  | 125.00 |
+| 9  | Tribulation Force         | Red Oak-TX         | 3/6 | 1065  | 118.33 |
+| 10 | MCC Sonburst Bible Stars  | Mechanicsville,-VA | 2/7 | 1110  | 123.33 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                      | Church             | Total | Avg    | QO |
+|---:|--------------------|---------------------------|--------------------|------:|-------:|---:|
+| 1  | Elliott Murray     | Grace Assembly of God     | New Whiteland-IN   | 900   | 100.00 | 2  |
+| 2  | Debie Tariku       | Word of Life Lightbearers | Springfield-VA     | 510   | 56.67  | 2  |
+| 3  | Samuel Galloway    | Team-LakeShore Church     | Rockwall-TX        | 510   | 56.67  | 2  |
+| 4  | RuthAnn Demmer     | Kids for Christ           | Fergus Falls-MN    | 510   | 56.67  |    |
+| 5  | David Hipshire     | Tribulation Force         | Red Oak-TX         | 500   | 55.56  |    |
+| 6  | Zachary Leake      | Wilmington Warriors       | Wilmington-NC      | 440   | 48.89  |    |
+| 7  | Blessing Inyangson | Word of Life Lightbearers | Springfield-VA     | 425   | 47.22  |    |
+| 8  | Parker Lubbe       | Quadruple Threat + 2      | Cedar Hill-TX      | 415   | 46.11  | 1  |
+| 9  | Claire Richardson  | Grace Assembly of God     | New Whiteland-IN   | 400   | 44.44  |    |
+| 10 | Emma Moer          | Team-LakeShore Church     | Rockwall-TX        | 395   | 43.89  |    |
+| 11 | Noah Zook          | MCC Sonburst Bible Stars  | Mechanicsville,-VA | 380   | 42.22  | 1  |
+| 12 | Micah Demmer       | Kids for Christ           | Fergus Falls-MN    | 370   | 41.11  | 2  |
+| 13 | Hannah Moer        | Team-LakeShore Church     | Rockwall-TX        | 355   | 39.44  | 1  |
+| 14 | Elijah Abad        | CRK Almighty              | Gloucester City-NJ | 340   | 37.78  | 3  |
+| 15 | Jamison Price      | Quadruple Threat + 2      | Cedar Hill-TX      | 335   | 37.22  | 1  |
+| 16 | Nathaniel Walker   | MCC Sonburst Bible Stars  | Mechanicsville,-VA | 320   | 35.56  | 1  |
+| 17 | Gunnar Bundrick    | Tribulation Force         | Red Oak-TX         | 310   | 34.44  | 3  |
+| 18 | Nick Richardson    | Grace Assembly of God     | New Whiteland-IN   | 305   | 33.89  | 3  |
+| 19 | Benshel Bright     | Quiz Kidz                 | Scotch Plains-NJ   | 305   | 33.89  |    |
+| 20 | Russell Flores     | CRK Almighty              | Gloucester City-NJ | 300   | 33.33  |    |
+| 21 | Kendall Calvery    | Quadruple Threat + 2      | Cedar Hill-TX      | 295   | 32.78  |    |
+| 22 | Stanley Thomas     | Quiz Kidz                 | Scotch Plains-NJ   | 275   | 30.56  |    |
+| 23 | Mariah Seidel      | Kids for Christ           | Fergus Falls-MN    | 250   | 27.78  |    |
+| 24 | Griffin Simpson    | MCC Sonburst Bible Stars  | Mechanicsville,-VA | 215   | 23.89  |    |
+| 25 | Celestine Demmer   | Kids for Christ           | Fergus Falls-MN    | 210   | 23.33  |    |
+| 26 | Jillian Garrett    | Grace Assembly of God     | New Whiteland-IN   | 205   | 22.78  |    |
+| 27 | Jillian Angeles    | CRK Almighty              | Gloucester City-NJ | 200   | 22.22  |    |
+| 28 | Grant Hoggard      | Tribulation Force         | Red Oak-TX         | 195   | 21.67  |    |
+| 29 | Jacob Flores       | CRK Almighty              | Gloucester City-NJ | 190   | 21.11  |    |
+| 30 | Holly Bowen        | MCC Sonburst Bible Stars  | Mechanicsville,-VA | 185   | 20.56  |    |
+| 31 | Greyson Kerns      | Wilmington Warriors       | Wilmington-NC      | 180   | 20.00  | 1  |
+| 32 | Joe Cheeli         | Quiz Kidz                 | Scotch Plains-NJ   | 180   | 20.00  |    |
+| 33 | Anna Schafhauser   | Quiz Kidz                 | Scotch Plains-NJ   | 165   | 18.33  |    |
+| 34 | Christian Shelton  | Wilmington Warriors       | Wilmington-NC      | 160   | 17.78  |    |
+| 35 | Isabella Burt      | Word of Life Lightbearers | Springfield-VA     | 155   | 17.22  |    |
+| 36 | Andy Boehling      | Wilmington Warriors       | Wilmington-NC      | 150   | 16.67  |    |
+| 37 | Josiah Baik        | Quiz Kidz                 | Scotch Plains-NJ   | 140   | 15.56  |    |
+| 38 | Jonathan Ogebe     | Word of Life Lightbearers | Springfield-VA     | 135   | 15.00  |    |
+| 39 | Omrane Ouedraogo   | Word of Life Lightbearers | Springfield-VA     | 115   | 12.78  | 1  |
+| 40 | Braden Cumbo       | Wilmington Warriors       | Wilmington-NC      | 110   | 12.22  |    |
+| 41 | Kierstin Childs    | Wilmington Warriors       | Wilmington-NC      | 85    | 9.44   |    |
+| 42 | Emma Miller        | Quadruple Threat + 2      | Cedar Hill-TX      | 70    | 7.78   |    |
+| 43 | Brady Coleman      | Tribulation Force         | Red Oak-TX         | 60    | 6.67   |    |
+| 44 | Grant Fisher       | Team-LakeShore Church     | Rockwall-TX        | 55    | 6.11   |    |
+| 45 | Joshua Baragas     | Quadruple Threat + 2      | Cedar Hill-TX      | 35    | 3.89   |    |
+| 46 | Daniel Schafhauser | Quiz Kidz                 | Scotch Plains-NJ   | 30    | 3.33   |    |
+| 47 | Hannah Eckhardt    | Kids for Christ           | Fergus Falls-MN    | 15    | 1.67   |    |
+| 48 | Hezekiah Reynes    | CRK Almighty              | Gloucester City-NJ | 15    | 1.67   |    |
+| 49 | Nikki Rittenhouse  | MCC Sonburst Bible Stars  | Mechanicsville,-VA | 10    | 1.11   |    |
+| 50 | Grace Schafhauser  | Quiz Kidz                 | Scotch Plains-NJ   | 10    | 1.11   |    |
+| 51 | Charlotte Burt     | Word of Life Lightbearers | Springfield-VA     | 10    | 1.11   |    |
+| 52 | Triston Rosario    | Quadruple Threat + 2      | Cedar Hill-TX      | 10    | 1.11   |    |
+
+
+### Mint
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                     | Church           | W/L | Total | Avg    |
+|---:|--------------------------|------------------|-----|------:|-------:|
+| 1  | Firefighters             | Sanford-FL       | 9/0 | 1905  | 211.67 |
+| 2  | River of Life            | Kent-WA          | 7/2 | 1495  | 166.11 |
+| 3  | Red Sea                  | Yorkville-IL     | 6/3 | 1620  | 180.00 |
+| 4  | S.P.Y. Kids 007          | Leesburg-VA      | 4/5 | 1135  | 126.11 |
+| 5  | Warriors in Training     | Columbiaville-MI | 4/5 | 1080  | 120.00 |
+| 6  | Fort Wayne: Team Solomon | Fort Wayne-IN    | 4/5 | 965   | 107.22 |
+| 7  | Harrison Thrashers       | Harrison-AR      | 3/6 | 1185  | 131.67 |
+| 8  | Guardians Of God\'s Word | Cincinnati-OH    | 3/6 | 1100  | 122.22 |
+| 9  | Truth Seekers            | Kearney-NE       | 3/6 | 945   | 105.00 |
+| 10 | Cedar Park Eagles        | Bothell-WA       | 2/7 | 1150  | 127.78 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                     | Church           | Total | Avg    | QO |
+|---:|---------------------|--------------------------|------------------|------:|-------:|---:|
+| 1  | Toby Robinson       | Firefighters             | Sanford-FL       | 1320  | 146.67 | 9  |
+| 2  | Tanner Laffey       | Red Sea                  | Yorkville-IL     | 825   | 91.67  | 4  |
+| 3  | Jeffrey Gutterud    | River of Life            | Kent-WA          | 800   | 88.89  | 4  |
+| 4  | Moriah Johnson      | Truth Seekers            | Kearney-NE       | 615   | 68.33  | 1  |
+| 5  | Hudson Hollin       | Warriors in Training     | Columbiaville-MI | 605   | 67.22  | 2  |
+| 6  | Jonathan Robinson   | Firefighters             | Sanford-FL       | 585   | 65.00  | 5  |
+| 7  | Reid Jarrell        | Cedar Park Eagles        | Bothell-WA       | 570   | 63.33  | 2  |
+| 8  | Kerigan Bradshaw    | Harrison Thrashers       | Harrison-AR      | 545   | 60.56  | 2  |
+| 9  | Gunnar Smart        | Guardians Of God\'s Word | Cincinnati-OH    | 490   | 54.44  |    |
+| 10 | Sarah Judd          | S.P.Y. Kids 007          | Leesburg-VA      | 475   | 52.78  | 6  |
+| 11 | Johnathan Terrones  | River of Life            | Kent-WA          | 445   | 49.44  | 3  |
+| 12 | Landin Jacquay      | Fort Wayne: Team Solomon | Fort Wayne-IN    | 370   | 41.11  |    |
+| 13 | Nicholas Dillon     | Harrison Thrashers       | Harrison-AR      | 350   | 38.89  |    |
+| 14 | Trinity Garza       | Red Sea                  | Yorkville-IL     | 345   | 38.33  | 3  |
+| 15 | Hunter Hollin       | Warriors in Training     | Columbiaville-MI | 275   | 30.56  | 2  |
+| 16 | Bethany Warren      | Harrison Thrashers       | Harrison-AR      | 250   | 27.78  |    |
+| 17 | Jack Titkemeyer     | Guardians Of God\'s Word | Cincinnati-OH    | 245   | 27.22  |    |
+| 17 | David Haynes        | Guardians Of God\'s Word | Cincinnati-OH    | 245   | 27.22  |    |
+| 18 | Dylan Stewart       | Fort Wayne: Team Solomon | Fort Wayne-IN    | 240   | 26.67  | 1  |
+| 18 | Diana Bozzay        | S.P.Y. Kids 007          | Leesburg-VA      | 240   | 26.67  | 1  |
+| 19 | Destiny Garza       | Red Sea                  | Yorkville-IL     | 240   | 26.67  |    |
+| 19 | Luke Yoder          | S.P.Y. Kids 007          | Leesburg-VA      | 240   | 26.67  |    |
+| 20 | Grant Gorc          | Cedar Park Eagles        | Bothell-WA       | 210   | 23.33  | 1  |
+| 21 | Braden Shinn        | Fort Wayne: Team Solomon | Fort Wayne-IN    | 200   | 22.22  |    |
+| 21 | Joey Huntley        | Warriors in Training     | Columbiaville-MI | 200   | 22.22  |    |
+| 22 | Peter Graunke       | Red Sea                  | Yorkville-IL     | 180   | 20.00  |    |
+| 23 | Elijah Wentz        | Truth Seekers            | Kearney-NE       | 160   | 17.78  |    |
+| 24 | Cecily Houser       | Cedar Park Eagles        | Bothell-WA       | 150   | 16.67  |    |
+| 25 | Emily Bulger        | River of Life            | Kent-WA          | 140   | 15.56  |    |
+| 26 | Gabe Waggoner       | Cedar Park Eagles        | Bothell-WA       | 135   | 15.00  |    |
+| 27 | Emily Walsh         | S.P.Y. Kids 007          | Leesburg-VA      | 130   | 14.44  |    |
+| 28 | Tykus Gans          | Truth Seekers            | Kearney-NE       | 125   | 13.89  |    |
+| 28 | Josh Kiefer         | Guardians Of God\'s Word | Cincinnati-OH    | 125   | 13.89  |    |
+| 29 | Mateo Cuadros       | River of Life            | Kent-WA          | 110   | 12.22  |    |
+| 30 | Kellen Fairfield    | Cedar Park Eagles        | Bothell-WA       | 85    | 9.44   |    |
+| 31 | Grayson Vestergaard | Fort Wayne: Team Solomon | Fort Wayne-IN    | 55    | 6.11   |    |
+| 32 | Katherine Bozzay    | S.P.Y. Kids 007          | Leesburg-VA      | 50    | 5.56   |    |
+| 33 | Madison Jacquay     | Fort Wayne: Team Solomon | Fort Wayne-IN    | 45    | 5.00   |    |
+| 34 | Sierra Jacquay      | Fort Wayne: Team Solomon | Fort Wayne-IN    | 40    | 4.44   |    |
+| 34 | Isabel Paul         | Harrison Thrashers       | Harrison-AR      | 40    | 4.44   |    |
+| 35 | Sierra Waugh        | Truth Seekers            | Kearney-NE       | 30    | 3.33   |    |
+| 35 | Trey Madsen         | Red Sea                  | Yorkville-IL     | 30    | 3.33   |    |
+| 36 | Jadyn Kleinhenz     | Guardians Of God\'s Word | Cincinnati-OH    | 20    | 2.22   |    |
+| 36 | Stephen King        | Fort Wayne: Team Solomon | Fort Wayne-IN    | 20    | 2.22   |    |
+| 37 | Brennan Hanson      | Truth Seekers            | Kearney-NE       | 15    | 1.67   |    |
+| 38 | Jordan Perez        | Firefighters             | Sanford-FL       | 5     | .56    | 1  |
+| 39 | Trenton Miller      | Red Sea                  | Yorkville-IL     | 5     | .56    |    |
+| 40 | Micayla Herring     | Harrison Thrashers       | Harrison-AR      |       | .00    |    |
+| 40 | Joshua Daniels      | S.P.Y. Kids 007          | Leesburg-VA      |       | .00    |    |
+| 40 | Tyler Benson        | Red Sea                  | Yorkville-IL     |       | .00    |    |
+| 40 | Hailie Huntley      | Warriors in Training     | Columbiaville-MI |       | .00    |    |
+| 41 | Julia Kiefer        | Guardians Of God\'s Word | Cincinnati-OH    | -20   | -2.22  |    |
+| 42 | Seth King           | Fort Wayne: Team Solomon | Fort Wayne-IN    | -5    | -0.56  |    |
+| 42 | Ben Malas           | Red Sea                  | Yorkville-IL     | -5    | -0.56  |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                                                | Church           | W/L | Total | Avg    |
+|---:|-----------------------------------------------------|------------------|-----|------:|-------:|
+| 1  | Bethlehem Church                                    | Richmond Hill-NY | 7/2 | 1550  | 172.22 |
+| 2  | Fireball Quizzers                                   | Waxahachie-TX    | 7/2 | 1405  | 156.11 |
+| 3  | New Life Renton                                     | Renton-WA        | 6/3 | 1365  | 151.67 |
+| 4  | Bible Boyz                                          | Orlando-FL       | 6/3 | 1490  | 165.56 |
+| 5  | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO       | 5/4 | 1520  | 168.89 |
+| 6  | First Responders                                    | Ozark-MO         | 5/4 | 1305  | 145.00 |
+| 7  | God\'s Girlz                                        | Surprise-AZ      | 4/5 | 1135  | 126.11 |
+| 8  | 3 Men & A Lady                                      | Gahanna-OH       | 2/7 | 1165  | 129.44 |
+| 9  | Lightning on Sundae                                 | Bonifay-FL       | 2/7 | 1055  | 117.22 |
+| 10 | Now-n-Laters                                        | Springfield-MO   | 1/8 | 900   | 100.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                 | Team                                                | Church           | Total | Avg    | QO |
+|---:|-------------------------|-----------------------------------------------------|------------------|------:|-------:|---:|
+| 1  | Russell Cook            | New Life Renton                                     | Renton-WA        | 930   | 103.33 | 5  |
+| 2  | Megumi Sinniah          | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO       | 890   | 98.89  | 4  |
+| 3  | Brenden Kent            | 3 Men & A Lady                                      | Gahanna-OH       | 760   | 84.44  | 2  |
+| 4  | Kelise Bratihwaite      | First Responders                                    | Ozark-MO         | 730   | 81.11  | 4  |
+| 5  | Reuben Deemy            | Fireball Quizzers                                   | Waxahachie-TX    | 565   | 62.78  | 3  |
+| 6  | Sara Ann Haimchand      | Bethlehem Church                                    | Richmond Hill-NY | 510   | 56.67  | 4  |
+| 7  | Nathan Henderson        | Bible Boyz                                          | Orlando-FL       | 495   | 55.00  | 7  |
+| 8  | Jonah Woodbine          | Bible Boyz                                          | Orlando-FL       | 485   | 53.89  | 1  |
+| 9  | Lily Slater             | Now-n-Laters                                        | Springfield-MO   | 390   | 43.33  | 1  |
+| 10 | Kenzie Brown            | God\'s Girlz                                        | Surprise-AZ      | 380   | 42.22  | 2  |
+| 11 | Jordan Woodbine         | Bible Boyz                                          | Orlando-FL       | 370   | 41.11  |    |
+| 12 | Joanne Sinniah          | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO       | 365   | 40.56  |    |
+| 13 | Joshua Persad           | Bethlehem Church                                    | Richmond Hill-NY | 355   | 39.44  |    |
+| 14 | Joy Okafor              | Bethlehem Church                                    | Richmond Hill-NY | 350   | 38.89  | 1  |
+| 14 | Micah Tonsing           | First Responders                                    | Ozark-MO         | 350   | 38.89  | 1  |
+| 15 | Andrew Warren           | Lightning on Sundae                                 | Bonifay-FL       | 350   | 38.89  |    |
+| 16 | Vinton Deemy            | Fireball Quizzers                                   | Waxahachie-TX    | 325   | 36.11  | 1  |
+| 17 | McKenna Kollman         | God\'s Girlz                                        | Surprise-AZ      | 320   | 35.56  |    |
+| 18 | Faith Brown             | God\'s Girlz                                        | Surprise-AZ      | 315   | 35.00  | 1  |
+| 19 | Madison Ealum           | Lightning on Sundae                                 | Bonifay-FL       | 310   | 34.44  |    |
+| 20 | Nathan Jacobs           | New Life Renton                                     | Renton-WA        | 290   | 32.22  | 1  |
+| 21 | Landon Clark            | Now-n-Laters                                        | Springfield-MO   | 265   | 29.44  |    |
+| 22 | Jacob Smith             | 3 Men & A Lady                                      | Gahanna-OH       | 245   | 27.22  | 2  |
+| 23 | JJ Paul                 | Lightning on Sundae                                 | Bonifay-FL       | 245   | 27.22  | 1  |
+| 24 | John Georgiades         | Now-n-Laters                                        | Springfield-MO   | 230   | 25.56  |    |
+| 25 | Dwayne Bacchus          | Bethlehem Church                                    | Richmond Hill-NY | 220   | 24.44  |    |
+| 26 | Landon Holloway         | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO       | 210   | 23.33  | 1  |
+| 27 | Eli Saenz               | Fireball Quizzers                                   | Waxahachie-TX    | 165   | 18.33  |    |
+| 28 | Katie Mair              | 3 Men & A Lady                                      | Gahanna-OH       | 160   | 17.78  |    |
+| 29 | Josiah Tonsing          | First Responders                                    | Ozark-MO         | 145   | 16.11  |    |
+| 30 | Maribel Castaneda       | Fireball Quizzers                                   | Waxahachie-TX    | 140   | 15.56  |    |
+| 30 | Jorge Suarez            | Bible Boyz                                          | Orlando-FL       | 140   | 15.56  |    |
+| 31 | Jaqueline Martinez      | Fireball Quizzers                                   | Waxahachie-TX    | 135   | 15.00  |    |
+| 32 | Hannah Smith            | God\'s Girlz                                        | Surprise-AZ      | 120   | 13.33  |    |
+| 33 | Ellen Jacobs            | New Life Renton                                     | Renton-WA        | 95    | 10.56  |    |
+| 34 | Joshua Gangaram         | Bethlehem Church                                    | Richmond Hill-NY | 90    | 10.00  |    |
+| 35 | Emilie Justice          | Lightning on Sundae                                 | Bonifay-FL       | 75    | 8.33   |    |
+| 35 | Noah Saenz              | Fireball Quizzers                                   | Waxahachie-TX    | 75    | 8.33   |    |
+| 35 | Morgan Zepp             | Lightning on Sundae                                 | Bonifay-FL       | 75    | 8.33   |    |
+| 36 | Kambria Braithwaite     | First Responders                                    | Ozark-MO         | 70    | 7.78   |    |
+| 37 | Cage Holloway           | God\'s Quad Squad Returns, Tri Lakes Church, Branso | Branson-MO       | 55    | 6.11   |    |
+| 38 | Gideon Jennings         | New Life Renton                                     | Renton-WA        | 30    | 3.33   |    |
+| 39 | Shanessa Pooranampillai | New Life Renton                                     | Renton-WA        | 20    | 2.22   |    |
+| 39 | Emily Singh             | Bethlehem Church                                    | Richmond Hill-NY | 20    | 2.22   |    |
+| 40 | Caleb Horsch            | Now-n-Laters                                        | Springfield-MO   | 15    | 1.67   |    |
+| 41 | Kosette Braithwaite     | First Responders                                    | Ozark-MO         | 10    | 1.11   |    |
+| 42 | Christian Boodram       | Bethlehem Church                                    | Richmond Hill-NY | 5     | .56    |    |
+| 43 | Belen Castaneda         | Fireball Quizzers                                   | Waxahachie-TX    |       | .00    |    |
+| 43 | Briona Pieters          | Bethlehem Church                                    | Richmond Hill-NY |       | .00    |    |
+| 43 | Abigail Deshais         | God\'s Girlz                                        | Surprise-AZ      |       | .00    |    |
+| 43 | JJ Mair                 | 3 Men & A Lady                                      | Gahanna-OH       |       | .00    |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team               | Church           | W/L | Total | Avg    |
+|---:|--------------------|------------------|-----|------:|-------:|
+| 1  | Bethel Flames      | San Jose-CA      | 7/2 | 1280  | 142.22 |
+| 2  | 105                | Wesley Chapel-FL | 6/3 | 1330  | 147.78 |
+| 3  | Buzz Hogs          | Mabelvale-AR     | 6/3 | 1440  | 160.00 |
+| 4  | Bible Saints       | Princeton-MN     | 5/4 | 1265  | 140.56 |
+| 5  | BC United          | Wyckoff-NJ       | 5/4 | 1170  | 130.00 |
+| 6  | SALT               | Greensboro-NC    | 4/5 | 1350  | 150.00 |
+| 7  | Word Warriors      | Flower Mound-TX  | 4/5 | 1475  | 163.89 |
+| 8  | IAG Soaring Eagles | Gilbert-AZ       | 3/6 | 1100  | 122.22 |
+| 9  | JAG                | Meriden-KS       | 3/6 | 1050  | 116.67 |
+| 10 | New Life Pineville | Waxhaw-NC        | 2/7 | 1095  | 121.67 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team               | Church           | Total | Avg    | QO |
+|---:|---------------------|--------------------|------------------|------:|-------:|---:|
+| 1  | Jared Minick        | Buzz Hogs          | Mabelvale-AR     | 1040  | 115.56 | 6  |
+| 2  | Madie Rawlings      | Word Warriors      | Flower Mound-TX  | 850   | 94.44  | 3  |
+| 3  | Samuel Jebaraj      | Bethel Flames      | San Jose-CA      | 655   | 72.78  | 1  |
+| 4  | Connor Patterson    | SALT               | Greensboro-NC    | 610   | 67.78  | 1  |
+| 5  | Naomi Hagstrom      | Bible Saints       | Princeton-MN     | 585   | 65.00  | 2  |
+| 6  | Catrina Palmer      | 105                | Wesley Chapel-FL | 565   | 62.78  |    |
+| 7  | Michelle Koshy      | IAG Soaring Eagles | Gilbert-AZ       | 515   | 57.22  |    |
+| 8  | Cayla Brodeur       | BC United          | Wyckoff-NJ       | 460   | 51.11  | 2  |
+| 9  | Julia Rivera        | JAG                | Meriden-KS       | 460   | 51.11  | 1  |
+| 10 | Elizabeth Beekman   | New Life Pineville | Waxhaw-NC        | 450   | 50.00  | 3  |
+| 11 | Gabriella Hamvas    | Bible Saints       | Princeton-MN     | 450   | 50.00  | 2  |
+| 12 | Helyn Dunn          | 105                | Wesley Chapel-FL | 450   | 50.00  | 1  |
+| 13 | Savanah Biniakewitz | Buzz Hogs          | Mabelvale-AR     | 395   | 43.89  | 3  |
+| 14 | Alex Rawlings       | Word Warriors      | Flower Mound-TX  | 380   | 42.22  | 2  |
+| 15 | Isaiah Madonia      | SALT               | Greensboro-NC    | 350   | 38.89  | 3  |
+| 16 | Isaac Wuerffel      | New Life Pineville | Waxhaw-NC        | 350   | 38.89  |    |
+| 17 | Rachel Adelmann     | BC United          | Wyckoff-NJ       | 340   | 37.78  |    |
+| 18 | Gabriel Roberts     | Bethel Flames      | San Jose-CA      | 320   | 35.56  |    |
+| 19 | Gigi Palmer         | 105                | Wesley Chapel-FL | 315   | 35.00  |    |
+| 20 | Paul Daniel         | Bethel Flames      | San Jose-CA      | 305   | 33.89  | 1  |
+| 21 | Benjamin Beekman    | New Life Pineville | Waxhaw-NC        | 295   | 32.78  |    |
+| 22 | Jomi Malayil        | IAG Soaring Eagles | Gilbert-AZ       | 285   | 31.67  | 1  |
+| 23 | Karina Settles      | SALT               | Greensboro-NC    | 255   | 28.33  |    |
+| 24 | Lauren Oliver       | Word Warriors      | Flower Mound-TX  | 230   | 25.56  |    |
+| 25 | Nathan Kuenzi       | JAG                | Meriden-KS       | 225   | 25.00  | 1  |
+| 26 | Jonathan Moore      | JAG                | Meriden-KS       | 225   | 25.00  |    |
+| 27 | Emma Moorman        | BC United          | Wyckoff-NJ       | 170   | 18.89  |    |
+| 28 | Wyatt Lawrence      | Bible Saints       | Princeton-MN     | 165   | 18.33  | 1  |
+| 29 | Joshua Wearne       | JAG                | Meriden-KS       | 140   | 15.56  |    |
+| 29 | Sarah Settles       | SALT               | Greensboro-NC    | 140   | 15.56  |    |
+| 30 | Joel Joseph         | IAG Soaring Eagles | Gilbert-AZ       | 135   | 15.00  |    |
+| 31 | Garrett Adelmann    | BC United          | Wyckoff-NJ       | 125   | 13.89  |    |
+| 32 | Gavin Kuruvilla     | IAG Soaring Eagles | Gilbert-AZ       | 95    | 10.56  |    |
+| 33 | Albin Mathew        | IAG Soaring Eagles | Gilbert-AZ       | 70    | 7.78   |    |
+| 34 | Emanuel Lewis       | BC United          | Wyckoff-NJ       | 65    | 7.22   |    |
+| 35 | Jake Hagstrom       | Bible Saints       | Princeton-MN     | 25    | 2.78   |    |
+| 36 | Kyle Moos           | Bible Saints       | Princeton-MN     | 20    | 2.22   |    |
+| 36 | Wade Lawrence       | Bible Saints       | Princeton-MN     | 20    | 2.22   |    |
+| 37 | Jonny Parker        | Word Warriors      | Flower Mound-TX  | 15    | 1.67   |    |
+| 38 | Todd Pettet         | BC United          | Wyckoff-NJ       | 10    | 1.11   |    |
+| 39 | Darius Crawford     | Buzz Hogs          | Mabelvale-AR     | 5     | .56    |    |
+| 40 | Daniel Hudson       | New Life Pineville | Waxhaw-NC        |       | .00    |    |
+| 40 | Levi Biniakewitz    | Buzz Hogs          | Mabelvale-AR     |       | .00    |    |
+
+
+### Silver
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team               | Church           | W/L | Total | Avg    |
+|---:|--------------------|------------------|-----|------:|-------:|
+| 1  | FIRE               | Norcross-GA      | 8/1 | 1640  | 182.22 |
+| 2  | Brickmasters       | Racine-WI        | 6/3 | 1430  | 158.89 |
+| 3  | S.O.S.             | Mikwaukee-WI     | 5/4 | 1275  | 141.67 |
+| 4  | Vailsburg Victors  | Newark-NJ        | 5/4 | 1415  | 157.22 |
+| 5  | Spirit Squadron    | West Mifflin -PA | 4/5 | 1295  | 143.89 |
+| 6  | Eternal Eight      | Hamburg-PA       | 4/5 | 1230  | 136.67 |
+| 7  | TNT                | Louisville-KY    | 4/5 | 1215  | 135.00 |
+| 8  | Bethel Eagles      | San Jose-CA      | 4/5 | 1165  | 129.44 |
+| 9  | Double-Edged Sword | Irvine-CA        | 4/5 | 1120  | 124.44 |
+| 10 | Torches of Truth   | Humble-TX        | 1/8 | 770   | 85.56  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                    | Team               | Church           | Total | Avg    | QO |
+|---:|----------------------------|--------------------|------------------|------:|-------:|---:|
+| 1  | Ronald George              | FIRE               | Norcross-GA      | 1060  | 117.78 | 7  |
+| 2  | Brooklyne Sederwall        | Vailsburg Victors  | Newark-NJ        | 755   | 83.89  | 2  |
+| 3  | Trey Crowley               | Eternal Eight      | Hamburg-PA       | 685   | 76.11  | 3  |
+| 4  | Nathaniel Duncan           | S.O.S.             | Mikwaukee-WI     | 685   | 76.11  | 2  |
+| 5  | Jonathan Haung             | Double-Edged Sword | Irvine-CA        | 675   | 75.00  | 2  |
+| 6  | Noah Barnes                | TNT                | Louisville-KY    | 655   | 72.78  | 3  |
+| 7  | Rebekah Toeller            | Brickmasters       | Racine-WI        | 580   | 64.44  |    |
+| 8  | Jessica Kyzer              | S.O.S.             | Mikwaukee-WI     | 465   | 51.67  | 5  |
+| 9  | Timothy Nirmal             | Bethel Eagles      | San Jose-CA      | 450   | 50.00  |    |
+| 10 | Reanna Toeller             | Brickmasters       | Racine-WI        | 445   | 49.44  | 2  |
+| 11 | Alvin Johann Vasanthakumar | FIRE               | Norcross-GA      | 400   | 44.44  | 5  |
+| 12 | Trevor Webb                | TNT                | Louisville-KY    | 385   | 42.78  |    |
+| 13 | Fran-jec Makoule           | Vailsburg Victors  | Newark-NJ        | 345   | 38.33  | 3  |
+| 14 | Brennan McCreary           | Spirit Squadron    | West Mifflin -PA | 345   | 38.33  | 2  |
+| 15 | Joseph Raines              | Torches of Truth   | Humble-TX        | 340   | 37.78  |    |
+| 16 | David Daniel               | Bethel Eagles      | San Jose-CA      | 320   | 35.56  |    |
+| 17 | Hannah Brown               | Spirit Squadron    | West Mifflin -PA | 310   | 34.44  |    |
+| 18 | Abigail Bartynski          | Eternal Eight      | Hamburg-PA       | 250   | 27.78  | 2  |
+| 19 | Jabez Williams             | Bethel Eagles      | San Jose-CA      | 250   | 27.78  | 1  |
+| 20 | LeeAnn Harris              | Spirit Squadron    | West Mifflin -PA | 245   | 27.22  |    |
+| 21 | Acacia Todd                | Vailsburg Victors  | Newark-NJ        | 240   | 26.67  | 1  |
+| 22 | Will Brugos                | Spirit Squadron    | West Mifflin -PA | 240   | 26.67  |    |
+| 23 | Jayden Garrison            | Brickmasters       | Racine-WI        | 215   | 23.89  | 1  |
+| 24 | Jonathan Turner            | Torches of Truth   | Humble-TX        | 200   | 22.22  |    |
+| 25 | Emmanuel Joshua Yesudasan  | FIRE               | Norcross-GA      | 190   | 21.11  |    |
+| 26 | Trea Webb                  | TNT                | Louisville-KY    | 175   | 19.44  | 2  |
+| 27 | Joseph Nguyen              | Torches of Truth   | Humble-TX        | 170   | 18.89  | 1  |
+| 28 | Tabitha Nirmal             | Bethel Eagles      | San Jose-CA      | 145   | 16.11  |    |
+| 29 | Timothy Crowley            | Eternal Eight      | Hamburg-PA       | 140   | 15.56  |    |
+| 30 | Calvin Lee                 | Double-Edged Sword | Irvine-CA        | 130   | 14.44  |    |
+| 31 | Andrew Li                  | Double-Edged Sword | Irvine-CA        | 125   | 13.89  |    |
+| 32 | Caleb O\'Neil              | S.O.S.             | Mikwaukee-WI     | 110   | 12.22  |    |
+| 33 | Brandon Baer               | Brickmasters       | Racine-WI        | 100   | 11.11  |    |
+| 34 | Reagan McCreary            | Spirit Squadron    | West Mifflin -PA | 95    | 10.56  |    |
+| 35 | Joshua Zhang               | Double-Edged Sword | Irvine-CA        | 75    | 8.33   |    |
+| 36 | Joshua Zou                 | Double-Edged Sword | Irvine-CA        | 65    | 7.22   |    |
+| 36 | Thomas Pospisil            | Eternal Eight      | Hamburg-PA       | 65    | 7.22   |    |
+| 37 | Johnny Nguyen              | Torches of Truth   | Humble-TX        | 60    | 6.67   |    |
+| 38 | Christopher Yen            | Double-Edged Sword | Irvine-CA        | 55    | 6.11   |    |
+| 39 | Sam David                  | Brickmasters       | Racine-WI        | 50    | 5.56   |    |
+| 40 | Sierra Fisher              | Eternal Eight      | Hamburg-PA       | 40    | 4.44   |    |
+| 40 | Gabriella Keim             | Eternal Eight      | Hamburg-PA       | 40    | 4.44   |    |
+| 40 | Kelsey McCafferty          | Spirit Squadron    | West Mifflin -PA | 40    | 4.44   |    |
+| 40 | Marvelous Ekeh             | Vailsburg Victors  | Newark-NJ        | 40    | 4.44   |    |
+| 41 | Mia Howell                 | Vailsburg Victors  | Newark-NJ        | 35    | 3.89   |    |
+| 42 | Naomi Lewis                | Brickmasters       | Racine-WI        | 30    | 3.33   |    |
+| 42 | Rachel Stanton             | Brickmasters       | Racine-WI        | 30    | 3.33   |    |
+| 43 | Samantha Pieper            | S.O.S.             | Mikwaukee-WI     | 20    | 2.22   |    |
+| 43 | Brandon Navilliat          | Spirit Squadron    | West Mifflin -PA | 20    | 2.22   |    |
+| 43 | Carley Cox                 | Eternal Eight      | Hamburg-PA       | 20    | 2.22   |    |
+| 44 | Hannah G Daniel            | FIRE               | Norcross-GA      |       | .00    |    |
+| 44 | Kevin Yao                  | Double-Edged Sword | Irvine-CA        |       | .00    |    |
+| 44 | Phoebe Wang                | Double-Edged Sword | Irvine-CA        |       | .00    |    |
+| 44 | Roshan Muthugomu           | FIRE               | Norcross-GA      |       | .00    |    |
+| 44 | Timmy Thomas               | FIRE               | Norcross-GA      |       | .00    |    |
+| 44 | Maria Britto               | FIRE               | Norcross-GA      |       | .00    |    |
+| 44 | Alleyah Schappell          | Eternal Eight      | Hamburg-PA       |       | .00    |    |
+| 44 | Victoria Weidner           | S.O.S.             | Mikwaukee-WI     |       | .00    |    |
+| 44 | Andrew Cox                 | TNT                | Louisville-KY    |       | .00    |    |
+| 45 | Eunice Stephen             | FIRE               | Norcross-GA      | -10   | -1.11  |    |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                       | Church          | W/L | Total | Avg    |
+|---:|----------------------------|-----------------|-----|------:|-------:|
+| 1  | XBOX                       | Lakeville-MN    | 7/2 | 1510  | 167.78 |
+| 2  | D.D.D.                     | Mustang-OK      | 6/3 | 1510  | 167.78 |
+| 3  | North Scottsdale Christian | Scottsdale-AZ   | 6/3 | 1500  | 166.67 |
+| 4  | Binghamton                 | Binghamton-NY   | 5/4 | 1210  | 134.44 |
+| 5  | Comets                     | New Richmond-WI | 4/5 | 1295  | 143.89 |
+| 6  | DSI                        | Lakeville-MN    | 4/5 | 1235  | 137.22 |
+| 7  | Searcy Fruit Loops         | Searcy-AR       | 4/5 | 1140  | 126.67 |
+| 8  | Smileys                    | Huntington-WV   | 4/5 | 960   | 106.67 |
+| 9  | Kansas Jayhawks            | Great Bend-KS   | 3/6 | 1230  | 136.67 |
+| 10 | Knights in Shining Armour  | Springfield-MO  | 2/7 | 890   | 98.89  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                       | Church          | Total | Avg    | QO |
+|---:|---------------------|----------------------------|-----------------|------:|-------:|---:|
+| 1  | Sydney Ames         | XBOX                       | Lakeville-MN    | 975   | 108.33 | 4  |
+| 2  | David Moses         | North Scottsdale Christian | Scottsdale-AZ   | 865   | 96.11  | 4  |
+| 3  | Caleb Horn          | D.D.D.                     | Mustang-OK      | 755   | 83.89  | 3  |
+| 4  | Noah Hensley        | Smileys                    | Huntington-WV   | 745   | 82.78  | 3  |
+| 5  | Korbin Widiger      | Kansas Jayhawks            | Great Bend-KS   | 695   | 77.22  | 2  |
+| 6  | Allison Shipman     | Searcy Fruit Loops         | Searcy-AR       | 480   | 53.33  |    |
+| 7  | Sharon Morara       | DSI                        | Lakeville-MN    | 475   | 52.78  |    |
+| 8  | Caleb Blomberg      | Comets                     | New Richmond-WI | 430   | 47.78  | 2  |
+| 9  | Ashton Heath        | DSI                        | Lakeville-MN    | 430   | 47.78  |    |
+| 10 | Caleb Gerhart       | Binghamton                 | Binghamton-NY   | 425   | 47.22  | 4  |
+| 11 | Emma Wolfe          | Knights in Shining Armour  | Springfield-MO  | 420   | 46.67  | 2  |
+| 12 | Lauren Grisham      | D.D.D.                     | Mustang-OK      | 385   | 42.78  |    |
+| 13 | David Blomberg      | Comets                     | New Richmond-WI | 370   | 41.11  | 1  |
+| 14 | Nick Congdon        | Binghamton                 | Binghamton-NY   | 355   | 39.44  | 1  |
+| 15 | Andrew Scarinzi     | Binghamton                 | Binghamton-NY   | 330   | 36.67  |    |
+| 16 | Mitchell Covey      | Comets                     | New Richmond-WI | 320   | 35.56  |    |
+| 17 | Andrew Emberson     | Searcy Fruit Loops         | Searcy-AR       | 315   | 35.00  |    |
+| 18 | Joanna Moses        | North Scottsdale Christian | Scottsdale-AZ   | 310   | 34.44  | 1  |
+| 19 | Landon Grisham      | D.D.D.                     | Mustang-OK      | 300   | 33.33  | 2  |
+| 20 | Holly Garrett       | North Scottsdale Christian | Scottsdale-AZ   | 275   | 30.56  | 2  |
+| 21 | Gabe Loper          | Knights in Shining Armour  | Springfield-MO  | 275   | 30.56  | 1  |
+| 22 | Bryce Lofton        | DSI                        | Lakeville-MN    | 260   | 28.89  | 1  |
+| 23 | Dakota Marsh        | Searcy Fruit Loops         | Searcy-AR       | 235   | 26.11  |    |
+| 24 | Robby Brining       | Kansas Jayhawks            | Great Bend-KS   | 210   | 23.33  | 1  |
+| 25 | Kyle Ringley        | XBOX                       | Lakeville-MN    | 210   | 23.33  |    |
+| 25 | Abby MacKinney      | Kansas Jayhawks            | Great Bend-KS   | 210   | 23.33  |    |
+| 26 | Levi Cooper         | Knights in Shining Armour  | Springfield-MO  | 185   | 20.56  |    |
+| 27 | Joelle Rapp         | Comets                     | New Richmond-WI | 170   | 18.89  |    |
+| 28 | Zach Morara         | XBOX                       | Lakeville-MN    | 165   | 18.33  |    |
+| 29 | Mark Ziegler        | Smileys                    | Huntington-WV   | 150   | 16.67  |    |
+| 30 | Michael Shipman     | Searcy Fruit Loops         | Searcy-AR       | 110   | 12.22  |    |
+| 30 | Gabby Ringley       | XBOX                       | Lakeville-MN    | 110   | 12.22  |    |
+| 31 | Alexander Patterson | Binghamton                 | Binghamton-NY   | 100   | 11.11  |    |
+| 32 | Kailan Weidner      | D.D.D.                     | Mustang-OK      | 70    | 7.78   |    |
+| 32 | Savannah Reid       | DSI                        | Lakeville-MN    | 70    | 7.78   |    |
+| 33 | Lisa Marlow         | Kansas Jayhawks            | Great Bend-KS   | 65    | 7.22   |    |
+| 34 | Tia Willett         | North Scottsdale Christian | Scottsdale-AZ   | 50    | 5.56   |    |
+| 34 | Kaitlyn Mohr        | XBOX                       | Lakeville-MN    | 50    | 5.56   |    |
+| 35 | Caitlyn Leedy       | Smileys                    | Huntington-WV   | 35    | 3.89   |    |
+| 36 | Julia White         | Smileys                    | Huntington-WV   | 30    | 3.33   |    |
+| 36 | Skyler Mayhan       | Kansas Jayhawks            | Great Bend-KS   | 30    | 3.33   |    |
+| 37 | Joshuah Muiruri     | Kansas Jayhawks            | Great Bend-KS   | 20    | 2.22   |    |
+| 38 | Zeke Loper          | Knights in Shining Armour  | Springfield-MO  | 15    | 1.67   |    |
+| 39 | Owen Covey          | Comets                     | New Richmond-WI | 5     | .56    |    |
+| 40 | Annah Hensley       | Smileys                    | Huntington-WV   |       | .00    |    |
+| 40 | Noah Daniel         | Smileys                    | Huntington-WV   |       | .00    |    |
+| 40 | Olivia Lowe         | Smileys                    | Huntington-WV   |       | .00    |    |
+| 40 | Lacey Leebrick      | North Scottsdale Christian | Scottsdale-AZ   |       | .00    |    |
+| 40 | Alyssa Lowe         | Smileys                    | Huntington-WV   |       | .00    |    |
+| 40 | Seth Crawford       | Comets                     | New Richmond-WI |       | .00    |    |
+| 40 | Tristan Steel       | Comets                     | New Richmond-WI |       | .00    |    |
+| 40 | Samantha Brown      | Comets                     | New Richmond-WI |       | .00    |    |
+| 40 | Carmen Schmidt      | North Scottsdale Christian | Scottsdale-AZ   |       | .00    |    |
+| 40 | Talitha Weedon      | North Scottsdale Christian | Scottsdale-AZ   |       | .00    |    |
+| 40 | Lance Cooper        | Knights in Shining Armour  | Springfield-MO  |       | .00    |    |
+| 40 | Catherine Wolfe     | Knights in Shining Armour  | Springfield-MO  |       | .00    |    |
+| 40 | Sarah Sager         | Binghamton                 | Binghamton-NY   |       | .00    |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                            | Church          | W/L | Total | Avg    |
+|---:|---------------------------------|-----------------|-----|------:|-------:|
+| 1  | Bismarck Boppin\' Bible Buzzers | Bismarck-ND     | 8/1 | 1570  | 174.44 |
+| 2  | DAG Church                      | Decatur-AR      | 7/2 | 1525  | 169.44 |
+| 3  | CIA - Special Agents            | Mendon-MA       | 6/3 | 1515  | 168.33 |
+| 4  | Westgate A Team                 | Edmonds-WA      | 5/4 | 1300  | 144.44 |
+| 5  | Kidtricity                      | Montgomery-AL   | 5/4 | 1225  | 136.11 |
+| 6  | PCC Giant Slayers               | Portland-OR     | 4/5 | 1335  | 148.33 |
+| 7  | Chosen Ones                     | Houston-TX      | 3/6 | 1105  | 122.78 |
+| 8  | Freedom Fighters                | Collierville-TN | 3/6 | 1130  | 125.56 |
+| 9  | Salt Shakers                    | Lubbock-TX      | 2/7 | 1075  | 119.44 |
+| 10 | Masters                         | Dodson-LA       | 2/7 | 740   | 82.22  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                            | Church          | Total | Avg    | QO |
+|---:|-------------------|---------------------------------|-----------------|------:|-------:|---:|
+| 1  | Noah Ku           | Westgate A Team                 | Edmonds-WA      | 1060  | 117.78 | 7  |
+| 2  | Kaden Sago        | Bismarck Boppin\' Bible Buzzers | Bismarck-ND     | 1035  | 115.00 | 3  |
+| 3  | Samy Gunaraj      | Freedom Fighters                | Collierville-TN | 870   | 96.67  | 5  |
+| 4  | Tayla Vannelli    | CIA - Special Agents            | Mendon-MA       | 695   | 77.22  | 1  |
+| 5  | Amanda Duncan     | DAG Church                      | Decatur-AR      | 690   | 76.67  | 3  |
+| 6  | Christian Hart    | Kidtricity                      | Montgomery-AL   | 585   | 65.00  |    |
+| 7  | Brendon Johnson   | Salt Shakers                    | Lubbock-TX      | 500   | 55.56  | 1  |
+| 8  | Shannon Morrill   | CIA - Special Agents            | Mendon-MA       | 490   | 54.44  | 2  |
+| 9  | Angel McNeil      | Salt Shakers                    | Lubbock-TX      | 465   | 51.67  | 4  |
+| 10 | Matt Anderson     | DAG Church                      | Decatur-AR      | 450   | 50.00  | 5  |
+| 11 | Ari Lauthner      | PCC Giant Slayers               | Portland-OR     | 440   | 48.89  | 1  |
+| 12 | My\'Randa Tolar   | Masters                         | Dodson-LA       | 405   | 45.00  | 3  |
+| 13 | Daniel Duran Jr.  | PCC Giant Slayers               | Portland-OR     | 400   | 44.44  | 1  |
+| 14 | Chizaram Ajiwe    | Chosen Ones                     | Houston-TX      | 375   | 41.67  | 1  |
+| 15 | Rylan Sago        | Bismarck Boppin\' Bible Buzzers | Bismarck-ND     | 355   | 39.44  | 2  |
+| 16 | Trey Anderson     | DAG Church                      | Decatur-AR      | 335   | 37.22  |    |
+| 17 | Kaylen Williams   | Masters                         | Dodson-LA       | 310   | 34.44  |    |
+| 18 | James Patterson   | Kidtricity                      | Montgomery-AL   | 290   | 32.22  | 1  |
+| 19 | Micah Brown       | Kidtricity                      | Montgomery-AL   | 275   | 30.56  |    |
+| 20 | Evan Llafet       | PCC Giant Slayers               | Portland-OR     | 265   | 29.44  |    |
+| 21 | Josiah Tveit      | Westgate A Team                 | Edmonds-WA      | 245   | 27.22  | 2  |
+| 22 | Stephanie Oyolu   | Chosen Ones                     | Houston-TX      | 210   | 23.33  |    |
+| 23 | Danielle Hanks    | Freedom Fighters                | Collierville-TN | 200   | 22.22  | 1  |
+| 24 | Chimezirim Nwogu  | Chosen Ones                     | Houston-TX      | 190   | 21.11  | 2  |
+| 25 | Fatih Caughey     | CIA - Special Agents            | Mendon-MA       | 190   | 21.11  |    |
+| 26 | Emiliano Duran    | PCC Giant Slayers               | Portland-OR     | 175   | 19.44  |    |
+| 27 | Brooke Leingang   | Bismarck Boppin\' Bible Buzzers | Bismarck-ND     | 145   | 16.11  |    |
+| 27 | Michelle Vannelli | CIA - Special Agents            | Mendon-MA       | 145   | 16.11  |    |
+| 28 | Rachel Mgbeike    | Chosen Ones                     | Houston-TX      | 125   | 13.89  |    |
+| 29 | Kelton Johnson    | Salt Shakers                    | Lubbock-TX      | 110   | 12.22  |    |
+| 30 | Michael Wooten    | Chosen Ones                     | Houston-TX      | 95    | 10.56  | 1  |
+| 31 | Vistoria Wooten   | Chosen Ones                     | Houston-TX      | 85    | 9.44   | 1  |
+| 32 | Trey Hanks        | Freedom Fighters                | Collierville-TN | 60    | 6.67   |    |
+| 32 | Katya Brodsky     | PCC Giant Slayers               | Portland-OR     | 60    | 6.67   |    |
+| 33 | Johanna Day       | DAG Church                      | Decatur-AR      | 55    | 6.11   |    |
+| 34 | Brandon Martin    | Kidtricity                      | Montgomery-AL   | 45    | 5.00   |    |
+| 35 | Wayne Ellis       | Chosen Ones                     | Houston-TX      | 35    | 3.89   |    |
+| 35 | Kaylee Freyer     | Bismarck Boppin\' Bible Buzzers | Bismarck-ND     | 35    | 3.89   |    |
+| 36 | Skyla Walker      | Masters                         | Dodson-LA       | 30    | 3.33   |    |
+| 36 | Jessie Lipska     | Kidtricity                      | Montgomery-AL   | 30    | 3.33   |    |
+| 37 | Grace McNeil      | Salt Shakers                    | Lubbock-TX      |       | .00    |    |
+| 37 | Amber Lydon       | DAG Church                      | Decatur-AR      |       | .00    |    |
+| 38 | Nicole Ellis      | Chosen Ones                     | Houston-TX      | -10   | -1.11  |    |
+| 39 | Ethan Walker      | Masters                         | Dodson-LA       | -5    | -0.56  |    |
+

--- a/_pages/jbq/2013/index.md
+++ b/_pages/jbq/2013/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2013 JBQ Season"
+permalink: /jbq/2013/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+<a href="{% link _pages/jbq/2013/nationals.md %}" class="button is-primary">National Finals</a>
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2013/nationals.md
+++ b/_pages/jbq/2013/nationals.md
@@ -1,0 +1,665 @@
+---
+layout: page
+title: "2013 National Festival: Cedar Hill, Texas"
+permalink: /jbq/2013/nationals/
+date: "2015-06-10"
+toc_title: Results
+menubar_toc: true
+---
+
+## Friday (AM)
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                     | Church        | W/L | Total | Avg    |
+|--:|--------------------------|---------------|-----|------:|-------:|
+| 1 | Bible Boyz - 117         | Orlando-FL    | 5/2 | 1300  | 185.71 |
+| 2 | Super 6                  | Cedar Hill-TX | 5/2 | 1290  | 184.29 |
+| 3 | Quizzen for the Rizen    | Novi-MI       | 5/2 | 1280  | 182.86 |
+| 4 | Archangels               | Louisville-OH | 5/2 | 1160  | 165.71 |
+| 5 | Christ Ambassadors       | Gilbert -AZ   | 3/4 | 830   | 118.57 |
+| 6 | Avengers of God (A.O.G.) | Lakeville-MN  | 3/4 | 825   | 117.86 |
+| 7 | Pillars of Fire          | Marlboro-NJ   | 2/5 | 900   | 128.57 |
+| 8 | Truth Seekers            | Shreveport-LA | 0/7 | 380   | 54.29  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                     | Church        | Total | Avg    | QO |
+|---:|--------------------|--------------------------|---------------|------:|-------:|---:|
+| 1  | Connor Norquest    | Archangels               | Louisville-OH | 700   | 100.00 | 3  |
+| 2  | Lynnae Chapman     | Quizzen for the Rizen    | Novi-MI       | 595   | 85.00  | 2  |
+| 3  | Megan Holleman     | Quizzen for the Rizen    | Novi-MI       | 525   | 75.00  | 5  |
+| 4  | Parker Lubbe       | Super 6                  | Cedar Hill-TX | 480   | 68.57  | 2  |
+| 5  | Jonah Woodbine     | Bible Boyz - 117         | Orlando-FL    | 480   | 68.57  | 1  |
+| 6  | Esteban Suarez     | Bible Boyz - 117         | Orlando-FL    | 445   | 63.57  | 6  |
+| 7  | Joel Valliath      | Pillars of Fire          | Marlboro-NJ   | 445   | 63.57  |    |
+| 8  | Gavin Kuruvilla    | Christ Ambassadors       | Gilbert -AZ   | 430   | 61.43  | 3  |
+| 9  | Cameron Norquest   | Archangels               | Louisville-OH | 405   | 57.86  | 4  |
+| 10 | Jamison Price      | Super 6                  | Cedar Hill-TX | 375   | 53.57  | 5  |
+| 11 | Joshua Steward     | Bible Boyz - 117         | Orlando-FL    | 375   | 53.57  | 1  |
+| 12 | Eden Stergion      | Avengers of God (A.O.G.) | Lakeville-MN  | 345   | 49.29  |    |
+| 13 | Kendall Calvery    | Super 6                  | Cedar Hill-TX | 270   | 38.57  |    |
+| 14 | Albin Mathew       | Christ Ambassadors       | Gilbert -AZ   | 235   | 33.57  |    |
+| 15 | Ashton Heath       | Avengers of God (A.O.G.) | Lakeville-MN  | 230   | 32.86  |    |
+| 16 | Julianne Marmion   | Pillars of Fire          | Marlboro-NJ   | 225   | 32.14  | 1  |
+| 17 | Logan Mayo         | Truth Seekers            | Shreveport-LA | 225   | 32.14  |    |
+| 18 | Zach Morara        | Avengers of God (A.O.G.) | Lakeville-MN  | 165   | 23.57  |    |
+| 19 | Josh Barajas       | Super 6                  | Cedar Hill-TX | 155   | 22.14  |    |
+| 20 | Isaac Erickson     | Truth Seekers            | Shreveport-LA | 130   | 18.57  |    |
+| 21 | Austin Chmiel      | Quizzen for the Rizen    | Novi-MI       | 120   | 17.14  |    |
+| 22 | Andrew Mascarillo  | Pillars of Fire          | Marlboro-NJ   | 110   | 15.71  |    |
+| 23 | Ethan Valliath     | Pillars of Fire          | Marlboro-NJ   | 100   | 14.29  |    |
+| 24 | Joel Joseoh        | Christ Ambassadors       | Gilbert -AZ   | 80    | 11.43  |    |
+| 25 | Jomi Malayil       | Christ Ambassadors       | Gilbert -AZ   | 75    | 10.71  |    |
+| 25 | Bryce Lofton       | Avengers of God (A.O.G.) | Lakeville-MN  | 75    | 10.71  |    |
+| 26 | Caitie Bailey      | Archangels               | Louisville-OH | 55    | 7.86   |    |
+| 27 | Leandra Marlow     | Quizzen for the Rizen    | Novi-MI       | 40    | 5.71   |    |
+| 28 | Griffin Williams   | Truth Seekers            | Shreveport-LA | 20    | 2.86   |    |
+| 28 | Emma Mascarillo    | Pillars of Fire          | Marlboro-NJ   | 20    | 2.86   |    |
+| 29 | Alec Stergion      | Avengers of God (A.O.G.) | Lakeville-MN  | 10    | 1.43   |    |
+| 29 | Emma Mller         | Super 6                  | Cedar Hill-TX | 10    | 1.43   |    |
+| 29 | Sahun Karakkattu   | Christ Ambassadors       | Gilbert -AZ   | 10    | 1.43   |    |
+| 30 | Joshua Flippo      | Truth Seekers            | Shreveport-LA | 5     | .71    |    |
+| 31 | Caroline Tew       | Truth Seekers            | Shreveport-LA |       | .00    |    |
+| 31 | Braden Tew         | Truth Seekers            | Shreveport-LA |       | .00    |    |
+| 31 | Jonathon Bonzelaar | Quizzen for the Rizen    | Novi-MI       |       | .00    |    |
+| 31 | Jocelyn McMillen   | Archangels               | Louisville-OH |       | .00    |    |
+| 31 | Sarah Carrico      | Archangels               | Louisville-OH |       | .00    |    |
+
+
+### Cream
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                   | Church         | W/L | Total | Avg    |
+|--:|------------------------|----------------|-----|------:|-------:|
+| 1 | Lawson Illuminators #2 | Lawson-MO      | 6/0 | 1100  | 183.33 |
+| 2 | BC United              | Wyckoff-NJ     | 5/2 | 1175  | 167.86 |
+| 3 | Calvary West           | Sugar Grove-IL | 4/3 | 1210  | 172.86 |
+| 4 | ATC Flames             | Norcross-GA    | 3/3 | 1015  | 169.17 |
+| 5 | God\'s Girlz           | Surprise-AZ    | 3/3 | 835   | 139.17 |
+| 6 | DeSoto Doves           | DeSoto-MO      | 2/4 | 865   | 144.17 |
+| 7 | Faithful Falcons       | Austin-TX      | 2/4 | 740   | 123.33 |
+| 8 | Parkway                | Grants Pass-OR | 0/6 | 385   | 64.17  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                   | Team                   | Church         | Total | Avg    | QO |
+|---:|---------------------------|------------------------|----------------|------:|-------:|---:|
+| 1  | Breanna Cole              | Lawson Illuminators #2 | Lawson-MO      | 715   | 119.17 | 3  |
+| 2  | Mark Grogan               | DeSoto Doves           | DeSoto-MO      | 645   | 107.50 | 3  |
+| 3  | Ezequiel Navarro          | Calvary West           | Sugar Grove-IL | 560   | 80.00  | 2  |
+| 4  | Jonathan Schweitzer       | Calvary West           | Sugar Grove-IL | 540   | 77.14  | 3  |
+| 5  | Faith Brown               | God\'s Girlz           | Surprise-AZ    | 535   | 89.17  | 4  |
+| 6  | Ronald George             | ATC Flames             | Norcross-GA    | 515   | 85.83  | 1  |
+| 7  | Josh James                | Faithful Falcons       | Austin-TX      | 485   | 80.83  | 2  |
+| 8  | Emmanuel Joshua Yesudasan | ATC Flames             | Norcross-GA    | 445   | 74.17  | 4  |
+| 9  | Emma Moorman              | BC United              | Wyckoff-NJ     | 390   | 55.71  | 1  |
+| 10 | Cayla Brodeur             | BC United              | Wyckoff-NJ     | 390   | 55.71  |    |
+| 11 | Kenzie Brown              | God\'s Girlz           | Surprise-AZ    | 300   | 50.00  | 1  |
+| 12 | Emanuel Lewis             | BC United              | Wyckoff-NJ     | 280   | 40.00  | 3  |
+| 13 | Nick Cook                 | Lawson Illuminators #2 | Lawson-MO      | 265   | 44.17  | 3  |
+| 14 | Nicole Kemmer             | Parkway                | Grants Pass-OR | 220   | 36.67  | 1  |
+| 15 | Rebekah Birrell           | Faithful Falcons       | Austin-TX      | 195   | 32.50  | 1  |
+| 16 | Jenna Wiltrout            | Parkway                | Grants Pass-OR | 185   | 30.83  |    |
+| 17 | Dominique Siegler         | DeSoto Doves           | DeSoto-MO      | 170   | 28.33  | 1  |
+| 18 | Luke Moorman              | BC United              | Wyckoff-NJ     | 115   | 16.43  |    |
+| 19 | Broxton Cole              | Lawson Illuminators #2 | Lawson-MO      | 80    | 13.33  |    |
+| 20 | Joshua Dupati             | ATC Flames             | Norcross-GA    | 65    | 10.83  |    |
+| 21 | Stacey Gell               | Faithful Falcons       | Austin-TX      | 60    | 10.00  |    |
+| 21 | Luke Lydecker             | Calvary West           | Sugar Grove-IL | 60    | 8.57   |    |
+| 22 | Chloe Mitchell            | DeSoto Doves           | DeSoto-MO      | 55    | 9.17   |    |
+| 23 | Ethan Searcy              | Lawson Illuminators #2 | Lawson-MO      | 40    | 6.67   |    |
+| 24 | Anna Somerlot             | Calvary West           | Sugar Grove-IL | 30    | 4.29   |    |
+| 25 | Kaitlyn Cardiel           | Parkway                | Grants Pass-OR | 25    | 4.17   |    |
+| 26 | Cameron Green             | Calvary West           | Sugar Grove-IL | 20    | 2.86   |    |
+| 27 | Christopher Schweitzer    | Calvary West           | Sugar Grove-IL |       | .00    |    |
+| 27 | Eleanor Barton            | Calvary West           | Sugar Grove-IL |       | .00    |    |
+| 27 | Grace Iranloye            | Calvary West           | Sugar Grove-IL |       | .00    |    |
+| 27 | Faith Blinn               | God\'s Girlz           | Surprise-AZ    |       | .00    |    |
+| 27 | Ashlyn Pamame             | God\'s Girlz           | Surprise-AZ    |       | .00    |    |
+| 27 | Luciana Salerno           | BC United              | Wyckoff-NJ     |       | .00    |    |
+| 27 | Keira Pamame              | God\'s Girlz           | Surprise-AZ    |       | .00    |    |
+| 27 | Joy Fambrough             | DeSoto Doves           | DeSoto-MO      |       | .00    |    |
+| 27 | Linda Jawahar             | ATC Flames             | Norcross-GA    |       | .00    |    |
+| 27 | Hailey Nichol             | DeSoto Doves           | DeSoto-MO      |       | .00    |    |
+| 27 | Shreyas                   | ATC Flames             | Norcross-GA    |       | .00    |    |
+| 27 | Carolyn Justifus          | ATC Flames             | Norcross-GA    |       | .00    |    |
+| 27 | Rishona Nadar             | ATC Flames             | Norcross-GA    |       | .00    |    |
+| 28 | Braden Pennington         | Parkway                | Grants Pass-OR | -35   | -5.83  |    |
+| 29 | Joshua Justifus           | ATC Flames             | Norcross-GA    | -10   | -1.67  |    |
+| 29 | Katie DeGeyter            | Parkway                | Grants Pass-OR | -10   | -1.67  |    |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church           | W/L | Total | Avg    |
+|--:|---------------------------|------------------|-----|------:|-------:|
+| 1 | Reign of Fire             | Waxahachie-TX    | 6/1 | 1355  | 193.57 |
+| 2 | S.P.Y. Girls              | Leesburg-VA      | 6/1 | 1255  | 179.29 |
+| 3 | Dayspring Assembly of God | Bowling Green-OH | 5/2 | 1125  | 160.71 |
+| 4 | iQuiz                     | New Richmond-WI  | 4/3 | 1125  | 160.71 |
+| 5 | DAG Church                | Decatur -AR      | 2/5 | 970   | 138.57 |
+| 6 | PACE POWER                | Pace-FL          | 2/5 | 825   | 117.86 |
+| 7 | Mighty Leviathans         | Costa Mesa-CA    | 2/5 | 750   | 107.14 |
+| 8 | Undignified               | Dumas-TX         | 1/6 | 895   | 127.86 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                      | Church           | Total | Avg    | QO |
+|---:|--------------------|---------------------------|------------------|------:|-------:|---:|
+| 1  | Celeste Zavala     | Undignified               | Dumas-TX         | 700   | 100.00 | 4  |
+| 2  | Diana Bozzay       | S.P.Y. Girls              | Leesburg-VA      | 610   | 87.14  | 2  |
+| 3  | Brayden Tompkins   | PACE POWER                | Pace-FL          | 575   | 82.14  | 2  |
+| 4  | Reuben Deemy       | Reign of Fire             | Waxahachie-TX    | 505   | 72.14  | 1  |
+| 5  | Shani Estep        | Dayspring Assembly of God | Bowling Green-OH | 495   | 70.71  | 1  |
+| 6  | Joelle Rapp        | iQuiz                     | New Richmond-WI  | 465   | 66.43  |    |
+| 7  | Pearl Smith        | Mighty Leviathans         | Costa Mesa-CA    | 460   | 65.71  | 2  |
+| 8  | Amanda Duncan      | DAG Church                | Decatur -AR      | 400   | 57.14  |    |
+| 9  | Vinton Deemy       | Reign of Fire             | Waxahachie-TX    | 385   | 55.00  | 2  |
+| 10 | Luke Kobylski      | Dayspring Assembly of God | Bowling Green-OH | 370   | 52.86  | 5  |
+| 11 | Matt Anderson      | DAG Church                | Decatur -AR      | 360   | 51.43  | 3  |
+| 12 | Emily Walsh        | S.P.Y. Girls              | Leesburg-VA      | 355   | 50.71  |    |
+| 13 | Jaqueline Martinez | Reign of Fire             | Waxahachie-TX    | 290   | 41.43  | 4  |
+| 14 | SiSi Dial          | S.P.Y. Girls              | Leesburg-VA      | 290   | 41.43  | 2  |
+| 15 | Owen Covey         | iQuiz                     | New Richmond-WI  | 200   | 28.57  | 1  |
+| 15 | Annie Akins        | Undignified               | Dumas-TX         | 200   | 28.57  | 1  |
+| 16 | Johanna Slembarski | Dayspring Assembly of God | Bowling Green-OH | 200   | 28.57  |    |
+| 17 | David Blomberg     | iQuiz                     | New Richmond-WI  | 180   | 25.71  |    |
+| 18 | Noah Saenz         | Reign of Fire             | Waxahachie-TX    | 175   | 25.00  | 2  |
+| 19 | Mitchell Covey     | iQuiz                     | New Richmond-WI  | 170   | 24.29  |    |
+| 20 | Trey Anderson      | DAG Church                | Decatur -AR      | 165   | 23.57  |    |
+| 21 | Victor Robinson    | PACE POWER                | Pace-FL          | 140   | 20.00  |    |
+| 22 | Dinah Lee Smith    | Mighty Leviathans         | Costa Mesa-CA    | 125   | 17.86  |    |
+| 23 | Gabriel Sirvent    | Mighty Leviathans         | Costa Mesa-CA    | 120   | 17.14  | 1  |
+| 24 | Caleb Blomberg     | iQuiz                     | New Richmond-WI  | 110   | 15.71  |    |
+| 25 | Josiah Davis       | PACE POWER                | Pace-FL          | 100   | 14.29  |    |
+| 26 | Annie Valantine    | Dayspring Assembly of God | Bowling Green-OH | 60    | 8.57   |    |
+| 27 | Jasmine Sirvent    | Mighty Leviathans         | Costa Mesa-CA    | 45    | 6.43   |    |
+| 28 | Johanna Day        | DAG Church                | Decatur -AR      | 20    | 2.86   |    |
+| 29 | Randi Jo Bolinger  | DAG Church                | Decatur -AR      | 15    | 2.14   |    |
+| 30 | Emma Anderson      | DAG Church                | Decatur -AR      | 10    | 1.43   |    |
+| 30 | Kaitlyn Skewes     | PACE POWER                | Pace-FL          | 10    | 1.43   |    |
+| 31 | Megan Johnson      | iQuiz                     | New Richmond-WI  |       | .00    |    |
+| 31 | Jason Rapp         | iQuiz                     | New Richmond-WI  |       | .00    |    |
+| 31 | Madison Wilkerson  | Dayspring Assembly of God | Bowling Green-OH |       | .00    |    |
+| 31 | Cara Hodge         | S.P.Y. Girls              | Leesburg-VA      |       | .00    |    |
+| 31 | Sophia Gustafson   | S.P.Y. Girls              | Leesburg-VA      |       | .00    |    |
+| 31 | Seth Crawford      | iQuiz                     | New Richmond-WI  |       | .00    |    |
+| 31 | Sam Philpott       | DAG Church                | Decatur -AR      |       | .00    |    |
+| 31 | Kia Vecchio        | Undignified               | Dumas-TX         |       | .00    |    |
+| 31 | Deegan Brooks      | DAG Church                | Decatur -AR      |       | .00    |    |
+
+
+### Mint
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                 | Church            | W/L | Total | Avg    |
+|--:|----------------------|-------------------|-----|------:|-------:|
+| 1 | Quiz Commanders      | Yorkville-IL      | 5/2 | 1285  | 183.57 |
+| 2 | Greensboro - WOW     | Greensboro-NC     | 5/2 | 1125  | 160.71 |
+| 3 | Love Boldly          | Tallahassee-FL    | 5/2 | 1065  | 152.14 |
+| 4 | Juicy Fruit Ninjas   | Branson-MO        | 4/3 | 1290  | 184.29 |
+| 5 | Thing 1              | St.Cloud-MN       | 4/3 | 1005  | 143.57 |
+| 6 | MCC Etoiles De Bible | Mechanicsville-VA | 3/4 | 795   | 113.57 |
+| 7 | Bellevue Buzzers     | Bellevue-WA       | 2/5 | 1010  | 144.29 |
+| 8 | Flamin\' Hot Buzzers | Albuquerque-NM    | 0/7 | 410   | 58.57  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                 | Church            | Total | Avg    | QO |
+|---:|----------------------|----------------------|-------------------|------:|-------:|---:|
+| 1  | Megumi Sinniah       | Juicy Fruit Ninjas   | Branson-MO        | 785   | 112.14 | 5  |
+| 2  | Trinity Garza        | Quiz Commanders      | Yorkville-IL      | 475   | 67.86  | 2  |
+| 3  | Aidan Rajesh         | Greensboro - WOW     | Greensboro-NC     | 475   | 67.86  | 1  |
+| 4  | Destiny Garza        | Quiz Commanders      | Yorkville-IL      | 450   | 64.29  |    |
+| 5  | Joanne Sinniah       | Juicy Fruit Ninjas   | Branson-MO        | 440   | 62.86  | 1  |
+| 6  | Kaleb Alford         | Love Boldly          | Tallahassee-FL    | 395   | 56.43  | 1  |
+| 7  | David Cuevas         | Greensboro - WOW     | Greensboro-NC     | 370   | 52.86  | 1  |
+| 8  | Adrien Jefferson     | Bellevue Buzzers     | Bellevue-WA       | 355   | 50.71  |    |
+| 9  | Teddy Arasavelli     | Bellevue Buzzers     | Bellevue-WA       | 335   | 47.86  | 4  |
+| 10 | Blake Garza          | Quiz Commanders      | Yorkville-IL      | 315   | 45.00  | 3  |
+| 11 | Zach Rothwell        | Thing 1              | St.Cloud-MN       | 315   | 45.00  |    |
+| 12 | Ethan Stewart        | Love Boldly          | Tallahassee-FL    | 310   | 44.29  | 3  |
+| 13 | Tom Hoffmann         | Thing 1              | St.Cloud-MN       | 280   | 40.00  | 2  |
+| 14 | Nikki Rittenhouse    | MCC Etoiles De Bible | Mechanicsville-VA | 270   | 38.57  | 1  |
+| 14 | Emma Hoffmann        | Thing 1              | St.Cloud-MN       | 270   | 38.57  | 1  |
+| 15 | Tanya Naveen         | Bellevue Buzzers     | Bellevue-WA       | 270   | 38.57  |    |
+| 16 | Nathaniel Walker     | MCC Etoiles De Bible | Mechanicsville-VA | 255   | 36.43  | 1  |
+| 17 | Emma Stewart         | Love Boldly          | Tallahassee-FL    | 225   | 32.14  |    |
+| 18 | Isaac Cuevas         | Greensboro - WOW     | Greensboro-NC     | 150   | 21.43  |    |
+| 19 | Braylen Elzy         | Flamin\' Hot Buzzers | Albuquerque-NM    | 135   | 19.29  |    |
+| 20 | Morgan Peltz         | Thing 1              | St.Cloud-MN       | 120   | 17.14  |    |
+| 20 | Drew Wilson          | Flamin\' Hot Buzzers | Albuquerque-NM    | 120   | 17.14  |    |
+| 21 | Madison Steele       | MCC Etoiles De Bible | Mechanicsville-VA | 95    | 13.57  | 1  |
+| 22 | Mikaela Fielder      | Love Boldly          | Tallahassee-FL    | 90    | 12.86  |    |
+| 23 | Justice Schwickerath | MCC Etoiles De Bible | Mechanicsville-VA | 80    | 11.43  |    |
+| 24 | Sophia Whitfield     | MCC Etoiles De Bible | Mechanicsville-VA | 75    | 10.71  |    |
+| 25 | Matthew Baloga       | Greensboro - WOW     | Greensboro-NC     | 70    | 10.00  |    |
+| 26 | Isaiah Smith         | Juicy Fruit Ninjas   | Branson-MO        | 65    | 9.29   |    |
+| 26 | Gabriel Gonzales     | Flamin\' Hot Buzzers | Albuquerque-NM    | 65    | 9.29   |    |
+| 27 | Alex McCollum        | Greensboro - WOW     | Greensboro-NC     | 60    | 8.57   |    |
+| 27 | Mandy Rydeski        | Flamin\' Hot Buzzers | Albuquerque-NM    | 60    | 8.57   |    |
+| 28 | Noah Gallo           | Bellevue Buzzers     | Bellevue-WA       | 45    | 6.43   |    |
+| 29 | Mervin wallace       | Love Boldly          | Tallahassee-FL    | 35    | 5.00   |    |
+| 29 | Nicola Betz          | Quiz Commanders      | Yorkville-IL      | 35    | 5.00   |    |
+| 30 | Noah Rothwell        | Thing 1              | St.Cloud-MN       | 20    | 2.86   |    |
+| 30 | Sarah Winfield       | Flamin\' Hot Buzzers | Albuquerque-NM    | 20    | 2.86   |    |
+| 30 | Allison Stanley      | MCC Etoiles De Bible | Mechanicsville-VA | 20    | 2.86   |    |
+| 31 | Hope Alford          | Love Boldly          | Tallahassee-FL    | 10    | 1.43   |    |
+| 31 | Carter Garza         | Quiz Commanders      | Yorkville-IL      | 10    | 1.43   |    |
+| 31 | Janaya Linder        | Flamin\' Hot Buzzers | Albuquerque-NM    | 10    | 1.43   |    |
+| 32 | Zachary Lickey       | Bellevue Buzzers     | Bellevue-WA       | 5     | .71    |    |
+| 33 | Stephanie Gutierrez  | Flamin\' Hot Buzzers | Albuquerque-NM    |       | .00    |    |
+| 33 | Landon Holloway      | Juicy Fruit Ninjas   | Branson-MO        |       | .00    |    |
+| 33 | Meleah Wallace       | Love Boldly          | Tallahassee-FL    |       | .00    |    |
+| 33 | Megan Bartlett       | Thing 1              | St.Cloud-MN       |       | .00    |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                     | Church        | W/L | Total | Avg    |
+|--:|--------------------------|---------------|-----|------:|-------:|
+| 1 | FBI Flaming Buzzers Inc. | Brookfield-WI | 6/1 | 1355  | 193.57 |
+| 2 | Guardians of God\'s Word | Cincinnati-OH | 6/1 | 1255  | 179.29 |
+| 3 | Bible Treasure Seekers   | Greensboro-NC | 5/1 | 1055  | 175.83 |
+| 4 | Fibulator Tribulators    | Fort Wayne-IN | 3/4 | 920   | 131.43 |
+| 5 | CIA - Special Agents     | Mendon-MA     | 3/4 | 1040  | 148.57 |
+| 6 | Alpha & Omega\'s Kids    | San Jose-CA   | 2/5 | 1040  | 148.57 |
+| 7 | Cedar Park Eagles - A2   | Bothell-WA    | 2/4 | 530   | 88.33  |
+| 8 | Purple People            | Manhattan-KS  | 0/7 | 625   | 89.29  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                     | Church        | Total | Avg    | QO |
+|---:|----------------------|--------------------------|---------------|------:|-------:|---:|
+| 1  | Olivia Cypcar        | FBI Flaming Buzzers Inc. | Brookfield-WI | 855   | 122.14 | 4  |
+| 2  | Abigail Prejean      | Bible Treasure Seekers   | Greensboro-NC | 605   | 100.83 | 3  |
+| 3  | Samuel Jebaraj       | Alpha & Omega\'s Kids    | San Jose-CA   | 585   | 83.57  | 2  |
+| 4  | Jadyn Kleinhenz      | Guardians of God\'s Word | Cincinnati-OH | 450   | 64.29  | 1  |
+| 5  | David Haynes         | Guardians of God\'s Word | Cincinnati-OH | 440   | 62.86  |    |
+| 6  | Miles Kastner        | FBI Flaming Buzzers Inc. | Brookfield-WI | 395   | 56.43  | 5  |
+| 7  | Ryan Ravitz          | CIA - Special Agents     | Mendon-MA     | 355   | 50.71  |    |
+| 8  | Dylan Stewart        | Fibulator Tribulators    | Fort Wayne-IN | 350   | 50.00  | 3  |
+| 9  | Josh Kiefer          | Guardians of God\'s Word | Cincinnati-OH | 335   | 47.86  | 3  |
+| 10 | Faith Caughey        | CIA - Special Agents     | Mendon-MA     | 330   | 47.14  | 1  |
+| 11 | Samuel Del Toro      | Purple People            | Manhattan-KS  | 325   | 46.43  | 3  |
+| 12 | Emily May            | Cedar Park Eagles - A2   | Bothell-WA    | 295   | 49.17  | 1  |
+| 13 | Jabez Williams       | Alpha & Omega\'s Kids    | San Jose-CA   | 275   | 39.29  |    |
+| 14 | Michelle Vannelli    | CIA - Special Agents     | Mendon-MA     | 255   | 36.43  | 1  |
+| 15 | Isaiah Madonia       | Bible Treasure Seekers   | Greensboro-NC | 245   | 40.83  | 1  |
+| 16 | Stephen King         | Fibulator Tribulators    | Fort Wayne-IN | 200   | 28.57  |    |
+| 17 | Tony Benedetti       | Fibulator Tribulators    | Fort Wayne-IN | 170   | 24.29  |    |
+| 17 | Sarah Settles        | Bible Treasure Seekers   | Greensboro-NC | 170   | 28.33  |    |
+| 17 | Ethan Walker         | Purple People            | Manhattan-KS  | 170   | 24.29  |    |
+| 17 | Sarah Shivakumar     | Alpha & Omega\'s Kids    | San Jose-CA   | 170   | 24.29  |    |
+| 18 | Seth King            | Fibulator Tribulators    | Fort Wayne-IN | 160   | 22.86  |    |
+| 19 | Amariah Walker       | Purple People            | Manhattan-KS  | 130   | 18.57  |    |
+| 20 | Christiaan West      | Cedar Park Eagles - A2   | Bothell-WA    | 115   | 19.17  |    |
+| 21 | Mikayla Mikolajewski | FBI Flaming Buzzers Inc. | Brookfield-WI | 100   | 14.29  |    |
+| 21 | Lizzy Fugere         | CIA - Special Agents     | Mendon-MA     | 100   | 14.29  |    |
+| 22 | Michael Fouch        | Cedar Park Eagles - A2   | Bothell-WA    | 80    | 13.33  |    |
+| 23 | Kiley Frank          | Cedar Park Eagles - A2   | Bothell-WA    | 40    | 6.67   |    |
+| 23 | Sean King            | Fibulator Tribulators    | Fort Wayne-IN | 40    | 5.71   |    |
+| 24 | Julia Kiefer         | Guardians of God\'s Word | Cincinnati-OH | 30    | 4.29   |    |
+| 25 | Nathaniel Prejean    | Bible Treasure Seekers   | Greensboro-NC | 25    | 4.17   |    |
+| 26 | Julia Martello       | Bible Treasure Seekers   | Greensboro-NC | 10    | 1.67   |    |
+| 26 | Abishai Shivakumar   | Alpha & Omega\'s Kids    | San Jose-CA   | 10    | 1.43   |    |
+| 27 | Brianna Cypcar       | FBI Flaming Buzzers Inc. | Brookfield-WI | 5     | .71    |    |
+| 28 | Ethan Stewart        | Fibulator Tribulators    | Fort Wayne-IN |       | .00    |    |
+| 28 | Zoe Kastner          | FBI Flaming Buzzers Inc. | Brookfield-WI |       | .00    |    |
+| 28 | Riley Longacre       | CIA - Special Agents     | Mendon-MA     |       | .00    |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                       | Church             | W/L | Total | Avg    |
+|--:|----------------------------|--------------------|-----|------:|-------:|
+| 1 | Naperville                 | Naperville-IL      | 7/0 | 1440  | 205.71 |
+| 2 | CRK Almighty               | Gloucester City-NJ | 6/1 | 1275  | 182.14 |
+| 3 | Bismarck Blitz             | Bismarck-ND        | 5/2 | 1235  | 176.43 |
+| 4 | GOD MOD                    | Mustang-OK         | 3/4 | 760   | 108.57 |
+| 5 | Pathfinders                | Montgomery-AL      | 2/5 | 865   | 123.57 |
+| 6 | Washington Street Warriors | Binghamton-NY      | 2/5 | 785   | 112.14 |
+| 7 | Buzz Hogs                  | Mabelvale-AR       | 2/5 | 640   | 91.43  |
+| 8 | Soaring Eagles             | Gilbert-AZ         | 1/6 | 660   | 94.29  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer          | Team                       | Church             | Total | Avg    | QO |
+|---:|------------------|----------------------------|--------------------|------:|-------:|---:|
+| 1  | Shreanna Powell  | Naperville                 | Naperville-IL      | 835   | 119.29 | 4  |
+| 2  | Elijah Abad      | CRK Almighty               | Gloucester City-NJ | 810   | 115.71 | 4  |
+| 3  | Kaden Sago       | Bismarck Blitz             | Bismarck-ND        | 800   | 114.29 | 3  |
+| 4  | Payton Astorga   | Pathfinders                | Montgomery-AL      | 505   | 72.14  | 1  |
+| 5  | Caleb Gerhart    | Washington Street Warriors | Binghamton-NY      | 415   | 59.29  | 3  |
+| 6  | Sheldon Powell   | Naperville                 | Naperville-IL      | 405   | 57.86  | 5  |
+| 7  | Michelle Koshy   | Soaring Eagles             | Gilbert-AZ         | 365   | 52.14  | 1  |
+| 8  | Caleb Horn       | GOD MOD                    | Mustang-OK         | 335   | 47.86  | 1  |
+| 9  | Jonathan Duggins | Buzz Hogs                  | Mabelvale-AR       | 295   | 42.14  | 3  |
+| 10 | Jared Minick     | Buzz Hogs                  | Mabelvale-AR       | 280   | 40.00  | 2  |
+| 11 | Andrew Scarinzi  | Washington Street Warriors | Binghamton-NY      | 260   | 37.14  |    |
+| 12 | Kevin Sowers     | Pathfinders                | Montgomery-AL      | 230   | 32.86  | 1  |
+| 13 | Landon Grisham   | GOD MOD                    | Mustang-OK         | 225   | 32.14  | 1  |
+| 14 | Jacob Flores     | CRK Almighty               | Gloucester City-NJ | 220   | 31.43  |    |
+| 15 | Rylan Sago       | Bismarck Blitz             | Bismarck-ND        | 215   | 30.71  |    |
+| 16 | Kaylee Freyer    | Bismarck Blitz             | Bismarck-ND        | 170   | 24.29  | 1  |
+| 17 | Sarah Mathew     | Soaring Eagles             | Gilbert-AZ         | 170   | 24.29  |    |
+| 18 | Samuel Borja     | CRK Almighty               | Gloucester City-NJ | 135   | 19.29  |    |
+| 19 | Sieanna Sowers   | Pathfinders                | Montgomery-AL      | 120   | 17.14  |    |
+| 19 | Aryana Campbell  | GOD MOD                    | Mustang-OK         | 120   | 17.14  |    |
+| 20 | Shaymis Powell   | Naperville                 | Naperville-IL      | 110   | 15.71  |    |
+| 21 | Bethany Escobar  | CRK Almighty               | Gloucester City-NJ | 100   | 14.29  |    |
+| 22 | Angel Alias      | Soaring Eagles             | Gilbert-AZ         | 95    | 13.57  |    |
+| 23 | Erin Laboy       | Naperville                 | Naperville-IL      | 90    | 12.86  |    |
+| 24 | Kailan Weidner   | GOD MOD                    | Mustang-OK         | 80    | 11.43  |    |
+| 25 | Caleb Ferraro    | Washington Street Warriors | Binghamton-NY      | 65    | 9.29   |    |
+| 25 | Levi Biniakewitz | Buzz Hogs                  | Mabelvale-AR       | 65    | 9.29   |    |
+| 26 | Lillia Loven     | Bismarck Blitz             | Bismarck-ND        | 50    | 7.14   |    |
+| 27 | Bradley Gerhart  | Washington Street Warriors | Binghamton-NY      | 45    | 6.43   |    |
+| 28 | Grace Kuruvilla  | Soaring Eagles             | Gilbert-AZ         | 30    | 4.29   |    |
+| 29 | Lilly Powell     | Pathfinders                | Montgomery-AL      | 20    | 2.86   |    |
+| 30 | Hezekiah Reynes  | CRK Almighty               | Gloucester City-NJ | 10    | 1.43   |    |
+| 31 | Sarah Sager      | Washington Street Warriors | Binghamton-NY      |       | .00    |    |
+| 31 | Joanna Joseph    | Soaring Eagles             | Gilbert-AZ         |       | .00    |    |
+| 31 | Noah Taylor      | Pathfinders                | Montgomery-AL      |       | .00    |    |
+| 32 | Ryan Astorga     | Pathfinders                | Montgomery-AL      | -10   | -1.43  |    |
+
+
+### Silver
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                    | Church         | W/L | Total | Avg    |
+|--:|-------------------------|----------------|-----|------:|-------:|
+| 1 | Birds of Pray           | Lexington-KY   | 7/0 | 1285  | 183.57 |
+| 2 | Dynamic Diamonds        | Princeton-MN   | 5/2 | 1190  | 170.00 |
+| 3 | Princeton A             | Princeton-NC   | 4/3 | 1015  | 145.00 |
+| 4 | Splashers               | Bristow-VA     | 4/3 | 1100  | 157.14 |
+| 5 | Cedar Park Eagles - A1  | Bothell-WA     | 3/4 | 865   | 123.57 |
+| 6 | Nyan Cats               | Springfield-MO | 2/5 | 885   | 126.43 |
+| 7 | OCCEC                   | Irvine-CA      | 2/5 | 795   | 113.57 |
+| 8 | The Purple Prophetesses | Houston-TX     | 1/6 | 620   | 88.57  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                    | Church         | Total | Avg    | QO |
+|---:|-------------------|-------------------------|----------------|------:|-------:|---:|
+| 1  | Anna Kelly        | Birds of Pray           | Lexington-KY   | 895   | 127.86 | 5  |
+| 2  | Gabriella Hanvass | Dynamic Diamonds        | Princeton-MN   | 655   | 93.57  |    |
+| 3  | Caleb Jones       | Princeton A             | Princeton-NC   | 560   | 80.00  | 1  |
+| 4  | Landon Clark      | Nyan Cats               | Springfield-MO | 475   | 67.86  | 1  |
+| 5  | Josiah Smith      | Birds of Pray           | Lexington-KY   | 375   | 53.57  | 4  |
+| 6  | Jim Dapaah        | Splashers               | Bristow-VA     | 370   | 52.86  |    |
+| 7  | Makayla Jones     | Princeton A             | Princeton-NC   | 355   | 50.71  | 4  |
+| 8  | Shad Mills        | Cedar Park Eagles - A1  | Bothell-WA     | 345   | 49.29  | 4  |
+| 9  | Alex Jarrell      | Cedar Park Eagles - A1  | Bothell-WA     | 325   | 46.43  | 1  |
+| 10 | Lily Slater       | Nyan Cats               | Springfield-MO | 320   | 45.71  | 2  |
+| 11 | Katie Richardson  | Splashers               | Bristow-VA     | 320   | 45.71  | 1  |
+| 12 | Chris Yen         | OCCEC                   | Irvine-CA      | 305   | 43.57  | 1  |
+| 13 | Justess Vasquez   | The Purple Prophetesses | Houston-TX     | 300   | 42.86  |    |
+| 14 | Samuel Tran       | Splashers               | Bristow-VA     | 295   | 42.14  | 2  |
+| 15 | Wade Lawrence     | Dynamic Diamonds        | Princeton-MN   | 290   | 41.43  | 2  |
+| 16 | Phoebe Wang       | OCCEC                   | Irvine-CA      | 285   | 40.71  | 1  |
+| 17 | Jacob Hagstrom    | Dynamic Diamonds        | Princeton-MN   | 210   | 30.00  |    |
+| 18 | Kayden Vasquez    | The Purple Prophetesses | Houston-TX     | 205   | 29.29  | 2  |
+| 19 | Kevin Yao         | OCCEC                   | Irvine-CA      | 205   | 29.29  | 1  |
+| 20 | Grace Waggoner    | Cedar Park Eagles - A1  | Bothell-WA     | 120   | 17.14  |    |
+| 21 | Sydney Cummins    | The Purple Prophetesses | Houston-TX     | 115   | 16.43  |    |
+| 22 | Lucas Veronee     | Princeton A             | Princeton-NC   | 100   | 14.29  |    |
+| 23 | Cecily Houser     | Cedar Park Eagles - A1  | Bothell-WA     | 75    | 10.71  |    |
+| 24 | Caleb Horsch      | Nyan Cats               | Springfield-MO | 60    | 8.57   |    |
+| 25 | Bronte Mora       | Splashers               | Bristow-VA     | 55    | 7.86   |    |
+| 26 | Jeremy Dapaah     | Splashers               | Bristow-VA     | 50    | 7.14   |    |
+| 27 | Lydia Hagstrom    | Dynamic Diamonds        | Princeton-MN   | 40    | 5.71   |    |
+| 28 | Kristi Olsen      | Nyan Cats               | Springfield-MO | 30    | 4.29   |    |
+| 29 | Paula Glaser      | Birds of Pray           | Lexington-KY   | 20    | 2.86   |    |
+| 30 | John Hull         | Splashers               | Bristow-VA     | 10    | 1.43   |    |
+| 31 | Joshua Zou        | OCCEC                   | Irvine-CA      |       | .00    |    |
+| 31 | Kelly Yen         | OCCEC                   | Irvine-CA      |       | .00    |    |
+| 31 | Calvin Lee        | OCCEC                   | Irvine-CA      |       | .00    |    |
+| 31 | Rain Gomez        | The Purple Prophetesses | Houston-TX     |       | .00    |    |
+| 31 | Ivy Gomez         | The Purple Prophetesses | Houston-TX     |       | .00    |    |
+| 31 | JinWen Hu         | OCCEC                   | Irvine-CA      |       | .00    |    |
+| 31 | Josiah Laakkonen  | Birds of Pray           | Lexington-KY   |       | .00    |    |
+| 32 | Joseph Glaser     | Birds of Pray           | Lexington-KY   | -5    | -0.71  |    |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                | Church              | W/L | Total | Avg    |
+|--:|---------------------|---------------------|-----|------:|-------:|
+| 1 | Brickmasters        | Racine-WI           | 6/0 | 1105  | 184.17 |
+| 2 | Wilmington Warriors | Wilmington-NC       | 5/1 | 1120  | 186.67 |
+| 3 | 2 Men & A Lady      | Gahanna-OH          | 5/1 | 1050  | 175.00 |
+| 4 | Bethel              | Medford-OR          | 3/3 | 715   | 119.17 |
+| 5 | JAG                 | Meriden-KS          | 2/4 | 875   | 145.83 |
+| 6 | Bible Agents        | Springfield-MO      | 2/4 | 645   | 107.50 |
+| 7 | BC United Too       | Wyckoff-NJ          | 1/5 | 665   | 110.83 |
+| 8 | Knights of Christ   | Colorado Springs-CO | 0/6 | 690   | 115.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                | Church              | Total | Avg    | QO |
+|---:|--------------------|---------------------|---------------------|------:|-------:|---:|
+| 1  | Katie Mair         | 2 Men & A Lady      | Gahanna-OH          | 685   | 114.17 | 4  |
+| 2  | Rebekah Toeller    | Brickmasters        | Racine-WI           | 650   | 108.33 | 1  |
+| 3  | Caleb Shackelford  | Knights of Christ   | Colorado Springs-CO | 580   | 96.67  | 3  |
+| 4  | Brandon Dale       | Bethel              | Medford-OR          | 525   | 87.50  | 2  |
+| 5  | Andy Boehling      | Wilmington Warriors | Wilmington-NC       | 415   | 69.17  | 3  |
+| 6  | Christian Shelton  | Wilmington Warriors | Wilmington-NC       | 370   | 61.67  | 2  |
+| 7  | Emma Wolfe         | Bible Agents        | Springfield-MO      | 295   | 49.17  | 1  |
+| 8  | Kyler Kaniper      | JAG                 | Meriden-KS          | 295   | 49.17  |    |
+| 9  | Jacob Smith        | 2 Men & A Lady      | Gahanna-OH          | 280   | 46.67  | 3  |
+| 10 | Gabriella Connelly | BC United Too       | Wyckoff-NJ          | 280   | 46.67  | 1  |
+| 11 | Josh Broxterman    | JAG                 | Meriden-KS          | 250   | 41.67  | 2  |
+| 12 | Sam David          | Brickmasters        | Racine-WI           | 210   | 35.00  | 2  |
+| 13 | Cameron Ramsey     | Bible Agents        | Springfield-MO      | 210   | 35.00  | 1  |
+| 14 | Zachary Leake      | Wilmington Warriors | Wilmington-NC       | 210   | 35.00  |    |
+| 15 | Todd Pettet        | BC United Too       | Wyckoff-NJ          | 205   | 34.17  | 1  |
+| 16 | Julia Rivera       | JAG                 | Meriden-KS          | 170   | 28.33  |    |
+| 17 | Jayden Garrison    | Brickmasters        | Racine-WI           | 135   | 22.50  | 1  |
+| 18 | Abeni Feurbacher   | JAG                 | Meriden-KS          | 120   | 20.00  |    |
+| 18 | Sarah James        | BC United Too       | Wyckoff-NJ          | 120   | 20.00  |    |
+| 19 | Ethan Shackelford  | Knights of Christ   | Colorado Springs-CO | 110   | 18.33  |    |
+| 19 | Levi Cooper        | Bible Agents        | Springfield-MO      | 110   | 18.33  |    |
+| 19 | Luke Dale          | Bethel              | Medford-OR          | 110   | 18.33  |    |
+| 20 | JJ Mair            | 2 Men & A Lady      | Gahanna-OH          | 85    | 14.17  |    |
+| 21 | Kierstin Childs    | Wilmington Warriors | Wilmington-NC       | 60    | 10.00  |    |
+| 21 | Brock Boehling     | Wilmington Warriors | Wilmington-NC       | 60    | 10.00  |    |
+| 22 | Rachel Stanton     | Brickmasters        | Racine-WI           | 50    | 8.33   |    |
+| 22 | Nathaniel Ward     | BC United Too       | Wyckoff-NJ          | 50    | 8.33   |    |
+| 22 | Connor Frank       | Bethel              | Medford-OR          | 50    | 8.33   |    |
+| 23 | Matthias Moore     | JAG                 | Meriden-KS          | 45    | 7.50   |    |
+| 24 | Naomi Lewis        | Brickmasters        | Racine-WI           | 40    | 6.67   |    |
+| 25 | Joshua Calandrino  | Bethel              | Medford-OR          | 30    | 5.00   |    |
+| 25 | Caleb Black        | Bible Agents        | Springfield-MO      | 30    | 5.00   |    |
+| 26 | Ariana Klein       | Brickmasters        | Racine-WI           | 20    | 3.33   |    |
+| 27 | Anna Shelton       | Wilmington Warriors | Wilmington-NC       | 15    | 2.50   |    |
+| 28 | Garrett Adelmann   | BC United Too       | Wyckoff-NJ          | 10    | 1.67   |    |
+| 29 | Catie Wolfe        | Bible Agents        | Springfield-MO      |       | .00    |    |
+| 30 | Taylor Thompson    | Wilmington Warriors | Wilmington-NC       | -10   | -1.67  |    |
+
+
+### White
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                     | Church              | W/L | Total | Avg    |
+|--:|--------------------------|---------------------|-----|------:|-------:|
+| 1 | Sanford-Los Chicos       | Sanford-FL          | 6/0 | 1280  | 213.33 |
+| 2 | Glad Tidings             | Omaha-NE            | 6/1 | 1275  | 182.14 |
+| 3 | Cousins, Convis and Crew | East Lansing-MI     | 4/3 | 875   | 125.00 |
+| 4 | River of Life            | Kent-WA             | 3/4 | 1010  | 144.29 |
+| 5 | The Chosen Ones          | Houston-TX          | 3/3 | 740   | 123.33 |
+| 6 | Amazing Eight            | Scottsdale-AZ       | 2/5 | 1015  | 145.00 |
+| 7 | The Force                | Benton-AR           | 2/5 | 745   | 106.43 |
+| 8 | God\'s Force             | West Mifflin, PA-PA | 1/6 | 695   | 99.29  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                     | Church              | Total | Avg    | QO |
+|---:|---------------------|--------------------------|---------------------|------:|-------:|---:|
+| 1  | Toby Robinson       | Sanford-Los Chicos       | Sanford-FL          | 715   | 119.17 | 4  |
+| 2  | Leah Palensky       | Glad Tidings             | Omaha-NE            | 640   | 91.43  | 3  |
+| 3  | Mateo Cuadros       | River of Life            | Kent-WA             | 590   | 84.29  | 3  |
+| 4  | David Moses         | Amazing Eight            | Scottsdale-AZ       | 475   | 67.86  | 1  |
+| 5  | Jackson Atwell      | Glad Tidings             | Omaha-NE            | 410   | 58.57  | 4  |
+| 6  | Darcie Harr         | Cousins, Convis and Crew | East Lansing-MI     | 365   | 52.14  |    |
+| 7  | Jon Robinson        | Sanford-Los Chicos       | Sanford-FL          | 300   | 50.00  | 1  |
+| 8  | Hannah Greenwell    | The Force                | Benton-AR           | 270   | 38.57  |    |
+| 8  | Chimezirim Nwogu    | The Chosen Ones          | Houston-TX          | 270   | 45.00  |    |
+| 9  | Aubrey Goss         | Sanford-Los Chicos       | Sanford-FL          | 265   | 44.17  | 3  |
+| 9  | Jack Convis         | Cousins, Convis and Crew | East Lansing-MI     | 265   | 37.86  | 3  |
+| 10 | Holly Garrett       | Amazing Eight            | Scottsdale-AZ       | 265   | 37.86  | 2  |
+| 11 | Joanna Moses        | Amazing Eight            | Scottsdale-AZ       | 255   | 36.43  | 1  |
+| 12 | Chase Buher         | Cousins, Convis and Crew | East Lansing-MI     | 225   | 32.14  | 1  |
+| 13 | LeeAnn Harris       | God\'s Force             | West Mifflin, PA-PA | 220   | 31.43  | 1  |
+| 14 | Andrew Abuluyan     | River of Life            | Kent-WA             | 210   | 30.00  | 1  |
+| 15 | Jared Watson        | The Force                | Benton-AR           | 185   | 26.43  | 2  |
+| 16 | Sarah Onwudinjo     | The Chosen Ones          | Houston-TX          | 160   | 26.67  |    |
+| 17 | John Adams          | God\'s Force             | West Mifflin, PA-PA | 155   | 22.14  |    |
+| 18 | Bobbie Jean Barnes  | The Force                | Benton-AR           | 150   | 21.43  |    |
+| 19 | Wayne Ellis         | The Chosen Ones          | Houston-TX          | 145   | 24.17  |    |
+| 20 | Erin Brody          | God\'s Force             | West Mifflin, PA-PA | 130   | 18.57  |    |
+| 21 | Daniel Ejim         | The Chosen Ones          | Houston-TX          | 120   | 20.00  |    |
+| 21 | Rachel Hetrick      | Glad Tidings             | Omaha-NE            | 120   | 17.14  |    |
+| 22 | Will Brugos         | God\'s Force             | West Mifflin, PA-PA | 115   | 16.43  |    |
+| 23 | Raymond Harris      | God\'s Force             | West Mifflin, PA-PA | 95    | 13.57  |    |
+| 23 | Drew Dellacca       | River of Life            | Kent-WA             | 95    | 13.57  |    |
+| 24 | Alexis Kaffenberger | Glad Tidings             | Omaha-NE            | 75    | 10.71  |    |
+| 25 | Eli Buxton          | River of Life            | Kent-WA             | 60    | 8.57   |    |
+| 25 | Tre Dubrava         | The Force                | Benton-AR           | 60    | 8.57   |    |
+| 26 | Andrea Bosteder     | River of Life            | Kent-WA             | 55    | 7.86   |    |
+| 27 | Emily Greenwell     | The Force                | Benton-AR           | 50    | 7.14   |    |
+| 28 | Emmanuel Umoekpo    | The Chosen Ones          | Houston-TX          | 45    | 7.50   |    |
+| 29 | Joshua Davies       | Glad Tidings             | Omaha-NE            | 30    | 4.29   |    |
+| 30 | Madison Thomas      | The Force                | Benton-AR           | 20    | 2.86   |    |
+| 31 | Maia Gheorghiu      | Amazing Eight            | Scottsdale-AZ       | 15    | 2.14   |    |
+| 32 | Onome Oghor         | Cousins, Convis and Crew | East Lansing-MI     | 10    | 1.43   |    |
+| 32 | Britta Andrews      | Cousins, Convis and Crew | East Lansing-MI     | 10    | 1.43   |    |
+| 32 | Alexis Rowland      | The Force                | Benton-AR           | 10    | 1.43   |    |
+| 32 | Tawny Audi          | Amazing Eight            | Scottsdale-AZ       | 10    | 1.43   |    |
+| 33 | Brittyn Glover      | The Force                | Benton-AR           |       | .00    |    |
+| 33 | Abigail Massih      | Amazing Eight            | Scottsdale-AZ       |       | .00    |    |
+| 33 | Serenity Nicolas    | Amazing Eight            | Scottsdale-AZ       |       | .00    |    |
+| 34 | Brooke Patterson    | God\'s Force             | West Mifflin, PA-PA | -15   | -2.14  |    |
+| 35 | Jeremiah Brugos     | God\'s Force             | West Mifflin, PA-PA | -5    | -0.71  |    |
+| 35 | Lauren Oriza        | Amazing Eight            | Scottsdale-AZ       | -5    | -0.71  |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church           | W/L | Total | Avg    |
+|--:|---------------------------|------------------|-----|------:|-------:|
+| 1 | Light to the Nations      | Dallas-TX        | 7/0 | 1305  | 186.43 |
+| 2 | TWCA                      | Louisville-KY    | 5/2 | 1250  | 178.57 |
+| 3 | Obsessed                  | Harrison-AR      | 5/2 | 1015  | 145.00 |
+| 4 | Glittering Lightning      | Bonifay-FL       | 3/4 | 945   | 135.00 |
+| 5 | Lawson Illuminators #1    | Lawson-MO        | 3/4 | 930   | 132.86 |
+| 6 | Bethlehem Church          | Richmond Hill-NY | 2/5 | 920   | 131.43 |
+| 7 | Life Church Brats         | Emporia-KS       | 2/5 | 860   | 122.86 |
+| 8 | Portland Christian Center | Portland-OR      | 1/6 | 760   | 108.57 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                      | Church           | Total | Avg    | QO |
+|---:|---------------------|---------------------------|------------------|------:|-------:|---:|
+| 1  | Noah Barnes         | TWCA                      | Louisville-KY    | 745   | 106.43 | 4  |
+| 2  | Isaac Grey          | Light to the Nations      | Dallas-TX        | 690   | 98.57  | 4  |
+| 3  | Ethan Small         | Life Church Brats         | Emporia-KS       | 640   | 91.43  | 1  |
+| 4  | Jonathan Archer     | Lawson Illuminators #1    | Lawson-MO        | 625   | 89.29  | 4  |
+| 5  | Andrew Warren       | Glittering Lightning      | Bonifay-FL       | 415   | 59.29  |    |
+| 6  | Joshua Gangaram     | Bethlehem Church          | Richmond Hill-NY | 410   | 58.57  | 1  |
+| 7  | Natalie Bartholomew | Light to the Nations      | Dallas-TX        | 385   | 55.00  | 4  |
+| 8  | Ethan Price         | TWCA                      | Louisville-KY    | 320   | 45.71  | 3  |
+| 9  | Isabel Paul         | Obsessed                  | Harrison-AR      | 320   | 45.71  |    |
+| 10 | Evan Llafet         | Portland Christian Center | Portland-OR      | 260   | 37.14  |    |
+| 11 | Nicholas Dillon     | Obsessed                  | Harrison-AR      | 250   | 35.71  | 2  |
+| 12 | Sara Ann Haimchand  | Bethlehem Church          | Richmond Hill-NY | 245   | 35.00  | 1  |
+| 13 | Ari Lauther         | Portland Christian Center | Portland-OR      | 245   | 35.00  |    |
+| 14 | Hannah Miller       | Obsessed                  | Harrison-AR      | 235   | 33.57  |    |
+| 15 | Abbi Good           | Life Church Brats         | Emporia-KS       | 225   | 32.14  | 1  |
+| 16 | Dalton Rowe         | Obsessed                  | Harrison-AR      | 205   | 29.29  |    |
+| 17 | Grace Searcy        | Lawson Illuminators #1    | Lawson-MO        | 170   | 24.29  |    |
+| 18 | Emilie Justice      | Glittering Lightning      | Bonifay-FL       | 165   | 23.57  | 1  |
+| 18 | Emiliano Duran      | Portland Christian Center | Portland-OR      | 165   | 23.57  | 1  |
+| 19 | David Warren        | Glittering Lightning      | Bonifay-FL       | 145   | 20.71  | 1  |
+| 20 | Daynah Dyal         | Bethlehem Church          | Richmond Hill-NY | 140   | 20.00  |    |
+| 21 | Laken Manns         | Lawson Illuminators #1    | Lawson-MO        | 135   | 19.29  |    |
+| 22 | Isaac Torrez        | Light to the Nations      | Dallas-TX        | 120   | 17.14  |    |
+| 23 | Morgan Zepp         | Glittering Lightning      | Bonifay-FL       | 110   | 15.71  | 1  |
+| 24 | Katya Brodsky       | Portland Christian Center | Portland-OR      | 90    | 12.86  |    |
+| 24 | Hannah Stumper      | Light to the Nations      | Dallas-TX        | 90    | 12.86  |    |
+| 25 | Madison Ealum       | Glittering Lightning      | Bonifay-FL       | 80    | 11.43  |    |
+| 25 | Sydney Goodrich     | TWCA                      | Louisville-KY    | 80    | 11.43  |    |
+| 26 | Christian Boodram   | Bethlehem Church          | Richmond Hill-NY | 65    | 9.29   |    |
+| 27 | Brendan Goodrich    | TWCA                      | Louisville-KY    | 55    | 7.86   |    |
+| 28 | Jeremiah Watene     | TWCA                      | Louisville-KY    | 50    | 7.14   |    |
+| 29 | Paul Rambharose     | Bethlehem Church          | Richmond Hill-NY | 40    | 5.71   |    |
+| 30 | Stefan Wilson       | Light to the Nations      | Dallas-TX        | 30    | 4.29   |    |
+| 30 | Braeden Jordan      | Glittering Lightning      | Bonifay-FL       | 30    | 4.29   |    |
+| 31 | Sean Umali          | Bethlehem Church          | Richmond Hill-NY | 20    | 2.86   |    |
+| 32 | Abbie Paul          | Obsessed                  | Harrison-AR      | 10    | 1.43   |    |
+| 33 | Zoey Ludlam         | Life Church Brats         | Emporia-KS       |       | .00    |    |
+| 33 | Noah Small          | Life Church Brats         | Emporia-KS       |       | .00    |    |
+| 33 | Kylie Paul          | Obsessed                  | Harrison-AR      |       | .00    |    |
+| 33 | Rachel Millsap      | Obsessed                  | Harrison-AR      |       | .00    |    |
+| 34 | Malinda White       | Life Church Brats         | Emporia-KS       | -5    | -0.71  |    |
+| 34 | Jesse Wilson        | Light to the Nations      | Dallas-TX        | -5    | -0.71  |    |
+| 34 | Jonathan Torrez     | Light to the Nations      | Dallas-TX        | -5    | -0.71  |    |
+| 34 | Madison Herring     | Obsessed                  | Harrison-AR      | -5    | -0.71  |    |
+

--- a/_pages/jbq/2014/index.md
+++ b/_pages/jbq/2014/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2014 JBQ Season"
+permalink: /jbq/2014/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+<a href="{% link _pages/jbq/2014/nationals.md %}" class="button is-primary">National Finals</a>
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2014/nationals.md
+++ b/_pages/jbq/2014/nationals.md
@@ -1,0 +1,1147 @@
+---
+layout: page
+title: "2014 National Festival: Concord, NC"
+permalink: /jbq/2014/nationals/
+toc_title: Results
+menubar_toc: true
+---
+
+## Friday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                 | Church                                     | W/L  | Total | Avg    |
+|---:|----------------------|--------------------------------------------|------|------:|-------:|
+| 1  | Naperville           | Calvary Church - J                         | 14/1 | 3250  | 216.67 |
+| 2  | S.P.Y. Kids          | The Worship Center                         | 12/3 | 2945  | 196.33 |
+| 3  | Team A               | Portland Christian Center                  | 11/4 | 2180  | 145.33 |
+| 4  | Agents of Knowledge  | Baxter Heritage AG                         | 10/5 | 2570  | 171.33 |
+| 5  | The Chosen Ones      | Houston - Braeswood AG                     | 9/6  | 2305  | 153.67 |
+| 6  | Love Boldly          | Freedom Church Tallahassee                 | 9/6  | 2595  | 173.00 |
+| 7  | Celebration Quizzers | Celebration Church                         | 8/7  | 2255  | 150.33 |
+| 8  | HeRose               | Rogers 1st AG                              | 7/8  | 2075  | 138.33 |
+| 9  | The Bridge           | Princeton The Bridge                       | 7/8  | 2065  | 137.67 |
+| 10 | BC United Too        | Bethany Church                             | 6/9  | 2010  | 134.00 |
+| 11 | Bismarck Blitz       | Evangel AG                                 | 6/9  | 1900  | 126.67 |
+| 12 | Brickmasters         | Racine AG                                  | 6/9  | 1870  | 124.67 |
+| 13 | Armor Up             | Oswego AG                                  | 5/10 | 1525  | 101.67 |
+| 14 | ACTSelerators        | Fort Wayne 1st AG                          | 4/11 | 1980  | 132.00 |
+| 15 | OCCEC                | Orange County Christian Evangelical Church | 4/11 | 1500  | 100.00 |
+| 16 | NHF Super Quizzers   | New Hope Fellowship                        | 2/13 | 1395  | 93.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                 | Church                                     | Total | Avg    | QO |
+|---:|---------------------|----------------------|--------------------------------------------|------:|-------:|---:|
+| 1  | Shreanna Powell     | Naperville           | Calvary Church - J                         | 2010  | 134.00 | 13 |
+| 2  | AC Borowicz         | Agents of Knowledge  | Baxter Heritage AG                         | 1560  | 104.00 | 9  |
+| 3  | Brock Eder          | Celebration Quizzers | Celebration Church                         | 1405  | 93.67  | 6  |
+| 4  | Diana Bozzay        | S.P.Y. Kids          | The Worship Center                         | 1210  | 80.67  | 4  |
+| 5  | Ari Lauthner        | Team A               | Portland Christian Center                  | 1175  | 78.33  | 3  |
+| 6  | Ethan Stewart       | Love Boldly          | Freedom Church Tallahassee                 | 1145  | 76.33  | 7  |
+| 7  | Caleb Jones         | The Bridge           | Princeton The Bridge                       | 1025  | 68.33  | 2  |
+| 8  | Jackson Loschko     | Agents of Knowledge  | Baxter Heritage AG                         | 1010  | 67.33  | 12 |
+| 9  | Ethan Lancelot      | HeRose               | Rogers 1st AG                              | 960   | 64.00  |    |
+| 10 | Kevin Ju            | OCCEC                | Orange County Christian Evangelical Church | 945   | 63.00  | 2  |
+| 11 | Gabriella Connelly  | BC United Too        | Bethany Church                             | 935   | 62.33  | 3  |
+| 12 | Sheldon Powell      | Naperville           | Calvary Church - J                         | 915   | 61.00  | 11 |
+| 13 | Mark Grogan         | NHF Super Quizzers   | New Hope Fellowship                        | 905   | 60.33  | 3  |
+| 14 | Kaylee Freyer       | Bismarck Blitz       | Evangel AG                                 | 905   | 60.33  | 1  |
+| 15 | Sydney Shockley     | HeRose               | Rogers 1st AG                              | 890   | 59.33  | 4  |
+| 16 | Emily Walsh         | S.P.Y. Kids          | The Worship Center                         | 855   | 57.00  |    |
+| 17 | Connor Jackson      | Brickmasters         | Racine AG                                  | 850   | 56.67  |    |
+| 18 | Emma Stewart        | Love Boldly          | Freedom Church Tallahassee                 | 845   | 56.33  | 3  |
+| 19 | Daniel Ejim         | The Chosen Ones      | Houston - Braeswood AG                     | 830   | 55.33  | 2  |
+| 20 | Vinicius Lupas      | ACTSelerators        | Fort Wayne 1st AG                          | 810   | 54.00  |    |
+| 21 | Eric Bender         | Bismarck Blitz       | Evangel AG                                 | 740   | 49.33  | 6  |
+| 22 | James Pettibone     | BC United Too        | Bethany Church                             | 680   | 45.33  | 6  |
+| 23 | Makayla Jones       | The Bridge           | Princeton The Bridge                       | 675   | 45.00  | 8  |
+| 24 | Cara Hodge          | S.P.Y. Kids          | The Worship Center                         | 645   | 43.00  | 6  |
+| 25 | Emiliano Duran      | Team A               | Portland Christian Center                  | 610   | 40.67  | 2  |
+| 26 | Collin Nester       | Love Boldly          | Freedom Church Tallahassee                 | 605   | 40.33  | 4  |
+| 27 | Benjamin Lupus      | ACTSelerators        | Fort Wayne 1st AG                          | 520   | 34.67  | 1  |
+| 28 | Isaac Wolf          | ACTSelerators        | Fort Wayne 1st AG                          | 510   | 34.00  |    |
+| 29 | Sean Wallis         | Celebration Quizzers | Celebration Church                         | 505   | 33.67  | 3  |
+| 30 | Ariana Klein        | Brickmasters         | Racine AG                                  | 475   | 31.67  |    |
+| 31 | Cecilia Eisenbrandt | Armor Up             | Oswego AG                                  | 400   | 26.67  | 1  |
+| 32 | Carmen Eisenbrandt  | Armor Up             | Oswego AG                                  | 395   | 26.33  | 3  |
+| 33 | Nathaniel Ward      | BC United Too        | Bethany Church                             | 390   | 26.00  |    |
+| 33 | Michael Ukonu       | The Chosen Ones      | Houston - Braeswood AG                     | 390   | 26.00  |    |
+| 34 | Lucas Veronee       | The Bridge           | Princeton The Bridge                       | 365   | 24.33  |    |
+| 35 | Dominique Siegler   | NHF Super Quizzers   | New Hope Fellowship                        | 355   | 23.67  | 2  |
+| 36 | Cecillia Newby      | Armor Up             | Oswego AG                                  | 355   | 23.67  |    |
+| 37 | Brandon Ukonu       | The Chosen Ones      | Houston - Braeswood AG                     | 340   | 22.67  | 2  |
+| 38 | Sarah Onwudinjo     | The Chosen Ones      | Houston - Braeswood AG                     | 335   | 22.33  | 1  |
+| 39 | Ethan Walker        | Brickmasters         | Racine AG                                  | 325   | 21.67  | 2  |
+| 40 | Tyler Chang         | OCCEC                | Orange County Christian Evangelical Church | 320   | 21.33  | 3  |
+| 41 | Delaney Reynolds    | Armor Up             | Oswego AG                                  | 320   | 21.33  |    |
+| 42 | Emmanuel Umoekpo    | The Chosen Ones      | Houston - Braeswood AG                     | 275   | 18.33  | 2  |
+| 43 | Nathan Bender       | Bismarck Blitz       | Evangel AG                                 | 255   | 17.00  |    |
+| 44 | Elylah Stager       | Celebration Quizzers | Celebration Church                         | 235   | 15.67  |    |
+| 44 | Michele Zheng       | OCCEC                | Orange County Christian Evangelical Church | 235   | 15.67  |    |
+| 45 | Katya Brodsky       | Team A               | Portland Christian Center                  | 225   | 15.00  |    |
+| 46 | Erin Frye           | S.P.Y. Kids          | The Worship Center                         | 210   | 14.00  |    |
+| 47 | Sam David           | Brickmasters         | Racine AG                                  | 195   | 13.00  | 1  |
+| 48 | Shaymis Powell      | Naperville           | Calvary Church - J                         | 180   | 12.00  |    |
+| 49 | Ethan Phillips      | Team A               | Portland Christian Center                  | 170   | 11.33  |    |
+| 50 | Marjorie Ehrman     | ACTSelerators        | Fort Wayne 1st AG                          | 140   | 9.33   |    |
+| 51 | David Ubak          | The Chosen Ones      | Houston - Braeswood AG                     | 135   | 9.00   | 1  |
+| 52 | Joy Fambrough       | NHF Super Quizzers   | New Hope Fellowship                        | 120   | 8.00   |    |
+| 53 | Chloe Eder          | Celebration Quizzers | Celebration Church                         | 110   | 7.33   |    |
+| 54 | Erin Laboy          | Naperville           | Calvary Church - J                         | 100   | 6.67   |    |
+| 54 | Rebecca Longtin     | HeRose               | Rogers 1st AG                              | 100   | 6.67   |    |
+| 55 | Morgan Giese        | HeRose               | Rogers 1st AG                              | 90    | 6.00   |    |
+| 56 | Grace Noel          | Armor Up             | Oswego AG                                  | 55    | 3.67   |    |
+| 57 | Shaylee Powell      | Naperville           | Calvary Church - J                         | 45    | 3.00   |    |
+| 58 | Tinley Boysen       | HeRose               | Rogers 1st AG                              | 40    | 2.67   |    |
+| 59 | Ryan Smithkey       | Brickmasters         | Racine AG                                  | 25    | 1.67   |    |
+| 60 | Chloe Mitchell      | NHF Super Quizzers   | New Hope Fellowship                        | 20    | 1.33   |    |
+| 61 | Andrew Judd         | S.P.Y. Kids          | The Worship Center                         | 15    | 1.00   |    |
+| 62 | Samuel Otchere      | S.P.Y. Kids          | The Worship Center                         | 10    | .67    |    |
+| 63 | Brianna Connelly    | BC United Too        | Bethany Church                             | 5     | .33    |    |
+| 64 | Joshua Daniels      | S.P.Y. Kids          | The Worship Center                         |       | .00    |    |
+| 64 | Sofia Marks         | Celebration Quizzers | Celebration Church                         |       | .00    |    |
+| 64 | Riley Marks         | Celebration Quizzers | Celebration Church                         |       | .00    |    |
+| 64 | Naomi Ward          | BC United Too        | Bethany Church                             |       | .00    |    |
+| 64 | Melody Ward         | BC United Too        | Bethany Church                             |       | .00    |    |
+| 64 | Philip Bozzay       | S.P.Y. Kids          | The Worship Center                         |       | .00    |    |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                               | Church                            | W/L  | Total | Avg    |
+|---:|------------------------------------|-----------------------------------|------|------:|-------:|
+| 1  | BC United                          | Bethany Church                    | 14/1 | 3130  | 208.67 |
+| 2  | Triple Threat                      | Trinity                           | 12/3 | 3070  | 204.67 |
+| 3  | Quiz Commanders                    | Proventus Academy                 | 12/3 | 2455  | 163.67 |
+| 4  | Naperville                         | Calvary Church - S                | 10/5 | 2440  | 162.67 |
+| 5  | River of Life                      | River of Life Fellowship          | 9/6  | 2550  | 170.00 |
+| 6  | Gushers                            | Chapel Springs Church             | 9/6  | 2515  | 167.67 |
+| 7  | JAG                                | Jefferson AG                      | 9/6  | 2460  | 164.00 |
+| 8  | Funky Town Monkeys                 | Life AG                           | 8/7  | 2310  | 154.00 |
+| 9  | Brighton Assembly of God           | Brighton AG                       | 8/7  | 2470  | 164.67 |
+| 10 | McArthur\'s Mighty Men & WomAn     | Jacksonvill McArthur Church       | 7/8  | 1980  | 132.00 |
+| 11 | CIA - Special Agents               | Bethany Community Church          | 5/10 | 1625  | 108.33 |
+| 12 | Seekers of Truth                   | Charleston 1st AG                 | 4/11 | 1725  | 115.00 |
+| 13 | Carmel Apples                      | Carmel AG                         | 4/11 | 1710  | 114.00 |
+| 14 | Kingsport Kidz                     | Kingsport 1st AG                  | 4/11 | 1490  | 99.33  |
+| 15 | UFC- United For Christ             | The Bridge                        | 3/12 | 1900  | 126.67 |
+| 16 | Noble Christians In Service (NCIS) | Glad Tidings Church - Hanford, CA | 2/13 | 1405  | 93.67  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                   | Team                               | Church                            | Total | Avg    | QO |
+|---:|---------------------------|------------------------------------|-----------------------------------|------:|-------:|---:|
+| 1  | Mateo Cuadros             | River of Life                      | River of Life Fellowship          | 1645  | 109.67 | 7  |
+| 2  | Parker Lubbe              | Triple Threat                      | Trinity                           | 1425  | 95.00  | 6  |
+| 3  | Trinity Garza             | Quiz Commanders                    | Proventus Academy                 | 1275  | 85.00  | 5  |
+| 4  | Harrison Stevens          | Naperville                         | Calvary Church - S                | 1210  | 80.67  | 4  |
+| 5  | David Shepard             | Seekers of Truth                   | Charleston 1st AG                 | 1160  | 77.33  | 5  |
+| 6  | Todd Pettet               | BC United                          | Bethany Church                    | 1140  | 76.00  | 4  |
+| 7  | Josh Broxterman           | JAG                                | Jefferson AG                      | 1135  | 75.67  | 2  |
+| 8  | Cayla Brodeur             | BC United                          | Bethany Church                    | 1100  | 73.33  | 2  |
+| 9  | Josh Barajas              | Triple Threat                      | Trinity                           | 1090  | 72.67  | 5  |
+| 10 | Shawn Timothy             | Naperville                         | Calvary Church - S                | 1075  | 71.67  | 12 |
+| 11 | Micah Maynard             | Kingsport Kidz                     | Kingsport 1st AG                  | 1050  | 70.00  | 3  |
+| 12 | Nate Demoff               | Brighton Assembly of God           | Brighton AG                       | 1035  | 69.00  | 5  |
+| 13 | Jeremy Dapaah             | Gushers                            | Chapel Springs Church             | 960   | 64.00  | 4  |
+| 14 | Seth Swain                | McArthur\'s Mighty Men & WomAn     | Jacksonvill McArthur Church       | 850   | 56.67  | 1  |
+| 15 | Garrett Adelmann          | BC United                          | Bethany Church                    | 800   | 53.33  | 8  |
+| 16 | Samuel Tran               | Gushers                            | Chapel Springs Church             | 800   | 53.33  | 7  |
+| 17 | Faith Caughey             | CIA - Special Agents               | Bethany Community Church          | 800   | 53.33  | 1  |
+| 18 | Landon Grisham            | UFC- United For Christ             | The Bridge                        | 790   | 52.67  | 8  |
+| 19 | Zach Rothwell             | Funky Town Monkeys                 | Life AG                           | 765   | 51.00  |    |
+| 20 | Makayla Demoff            | Brighton Assembly of God           | Brighton AG                       | 740   | 49.33  |    |
+| 21 | Blake Garza               | Quiz Commanders                    | Proventus Academy                 | 735   | 49.00  | 5  |
+| 22 | Andrea Bosteder           | River of Life                      | River of Life Fellowship          | 710   | 47.33  | 8  |
+| 23 | Jared Demoff              | Brighton Assembly of God           | Brighton AG                       | 695   | 46.33  | 8  |
+| 24 | Tabitha Joanna Nirmal     | Noble Christians In Service (NCIS) | Glad Tidings Church - Hanford, CA | 660   | 44.00  | 2  |
+| 25 | Emma Hoffmann             | Funky Town Monkeys                 | Life AG                           | 640   | 42.67  |    |
+| 26 | Aryana Campbell           | UFC- United For Christ             | The Bridge                        | 620   | 41.33  | 1  |
+| 27 | Kyler Kaniper             | JAG                                | Jefferson AG                      | 615   | 41.00  |    |
+| 28 | Abeni Feurbacher          | JAG                                | Jefferson AG                      | 600   | 40.00  | 7  |
+| 29 | Tom Hoffmann              | Funky Town Monkeys                 | Life AG                           | 570   | 38.00  | 5  |
+| 30 | Emma Miller               | Triple Threat                      | Trinity                           | 555   | 37.00  | 2  |
+| 31 | Izlia Shepard             | Seekers of Truth                   | Charleston 1st AG                 | 530   | 35.33  | 3  |
+| 32 | David Warren              | Carmel Apples                      | Carmel AG                         | 520   | 34.67  | 1  |
+| 33 | Ethan Rosenbaum           | McArthur\'s Mighty Men & WomAn     | Jacksonvill McArthur Church       | 505   | 33.67  |    |
+| 34 | Wesley Horn               | UFC- United For Christ             | The Bridge                        | 500   | 33.33  |    |
+| 35 | Michelle Vannelli         | CIA - Special Agents               | Bethany Community Church          | 485   | 32.33  |    |
+| 36 | Hayden Alford             | Noble Christians In Service (NCIS) | Glad Tidings Church - Hanford, CA | 480   | 32.00  |    |
+| 37 | Carter Garza              | Quiz Commanders                    | Proventus Academy                 | 445   | 29.67  | 4  |
+| 38 | Morgan Zepp               | Carmel Apples                      | Carmel AG                         | 385   | 25.67  |    |
+| 39 | Ashlyn Wilson             | McArthur\'s Mighty Men & WomAn     | Jacksonvill McArthur Church       | 305   | 20.33  | 2  |
+| 40 | Faith Dillon              | Carmel Apples                      | Carmel AG                         | 300   | 20.00  |    |
+| 41 | Morgan Peltz              | Funky Town Monkeys                 | Life AG                           | 250   | 16.67  |    |
+| 42 | Maison Ealum              | Carmel Apples                      | Carmel AG                         | 230   | 15.33  | 1  |
+| 43 | Gabrielle (Gabby) Mendoza | Noble Christians In Service (NCIS) | Glad Tidings Church - Hanford, CA | 230   | 15.33  |    |
+| 43 | Garrett Richardson        | Gushers                            | Chapel Springs Church             | 230   | 15.33  |    |
+| 44 | Dakota Caldwell           | Kingsport Kidz                     | Kingsport 1st AG                  | 195   | 13.00  |    |
+| 45 | Bradley Beall             | Carmel Apples                      | Carmel AG                         | 185   | 12.33  | 1  |
+| 46 | Ashton Johnson            | McArthur\'s Mighty Men & WomAn     | Jacksonvill McArthur Church       | 175   | 11.67  |    |
+| 47 | KaAnna Salyer             | Kingsport Kidz                     | Kingsport 1st AG                  | 165   | 11.00  |    |
+| 48 | Caleb Sessoms             | River of Life                      | River of Life Fellowship          | 155   | 10.33  |    |
+| 49 | Joseph Skinner            | McArthur\'s Mighty Men & WomAn     | Jacksonvill McArthur Church       | 150   | 10.00  | 1  |
+| 50 | John Hull                 | Gushers                            | Chapel Springs Church             | 145   | 9.67   |    |
+| 50 | Bronte Mora               | Gushers                            | Chapel Springs Church             | 145   | 9.67   |    |
+| 51 | Reagan Stevens            | Naperville                         | Calvary Church - S                | 140   | 9.33   |    |
+| 52 | Elizabeth Fugere          | CIA - Special Agents               | Bethany Community Church          | 130   | 8.67   |    |
+| 53 | John Hamel                | CIA - Special Agents               | Bethany Community Church          | 110   | 7.33   | 1  |
+| 54 | Chloe Mora                | Gushers                            | Chapel Springs Church             | 110   | 7.33   |    |
+| 54 | Matthias Moore            | JAG                                | Jefferson AG                      | 110   | 7.33   |    |
+| 55 | Riley Longacre            | CIA - Special Agents               | Bethany Community Church          | 100   | 6.67   |    |
+| 56 | Luciana Salerno           | BC United                          | Bethany Church                    | 95    | 6.33   |    |
+| 57 | Kara Justice              | Carmel Apples                      | Carmel AG                         | 90    | 6.00   |    |
+| 58 | Noah Rothwell             | Funky Town Monkeys                 | Life AG                           | 85    | 5.67   |    |
+| 59 | Sebastian Steinbach       | Gushers                            | Chapel Springs Church             | 80    | 5.33   |    |
+| 60 | Jillian Kennard           | Kingsport Kidz                     | Kingsport 1st AG                  | 55    | 3.67   |    |
+| 61 | Carys Mora                | Gushers                            | Chapel Springs Church             | 45    | 3.00   |    |
+| 62 | Addison (Addy) McCullough | Noble Christians In Service (NCIS) | Glad Tidings Church - Hanford, CA | 40    | 2.67   |    |
+| 62 | Zach Sessoms              | River of Life                      | River of Life Fellowship          | 40    | 2.67   |    |
+| 63 | Josiah Hopple             | Seekers of Truth                   | Charleston 1st AG                 | 35    | 2.33   |    |
+| 64 | Morgan Gibson             | Kingsport Kidz                     | Kingsport 1st AG                  | 25    | 1.67   |    |
+| 65 | McKinley Stevens          | Naperville                         | Calvary Church - S                | 15    | 1.00   |    |
+| 66 | Kamryn Kaniper            | JAG                                | Jefferson AG                      | 5     | .33    |    |
+| 67 | Daniel Sils               | Seekers of Truth                   | Charleston 1st AG                 |       | .00    |    |
+| 67 | Katie O\'Connor           | Seekers of Truth                   | Charleston 1st AG                 |       | .00    |    |
+| 67 | Megan Bartlett            | Funky Town Monkeys                 | Life AG                           |       | .00    |    |
+| 67 | Sam Broxterman            | JAG                                | Jefferson AG                      |       | .00    |    |
+| 67 | Madison Rutherford        | Seekers of Truth                   | Charleston 1st AG                 |       | .00    |    |
+| 67 | Raqeem Graves             | Kingsport Kidz                     | Kingsport 1st AG                  |       | .00    |    |
+
+
+### Mint
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                          | Church                        | W/L  | Total | Avg    |
+|---:|-------------------------------|-------------------------------|------|------:|-------:|
+| 1  | Bible Boyz                    | Faith AG                      | 11/4 | 2825  | 188.33 |
+| 2  | ATC Flames                    | Atlanta Tamil Church          | 11/4 | 2605  | 173.67 |
+| 3  | Cedar Park                    | Cedar Park                    | 11/4 | 2365  | 157.67 |
+| 4  | Lawson Son Worshippers #1     | Lawson AG                     | 10/5 | 2625  | 175.00 |
+| 5  | Tribulation Force             | The Oaks Fellowship           | 10/5 | 2480  | 165.33 |
+| 6  | WoL Swordbearers              | Word of Life                  | 10/5 | 2465  | 164.33 |
+| 7  | Boyz of the Word              | New Albany, One Church        | 10/5 | 2455  | 163.67 |
+| 8  | Bethlehem Church              | Bethlehem Church              | 8/7  | 2145  | 143.00 |
+| 9  | Knights 4 Christ              | Tamil Gospel Church           | 8/7  | 2405  | 160.33 |
+| 10 | International Assembly of God | International AG              | 7/8  | 1965  | 131.00 |
+| 11 | Powdered Donuts               | Central AG                    | 6/9  | 1965  | 131.00 |
+| 12 | Askewville                    | Bethel AG - Askewville, NC    | 5/10 | 1950  | 130.00 |
+| 13 | Fire Bible Investigators      | Tucson Victory Worship Center | 5/10 | 1685  | 112.33 |
+| 14 | Jedis for Jesus               | River Valley Church           | 4/11 | 1755  | 117.00 |
+| 15 | #hashtag                      | LifeChurch AG                 | 3/12 | 1425  | 95.00  |
+| 16 | Victory Warriors              | Universal City - Victory AG   | 1/14 | 1210  | 80.67  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                 | Team                          | Church                        | Total | Avg    | QO |
+|---:|-------------------------|-------------------------------|-------------------------------|------:|-------:|---:|
+| 1  | Breanna Cole            | Lawson Son Worshippers #1     | Lawson AG                     | 1735  | 115.67 | 10 |
+| 2  | Ronald George           | ATC Flames                    | Atlanta Tamil Church          | 1720  | 114.67 | 9  |
+| 3  | Jonah Woodbine          | Bible Boyz                    | Faith AG                      | 1685  | 112.33 | 8  |
+| 4  | Josiah Mair             | Boyz of the Word              | New Albany, One Church        | 1680  | 112.00 | 9  |
+| 5  | Alex Jarrell            | Cedar Park                    | Cedar Park                    | 1555  | 103.67 | 9  |
+| 6  | Pete Mathew             | International Assembly of God | International AG              | 1315  | 87.67  | 7  |
+| 7  | David Hipshire          | Tribulation Force             | The Oaks Fellowship           | 1135  | 75.67  | 2  |
+| 8  | Landon Clark            | Powdered Donuts               | Central AG                    | 1120  | 74.67  | 2  |
+| 9  | Omrane Ouedraogo        | WoL Swordbearers              | Word of Life                  | 930   | 62.00  | 1  |
+| 10 | Gunnar Bundrick         | Tribulation Force             | The Oaks Fellowship           | 885   | 59.00  | 12 |
+| 11 | Alvin Vasanthakumar     | ATC Flames                    | Atlanta Tamil Church          | 885   | 59.00  | 11 |
+| 12 | Nigus Dawit             | WoL Swordbearers              | Word of Life                  | 880   | 58.67  | 1  |
+| 13 | Alex Koch               | Jedis for Jesus               | River Valley Church           | 865   | 57.67  | 1  |
+| 14 | Nathan Mills            | Victory Warriors              | Universal City - Victory AG   | 845   | 56.33  | 1  |
+| 15 | Micah Hill              | Askewville                    | Bethel AG - Askewville, NC    | 830   | 55.33  | 2  |
+| 16 | Deborah Devaraj         | Knights 4 Christ              | Tamil Gospel Church           | 710   | 47.33  |    |
+| 17 | Hannah Jones            | Powdered Donuts               | Central AG                    | 625   | 41.67  | 3  |
+| 18 | Laken Manns             | Lawson Son Worshippers #1     | Lawson AG                     | 620   | 41.33  | 3  |
+| 19 | Remiel Brigilin Stanley | Knights 4 Christ              | Tamil Gospel Church           | 580   | 38.67  |    |
+| 20 | Joseph Subrath          | Bethlehem Church              | Bethlehem Church              | 570   | 38.00  |    |
+| 21 | David Pesce             | Askewville                    | Bethel AG - Askewville, NC    | 555   | 37.00  |    |
+| 21 | Daynah Dyal             | Bethlehem Church              | Bethlehem Church              | 555   | 37.00  |    |
+| 22 | Dallas Pitman           | #hashtag                      | LifeChurch AG                 | 510   | 34.00  | 2  |
+| 23 | Amelia Gephart          | Fire Bible Investigators      | Tucson Victory Worship Center | 505   | 33.67  | 1  |
+| 24 | Justin Arocho           | Bethlehem Church              | Bethlehem Church              | 495   | 33.00  | 3  |
+| 25 | Tucker Briggs           | Bible Boyz                    | Faith AG                      | 475   | 31.67  | 3  |
+| 26 | Noah Zananiri           | Boyz of the Word              | New Albany, One Church        | 460   | 30.67  | 3  |
+| 27 | Jordan Nix              | #hashtag                      | LifeChurch AG                 | 460   | 30.67  |    |
+| 27 | Katelyn Hall            | #hashtag                      | LifeChurch AG                 | 460   | 30.67  |    |
+| 28 | Nathaniel Jebaraj       | Knights 4 Christ              | Tamil Gospel Church           | 440   | 29.33  | 1  |
+| 29 | Tate Putman             | Jedis for Jesus               | River Valley Church           | 440   | 29.33  |    |
+| 30 | Jerell Gipson           | Knights 4 Christ              | Tamil Gospel Church           | 430   | 28.67  | 2  |
+| 31 | Brady Coleman           | Tribulation Force             | The Oaks Fellowship           | 420   | 28.00  |    |
+| 32 | Christiaan West         | Cedar Park                    | Cedar Park                    | 410   | 27.33  | 3  |
+| 33 | Eliana Bazemore         | Askewville                    | Bethel AG - Askewville, NC    | 385   | 25.67  | 2  |
+| 34 | Reuben Abraham          | International Assembly of God | International AG              | 380   | 25.33  | 3  |
+| 35 | Sedenia Dawit           | WoL Swordbearers              | Word of Life                  | 370   | 24.67  | 2  |
+| 36 | Esteban Suarez          | Bible Boyz                    | Faith AG                      | 340   | 22.67  | 1  |
+| 37 | Michelle Lobato         | Fire Bible Investigators      | Tucson Victory Worship Center | 340   | 22.67  |    |
+| 38 | Tommy Briggs            | Bible Boyz                    | Faith AG                      | 330   | 22.00  |    |
+| 39 | Samuel Mair             | Boyz of the Word              | New Albany, One Church        | 315   | 21.00  | 1  |
+| 40 | Grace Waggoner          | Cedar Park                    | Cedar Park                    | 305   | 20.33  |    |
+| 41 | Hannah Royer            | Fire Bible Investigators      | Tucson Victory Worship Center | 300   | 20.00  | 2  |
+| 42 | Nathan Koch             | Jedis for Jesus               | River Valley Church           | 290   | 19.33  | 2  |
+| 43 | Daniel Solomon          | WoL Swordbearers              | Word of Life                  | 285   | 19.00  | 1  |
+| 44 | Madeline Berkey         | Fire Bible Investigators      | Tucson Victory Worship Center | 275   | 18.33  |    |
+| 45 | Skylar Fleming          | Victory Warriors              | Universal City - Victory AG   | 270   | 18.00  | 1  |
+| 46 | Broxton Cole            | Lawson Son Worshippers #1     | Lawson AG                     | 270   | 18.00  |    |
+| 47 | Joshua Senthil          | Knights 4 Christ              | Tamil Gospel Church           | 245   | 16.33  | 2  |
+| 48 | Godson Massene          | Bethlehem Church              | Bethlehem Church              | 235   | 15.67  | 1  |
+| 49 | Elizabeth Jones         | Powdered Donuts               | Central AG                    | 210   | 14.00  |    |
+| 49 | Ashley Okafor           | Bethlehem Church              | Bethlehem Church              | 210   | 14.00  |    |
+| 50 | Haven Hoggard           | Askewville                    | Bethel AG - Askewville, NC    | 180   | 12.00  |    |
+| 51 | Hannah Kuruvilla        | International Assembly of God | International AG              | 145   | 9.67   |    |
+| 52 | Omosiuwa Enakpene       | Fire Bible Investigators      | Tucson Victory Worship Center | 140   | 9.33   |    |
+| 53 | Joshua Kuruvilla        | International Assembly of God | International AG              | 125   | 8.33   |    |
+| 54 | Shobby Enakpene         | Fire Bible Investigators      | Tucson Victory Worship Center | 110   | 7.33   |    |
+| 55 | Cade Romine             | Jedis for Jesus               | River Valley Church           | 100   | 6.67   |    |
+| 56 | Cecily Houser           | Cedar Park                    | Cedar Park                    | 95    | 6.33   |    |
+| 57 | Brianna Boodram         | Bethlehem Church              | Bethlehem Church              | 85    | 5.67   |    |
+| 58 | Lindsey Schmidt         | Jedis for Jesus               | River Valley Church           | 60    | 4.00   |    |
+| 59 | Bailen Goodwin          | Victory Warriors              | Universal City - Victory AG   | 55    | 3.67   |    |
+| 60 | Faith Horne             | Victory Warriors              | Universal City - Victory AG   | 40    | 2.67   |    |
+| 60 | Elyssa Fulfer           | Tribulation Force             | The Oaks Fellowship           | 40    | 2.67   |    |
+| 61 | Vanessa Gomez           | Fire Bible Investigators      | Tucson Victory Worship Center | 15    | 1.00   |    |
+| 62 | Jackson Woodward        | Powdered Donuts               | Central AG                    | 10    | .67    |    |
+| 63 | Elli Woodward           | Powdered Donuts               | Central AG                    | 5     | .33    |    |
+| 64 | Joshua Daniel Dupati    | ATC Flames                    | Atlanta Tamil Church          |       | .00    |    |
+| 64 | Hana Tariku             | WoL Swordbearers              | Word of Life                  |       | .00    |    |
+| 64 | Joshua Raj              | Knights 4 Christ              | Tamil Gospel Church           |       | .00    |    |
+| 64 | Rachel Nadia Dhinakar   | Knights 4 Christ              | Tamil Gospel Church           |       | .00    |    |
+| 64 | Kaitlyn Edward          | Knights 4 Christ              | Tamil Gospel Church           |       | .00    |    |
+| 64 | Isaac Myhal             | Boyz of the Word              | New Albany, One Church        |       | .00    |    |
+| 64 | Michael Alexander       | Bethlehem Church              | Bethlehem Church              |       | .00    |    |
+| 65 | Abby Jones              | Powdered Donuts               | Central AG                    | -5    | -0.33  |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                      | Church                           | W/L  | Total | Avg    |
+|---:|---------------------------|----------------------------------|------|------:|-------:|
+| 1  | FAT Buzzers               | City Church                      | 12/3 | 2955  | 197.00 |
+| 2  | Christos Anthropos        | Dayspring                        | 12/3 | 2920  | 194.67 |
+| 3  | Lawson Son Worshippers #2 | Lawson AG                        | 12/3 | 2660  | 177.33 |
+| 4  | 360 Quizzers              | Life360 Church                   | 11/4 | 2640  | 176.00 |
+| 5  | The J.A.M.                | Brightmoor Christian Church      | 9/6  | 2345  | 156.33 |
+| 6  | Reign of Fire             | Bethesda AG                      | 8/7  | 2590  | 172.67 |
+| 7  | Kinston Tanglewood        | Kinston Tanglewood               | 8/7  | 2320  | 154.67 |
+| 8  | Bible Avengers            | Mechanicsville Christian Center  | 8/7  | 2280  | 152.00 |
+| 9  | God\'s Jewels             | North Scottsdale Christian       | 6/9  | 2295  | 153.00 |
+| 10 | Havre Assembly of God     | Havre AG                         | 6/9  | 2180  | 145.33 |
+| 11 | CRK Almighty              | Church of the Risen King         | 6/9  | 2145  | 143.00 |
+| 12 | Eagles                    | North Little Rock 1st AG         | 6/9  | 1905  | 127.00 |
+| 13 | Quizzer Connection        | Lubbock 1st AG                   | 6/9  | 1860  | 124.00 |
+| 14 | The Purple Prophetesses   | Lindale Church                   | 5/10 | 1565  | 104.33 |
+| 15 | COTN                      | Church of the Nations            | 3/12 | 1405  | 93.67  |
+| 16 | Crazy Conquerors 4 Christ | Victory International Fellowship | 2/13 | 1455  | 97.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                      | Church                           | Total | Avg    | QO |
+|---:|----------------------|---------------------------|----------------------------------|------:|-------:|---:|
+| 1  | Jonathan Archer      | Lawson Son Worshippers #2 | Lawson AG                        | 1885  | 125.67 | 12 |
+| 2  | Toby Robinson        | FAT Buzzers               | City Church                      | 1750  | 116.67 | 12 |
+| 3  | Alaynee Hawley       | Havre Assembly of God     | Havre AG                         | 1520  | 101.33 | 11 |
+| 4  | Joanna Moses         | God\'s Jewels             | North Scottsdale Christian       | 1245  | 83.00  | 6  |
+| 5  | Reuben Deemy         | Reign of Fire             | Bethesda AG                      | 1210  | 80.67  | 3  |
+| 6  | Aedan Moore          | Eagles                    | North Little Rock 1st AG         | 1195  | 79.67  | 3  |
+| 7  | Cameron Ramsey       | 360 Quizzers              | Life360 Church                   | 1185  | 79.00  | 8  |
+| 8  | Megan Holleman       | The J.A.M.                | Brightmoor Christian Church      | 1175  | 78.33  | 3  |
+| 9  | Maelee Becton        | Kinston Tanglewood        | Kinston Tanglewood               | 1170  | 78.00  | 1  |
+| 10 | Johanna Slembarski   | Christos Anthropos        | Dayspring                        | 1120  | 74.67  | 3  |
+| 11 | Angelia Whitfield    | Bible Avengers            | Mechanicsville Christian Center  | 1060  | 70.67  | 6  |
+| 12 | Shani Estep          | Christos Anthropos        | Dayspring                        | 975   | 65.00  | 1  |
+| 13 | Ezekiel (Zeke) Loper | COTN                      | Church of the Nations            | 965   | 64.33  | 3  |
+| 14 | Jacob Flores         | CRK Almighty              | Church of the Risen King         | 965   | 64.33  | 2  |
+| 15 | Justice Schwickerath | Bible Avengers            | Mechanicsville Christian Center  | 910   | 60.67  | 5  |
+| 16 | Luke Kobylski        | Christos Anthropos        | Dayspring                        | 825   | 55.00  | 10 |
+| 17 | Austin Chmiel        | The J.A.M.                | Brightmoor Christian Church      | 825   | 55.00  | 8  |
+| 18 | Sydney Cummins       | The Purple Prophetesses   | Lindale Church                   | 795   | 53.00  | 2  |
+| 19 | Jaqueline Martinez   | Reign of Fire             | Bethesda AG                      | 720   | 48.00  | 8  |
+| 20 | Miles Kastner        | Crazy Conquerors 4 Christ | Victory International Fellowship | 700   | 46.67  | 1  |
+| 21 | Brendon Johnson      | Quizzer Connection        | Lubbock 1st AG                   | 700   | 46.67  |    |
+| 22 | Joanne Sinniah       | 360 Quizzers              | Life360 Church                   | 690   | 46.00  | 1  |
+| 23 | Austin Ramsey        | 360 Quizzers              | Life360 Church                   | 685   | 45.67  | 7  |
+| 24 | Bethany Escobar      | CRK Almighty              | Church of the Risen King         | 670   | 44.67  | 3  |
+| 25 | Vinton Deemy         | Reign of Fire             | Bethesda AG                      | 660   | 44.00  |    |
+| 26 | Jordan Perez         | FAT Buzzers               | City Church                      | 645   | 43.00  | 1  |
+| 27 | Kelton Johnson       | Quizzer Connection        | Lubbock 1st AG                   | 640   | 42.67  |    |
+| 28 | Kayden Vasquez       | The Purple Prophetesses   | Lindale Church                   | 630   | 42.00  | 4  |
+| 29 | Nick Cook            | Lawson Son Worshippers #2 | Lawson AG                        | 625   | 41.67  | 5  |
+| 30 | Kennedy Santes       | Kinston Tanglewood        | Kinston Tanglewood               | 590   | 39.33  |    |
+| 31 | Holly Garrett        | God\'s Jewels             | North Scottsdale Christian       | 570   | 38.00  | 4  |
+| 32 | Faith Moon           | FAT Buzzers               | City Church                      | 560   | 37.33  | 4  |
+| 33 | Casey Powell         | Kinston Tanglewood        | Kinston Tanglewood               | 545   | 36.33  | 4  |
+| 34 | Angel McNeil         | Quizzer Connection        | Lubbock 1st AG                   | 520   | 34.67  | 4  |
+| 35 | Alaura Hawley        | Havre Assembly of God     | Havre AG                         | 445   | 29.67  | 1  |
+| 36 | Hezekiah Reynes      | CRK Almighty              | Church of the Risen King         | 410   | 27.33  |    |
+| 37 | Alexis Sharps        | Eagles                    | North Little Rock 1st AG         | 355   | 23.67  | 1  |
+| 38 | Tawny Audi           | God\'s Jewels             | North Scottsdale Christian       | 345   | 23.00  | 1  |
+| 38 | Isaac Ubert          | Crazy Conquerors 4 Christ | Victory International Fellowship | 345   | 23.00  | 1  |
+| 39 | Samuel Dimmock       | Crazy Conquerors 4 Christ | Victory International Fellowship | 300   | 20.00  |    |
+| 40 | Kathryn Ouyang       | COTN                      | Church of the Nations            | 275   | 18.33  |    |
+| 41 | Hannah Hall          | Eagles                    | North Little Rock 1st AG         | 260   | 17.33  |    |
+| 42 | Josiah Boe           | Havre Assembly of God     | Havre AG                         | 215   | 14.33  |    |
+| 42 | Jonathon Bonzelaar   | The J.A.M.                | Brightmoor Christian Church      | 215   | 14.33  |    |
+| 43 | Adam Shuman          | COTN                      | Church of the Nations            | 155   | 10.33  |    |
+| 44 | Seth Archer          | Lawson Son Worshippers #2 | Lawson AG                        | 150   | 10.00  |    |
+| 45 | Maia Gheorghiu       | God\'s Jewels             | North Scottsdale Christian       | 135   | 9.00   |    |
+| 45 | Abigail Chapa        | The Purple Prophetesses   | Lindale Church                   | 135   | 9.00   |    |
+| 46 | Jayne Weber          | Bible Avengers            | Mechanicsville Christian Center  | 120   | 8.00   |    |
+| 47 | Elizabeth Murray     | Crazy Conquerors 4 Christ | Victory International Fellowship | 110   | 7.33   |    |
+| 48 | Cameron Ramos        | CRK Almighty              | Church of the Risen King         | 100   | 6.67   |    |
+| 48 | Honey Schwickerath   | Bible Avengers            | Mechanicsville Christian Center  | 100   | 6.67   |    |
+| 49 | Angel Walker         | Bible Avengers            | Mechanicsville Christian Center  | 90    | 6.00   |    |
+| 50 | Cavan McIntyre       | The J.A.M.                | Brightmoor Christian Church      | 85    | 5.67   |    |
+| 51 | Morgan Liles         | Eagles                    | North Little Rock 1st AG         | 75    | 5.00   |    |
+| 52 | Caleb Black          | 360 Quizzers              | Life360 Church                   | 50    | 3.33   |    |
+| 53 | Blake Chmiel         | The J.A.M.                | Brightmoor Christian Church      | 40    | 2.67   |    |
+| 54 | Kaitlyn Ramsey       | 360 Quizzers              | Life360 Church                   | 30    | 2.00   |    |
+| 55 | Luke Nash            | Eagles                    | North Little Rock 1st AG         | 20    | 1.33   |    |
+| 56 | Karen Geddie         | Kinston Tanglewood        | Kinston Tanglewood               | 15    | 1.00   |    |
+| 57 | Hailey Chmiel        | The J.A.M.                | Brightmoor Christian Church      | 10    | .67    |    |
+| 57 | Linden Bowden        | COTN                      | Church of the Nations            | 10    | .67    |    |
+| 58 | London Cummins       | The Purple Prophetesses   | Lindale Church                   | 5     | .33    |    |
+| 59 | Chloe Clemons        | Eagles                    | North Little Rock 1st AG         |       | .00    |    |
+| 59 | Calista Gotos        | CRK Almighty              | Church of the Risen King         |       | .00    |    |
+| 59 | Savannah Stricklin   | Eagles                    | North Little Rock 1st AG         |       | .00    |    |
+| 59 | Eden Stokes          | The J.A.M.                | Brightmoor Christian Church      |       | .00    |    |
+| 59 | Elijah Escobar       | CRK Almighty              | Church of the Risen King         |       | .00    |    |
+| 59 | Aubrey Goss          | FAT Buzzers               | City Church                      |       | .00    |    |
+| 59 | Andrew Dippel        | Eagles                    | North Little Rock 1st AG         |       | .00    |    |
+| 59 | Catie Wolfe          | 360 Quizzers              | Life360 Church                   |       | .00    |    |
+| 59 | Mckenna Black        | 360 Quizzers              | Life360 Church                   |       | .00    |    |
+| 60 | Aniyah Stokes        | The J.A.M.                | Brightmoor Christian Church      | -5    | -0.33  |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                          | Church                          | W/L  | Total | Avg    |
+|---:|-------------------------------|---------------------------------|------|------:|-------:|
+| 1  | Pace Power                    | Pace AG Ministries              | 12/3 | 2765  | 184.33 |
+| 2  | Kids for Christ               | Abundant Life AG                | 10/5 | 2670  | 178.00 |
+| 3  | Wilmington warriors           | Church on the cape              | 10/5 | 2540  | 169.33 |
+| 4  | God Squad                     | International AG Mesa Az        | 10/5 | 2500  | 166.67 |
+| 5  | Quizzing Quartet              | Versailles King\'s Way AG       | 10/5 | 2450  | 163.33 |
+| 6  | Naperville                    | Calvary Church - C              | 10/5 | 2415  | 161.00 |
+| 7  | West Ridge Warriors           | West Ridge Church               | 10/5 | 2315  | 154.33 |
+| 8  | Bible Minions                 | Mechanicsville Christian Center | 9/6  | 2430  | 162.00 |
+| 9  | Greater Lansing               | First AG of Greater Lansing     | 8/7  | 2345  | 156.33 |
+| 10 | Neighborhood                  | Neighborhood AG                 | 7/8  | 2200  | 146.67 |
+| 11 | Kung Fu Quizzers              | Benton 1st AG                   | 6/9  | 1780  | 118.67 |
+| 12 | One 8                         | 1st AG                          | 5/10 | 1915  | 127.67 |
+| 13 | Transformed                   | Garland-First@Firewheel         | 5/10 | 2115  | 141.00 |
+| 14 | Life Church BRATS             | Life Church AG Church           | 3/12 | 1550  | 103.33 |
+| 15 | Collierville Freedom Fighters | Collierville 1st AG             | 3/12 | 1410  | 94.00  |
+| 16 | Righteous Refusers            | Walnut Grove                    | 2/13 | 1295  | 86.33  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                          | Church                          | Total | Avg    | QO |
+|---:|------------------------|-------------------------------|---------------------------------|------:|-------:|---:|
+| 1  | Brayden Tompkins       | Pace Power                    | Pace AG Ministries              | 1910  | 127.33 | 12 |
+| 2  | Ty Silas               | Naperville                    | Calvary Church - C              | 1575  | 105.00 | 10 |
+| 3  | Zachery Lickey         | Neighborhood                  | Neighborhood AG                 | 1555  | 103.67 | 10 |
+| 4  | Darcie Harr            | Greater Lansing               | First AG of Greater Lansing     | 1405  | 93.67  | 6  |
+| 5  | Simeon McCune          | West Ridge Warriors           | West Ridge Church               | 1390  | 92.67  | 4  |
+| 6  | Zane Brown             | Transformed                   | Garland-First@Firewheel         | 1230  | 82.00  | 6  |
+| 7  | Madison Steele         | Bible Minions                 | Mechanicsville Christian Center | 1145  | 76.33  | 7  |
+| 8  | Wesley Self            | Quizzing Quartet              | Versailles King\'s Way AG       | 1140  | 76.00  | 7  |
+| 9  | David Blomberg         | Kids for Christ               | Abundant Life AG                | 1090  | 72.67  | 8  |
+| 10 | Samy Paul              | Collierville Freedom Fighters | Collierville 1st AG             | 1090  | 72.67  | 3  |
+| 11 | Ethan Small            | Life Church BRATS             | Life Church AG Church           | 1025  | 68.33  | 2  |
+| 12 | Bobbie Jean Barnes     | Kung Fu Quizzers              | Benton 1st AG                   | 945   | 63.00  | 1  |
+| 13 | Jomi Malayil           | God Squad                     | International AG Mesa Az        | 935   | 62.33  | 2  |
+| 14 | Caleb Blomberg         | Kids for Christ               | Abundant Life AG                | 880   | 58.67  | 1  |
+| 15 | Kenan Flores           | Quizzing Quartet              | Versailles King\'s Way AG       | 855   | 57.00  | 1  |
+| 16 | Christian Shelton      | Wilmington warriors           | Church on the cape              | 815   | 54.33  |    |
+| 17 | Gavin Kuruvilla        | God Squad                     | International AG Mesa Az        | 800   | 53.33  |    |
+| 18 | Zachary Leake          | Wilmington warriors           | Church on the cape              | 775   | 51.67  | 1  |
+| 19 | Jackson Convis         | Greater Lansing               | First AG of Greater Lansing     | 770   | 51.33  | 8  |
+| 20 | Kierstin Child\'s      | Wilmington warriors           | Church on the cape              | 700   | 46.67  | 8  |
+| 21 | Justiss Silas          | Naperville                    | Calvary Church - C              | 680   | 45.33  | 7  |
+| 22 | Jared Watson           | Kung Fu Quizzers              | Benton 1st AG                   | 675   | 45.00  | 7  |
+| 23 | Payton Astorga         | One 8                         | 1st AG                          | 660   | 44.00  | 1  |
+| 24 | Kevin Sowers           | One 8                         | 1st AG                          | 565   | 37.67  | 2  |
+| 25 | Good News Iwuamadi     | Transformed                   | Garland-First@Firewheel         | 560   | 37.33  | 3  |
+| 26 | Braden Adams           | Bible Minions                 | Mechanicsville Christian Center | 555   | 37.00  | 2  |
+| 27 | Josiah Davis           | Pace Power                    | Pace AG Ministries              | 495   | 33.00  | 3  |
+| 28 | Will Rittenhouse       | Bible Minions                 | Mechanicsville Christian Center | 490   | 32.67  | 3  |
+| 29 | Jeremy Varghese        | God Squad                     | International AG Mesa Az        | 470   | 31.33  | 2  |
+| 30 | Abbi Good              | Life Church BRATS             | Life Church AG Church           | 465   | 31.00  | 2  |
+| 31 | Madeline Lickey        | Neighborhood                  | Neighborhood AG                 | 460   | 30.67  | 1  |
+| 32 | Chloe Smith            | West Ridge Warriors           | West Ridge Church               | 420   | 28.00  | 2  |
+| 33 | Raymond Harris         | Righteous Refusers            | Walnut Grove                    | 390   | 26.00  | 2  |
+| 34 | Ashley Thompson        | Pace Power                    | Pace AG Ministries              | 360   | 24.00  |    |
+| 35 | Olivia Lee             | Quizzing Quartet              | Versailles King\'s Way AG       | 355   | 23.67  | 1  |
+| 36 | Aiden McCreary         | Righteous Refusers            | Walnut Grove                    | 350   | 23.33  | 1  |
+| 37 | Micah Demmer           | Kids for Christ               | Abundant Life AG                | 350   | 23.33  |    |
+| 38 | Reagan McCreary        | Righteous Refusers            | Walnut Grove                    | 315   | 21.00  | 1  |
+| 39 | Luke Winrod            | Kids for Christ               | Abundant Life AG                | 270   | 18.00  |    |
+| 39 | Madisen McCune         | West Ridge Warriors           | West Ridge Church               | 270   | 18.00  |    |
+| 40 | Ryan Astorga           | One 8                         | 1st AG                          | 265   | 17.67  | 2  |
+| 41 | Kendra Winkleblech     | Righteous Refusers            | Walnut Grove                    | 240   | 16.00  |    |
+| 41 | Sieanna Sowers         | One 8                         | 1st AG                          | 240   | 16.00  |    |
+| 42 | Avryl Weiland          | West Ridge Warriors           | West Ridge Church               | 235   | 15.67  | 1  |
+| 43 | Joey Paul              | Collierville Freedom Fighters | Collierville 1st AG             | 230   | 15.33  |    |
+| 43 | Seth Christopher       | Bible Minions                 | Mechanicsville Christian Center | 230   | 15.33  |    |
+| 44 | Brock boehling         | Wilmington warriors           | Church on the cape              | 210   | 14.00  |    |
+| 45 | Amarachi Ayozie        | Transformed                   | Garland-First@Firewheel         | 205   | 13.67  |    |
+| 46 | Sarah Mathew           | God Squad                     | International AG Mesa Az        | 190   | 12.67  |    |
+| 47 | Julia Correa           | Neighborhood                  | Neighborhood AG                 | 185   | 12.33  | 1  |
+| 48 | Michelle Aum           | Naperville                    | Calvary Church - C              | 160   | 10.67  |    |
+| 49 | Onome Oghor            | Greater Lansing               | First AG of Greater Lansing     | 155   | 10.33  |    |
+| 50 | Skylar Sides           | One 8                         | 1st AG                          | 150   | 10.00  |    |
+| 51 | Joshua Malayil         | God Squad                     | International AG Mesa Az        | 105   | 7.00   |    |
+| 52 | Faithful Iwuamadi      | Transformed                   | Garland-First@Firewheel         | 100   | 6.67   |    |
+| 53 | Josiah Murphy          | Collierville Freedom Fighters | Collierville 1st AG             | 90    | 6.00   |    |
+| 54 | Cora Self              | Quizzing Quartet              | Versailles King\'s Way AG       | 85    | 5.67   |    |
+| 55 | Seth Winrod            | Kids for Christ               | Abundant Life AG                | 80    | 5.33   |    |
+| 56 | Noah Small             | Life Church BRATS             | Life Church AG Church           | 65    | 4.33   |    |
+| 57 | Emily Greenwell        | Kung Fu Quizzers              | Benton 1st AG                   | 60    | 4.00   |    |
+| 58 | Peyton Shuffitt        | One 8                         | 1st AG                          | 55    | 3.67   |    |
+| 59 | Brittyn Glover         | Kung Fu Quizzers              | Benton 1st AG                   | 50    | 3.33   |    |
+| 60 | Alexis Rowland         | Kung Fu Quizzers              | Benton 1st AG                   | 40    | 2.67   |    |
+| 61 | Abrianna Hoyle- Harris | Wilmington warriors           | Church on the cape              | 20    | 1.33   |    |
+| 61 | Ian Rehmel             | Quizzing Quartet              | Versailles King\'s Way AG       | 20    | 1.33   |    |
+| 61 | Britta Andrews         | Greater Lansing               | First AG of Greater Lansing     | 20    | 1.33   |    |
+| 62 | Austin Green           | Kung Fu Quizzers              | Benton 1st AG                   | 10    | .67    |    |
+| 62 | Corrie Lee Boehling    | Wilmington warriors           | Church on the cape              | 10    | .67    |    |
+| 62 | Michael Ikechukwu      | Transformed                   | Garland-First@Firewheel         | 10    | .67    |    |
+| 62 | Luke Shelton           | Wilmington warriors           | Church on the cape              | 10    | .67    |    |
+| 62 | Chi Chi Otah           | Transformed                   | Garland-First@Firewheel         | 10    | .67    |    |
+| 62 | Britt Adams            | Bible Minions                 | Mechanicsville Christian Center | 10    | .67    |    |
+| 63 | Heather Thompson       | Wilmington warriors           | Church on the cape              |       | .00    |    |
+| 63 | Austin Shuffitt        | One 8                         | 1st AG                          |       | .00    |    |
+| 63 | Grace Winrod           | Kids for Christ               | Abundant Life AG                |       | .00    |    |
+| 63 | Kylee White            | Life Church BRATS             | Life Church AG Church           |       | .00    |    |
+| 63 | Malinda White          | Life Church BRATS             | Life Church AG Church           |       | .00    |    |
+| 63 | John Adams             | Righteous Refusers            | Walnut Grove                    |       | .00    |    |
+| 63 | Stephen Bough          | Naperville                    | Calvary Church - C              |       | .00    |    |
+| 64 | Lilly Powell           | One 8                         | 1st AG                          | -20   | -1.33  |    |
+| 65 | Cierra Convis          | Greater Lansing               | First AG of Greater Lansing     | -5    | -0.33  |    |
+| 65 | Jadon Lantz            | Life Church BRATS             | Life Church AG Church           | -5    | -0.33  |    |
+
+## Saturday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team               | Church               | W/L | Total | Avg    |
+|---:|--------------------|----------------------|-----|------:|-------:|
+| 1  | ATC Flames         | Atlanta Tamil Church | 8/1 | 1545  | 171.67 |
+| 2  | Triple Threat      | Trinity              | 6/3 | 1725  | 191.67 |
+| 3  | Kids for Christ    | Abundant Life AG     | 6/3 | 1465  | 162.78 |
+| 4  | Bible Boyz         | Faith AG             | 6/3 | 1395  | 155.00 |
+| 5  | Naperville         | Calvary Church - J   | 5/4 | 1665  | 185.00 |
+| 6  | S.P.Y. Kids        | The Worship Center   | 4/5 | 1250  | 138.89 |
+| 7  | Christos Anthropos | Dayspring            | 4/5 | 1240  | 137.78 |
+| 8  | BC United          | Bethany Church       | 3/6 | 1190  | 132.22 |
+| 9  | FAT Buzzers        | City Church          | 3/6 | 1115  | 123.89 |
+| 10 | Pace Power         | Pace AG Ministries   | 0/9 | 780   | 86.67  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team               | Church               | Total | Avg    | QO |
+|---:|----------------------|--------------------|----------------------|------:|-------:|---:|
+| 1  | Ronald George        | ATC Flames         | Atlanta Tamil Church | 1085  | 120.56 | 7  |
+| 2  | Shreanna Powell      | Naperville         | Calvary Church - J   | 1060  | 117.78 | 7  |
+| 3  | Jonah Woodbine       | Bible Boyz         | Faith AG             | 915   | 101.67 | 2  |
+| 4  | Parker Lubbe         | Triple Threat      | Trinity              | 725   | 80.56  | 2  |
+| 5  | Josh Barajas         | Triple Threat      | Trinity              | 715   | 79.44  | 2  |
+| 6  | David Blomberg       | Kids for Christ    | Abundant Life AG     | 690   | 76.67  | 6  |
+| 7  | Brayden Tompkins     | Pace Power         | Pace AG Ministries   | 625   | 69.44  |    |
+| 8  | Cayla Brodeur        | BC United          | Bethany Church       | 610   | 67.78  | 1  |
+| 9  | Toby Robinson        | FAT Buzzers        | City Church          | 575   | 63.89  | 2  |
+| 10 | Johanna Slembarski   | Christos Anthropos | Dayspring            | 555   | 61.67  |    |
+| 11 | Alvin Vasanthakumar  | ATC Flames         | Atlanta Tamil Church | 460   | 51.11  | 4  |
+| 12 | Caleb Blomberg       | Kids for Christ    | Abundant Life AG     | 450   | 50.00  |    |
+| 13 | Sheldon Powell       | Naperville         | Calvary Church - J   | 410   | 45.56  | 5  |
+| 14 | Emily Walsh          | S.P.Y. Kids        | The Worship Center   | 390   | 43.33  |    |
+| 15 | Luke Kobylski        | Christos Anthropos | Dayspring            | 375   | 41.67  | 5  |
+| 16 | Diana Bozzay         | S.P.Y. Kids        | The Worship Center   | 360   | 40.00  | 1  |
+| 17 | Jordan Perez         | FAT Buzzers        | City Church          | 325   | 36.11  |    |
+| 18 | Shani Estep          | Christos Anthropos | Dayspring            | 310   | 34.44  | 1  |
+| 19 | Garrett Adelmann     | BC United          | Bethany Church       | 295   | 32.78  | 2  |
+| 20 | Cara Hodge           | S.P.Y. Kids        | The Worship Center   | 290   | 32.22  | 2  |
+| 21 | Emma Miller          | Triple Threat      | Trinity              | 285   | 31.67  | 1  |
+| 22 | Micah Demmer         | Kids for Christ    | Abundant Life AG     | 280   | 31.11  |    |
+| 23 | Todd Pettet          | BC United          | Bethany Church       | 255   | 28.33  |    |
+| 24 | Tucker Briggs        | Bible Boyz         | Faith AG             | 230   | 25.56  | 1  |
+| 25 | Faith Moon           | FAT Buzzers        | City Church          | 215   | 23.89  |    |
+| 26 | Esteban Suarez       | Bible Boyz         | Faith AG             | 150   | 16.67  | 1  |
+| 27 | Erin Frye            | S.P.Y. Kids        | The Worship Center   | 150   | 16.67  |    |
+| 28 | Josiah Davis         | Pace Power         | Pace AG Ministries   | 130   | 14.44  |    |
+| 29 | Tommy Briggs         | Bible Boyz         | Faith AG             | 100   | 11.11  |    |
+| 30 | Shaymis Powell       | Naperville         | Calvary Church - J   | 85    | 9.44   |    |
+| 31 | Erin Laboy           | Naperville         | Calvary Church - J   | 80    | 8.89   |    |
+| 32 | Joshua Daniels       | S.P.Y. Kids        | The Worship Center   | 60    | 6.67   |    |
+| 33 | Luke Winrod          | Kids for Christ    | Abundant Life AG     | 45    | 5.00   |    |
+| 34 | Shaylee Powell       | Naperville         | Calvary Church - J   | 30    | 3.33   |    |
+| 34 | Luciana Salerno      | BC United          | Bethany Church       | 30    | 3.33   |    |
+| 35 | Ashley Thompson      | Pace Power         | Pace AG Ministries   | 25    | 2.78   |    |
+| 36 | Samuel Otchere       | S.P.Y. Kids        | The Worship Center   |       | .00    |    |
+| 36 | Andrew Judd          | S.P.Y. Kids        | The Worship Center   |       | .00    |    |
+| 36 | Aubrey Goss          | FAT Buzzers        | City Church          |       | .00    |    |
+| 36 | Philip Bozzay        | S.P.Y. Kids        | The Worship Center   |       | .00    |    |
+| 36 | Grace Winrod         | Kids for Christ    | Abundant Life AG     |       | .00    |    |
+| 36 | Seth Winrod          | Kids for Christ    | Abundant Life AG     |       | .00    |    |
+| 36 | Joshua Daniel Dupati | ATC Flames         | Atlanta Tamil Church |       | .00    |    |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                           | Church                      | W/L | Total | Avg    |
+|---:|--------------------------------|-----------------------------|-----|------:|-------:|
+| 1  | Brighton Assembly of God       | Brighton AG                 | 8/1 | 1590  | 176.67 |
+| 2  | Havre Assembly of God          | Havre AG                    | 6/3 | 1445  | 160.56 |
+| 3  | Greater Lansing                | First AG of Greater Lansing | 5/4 | 1445  | 160.56 |
+| 4  | BC United Too                  | Bethany Church              | 5/4 | 1350  | 150.00 |
+| 5  | McArthur\'s Mighty Men & WomAn | Jacksonvill McArthur Church | 5/4 | 1275  | 141.67 |
+| 6  | The Bridge                     | Princeton The Bridge        | 4/5 | 1230  | 136.67 |
+| 7  | God\'s Jewels                  | North Scottsdale Christian  | 4/5 | 1150  | 127.78 |
+| 8  | International Assembly of God  | International AG            | 3/6 | 1280  | 142.22 |
+| 9  | Neighborhood                   | Neighborhood AG             | 3/6 | 1175  | 130.56 |
+| 10 | Knights 4 Christ               | Tamil Gospel Church         | 2/7 | 1100  | 122.22 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                 | Team                           | Church                      | Total | Avg    | QO |
+|---:|-------------------------|--------------------------------|-----------------------------|------:|-------:|---:|
+| 1  | Alaynee Hawley          | Havre Assembly of God          | Havre AG                    | 1050  | 116.67 | 6  |
+| 2  | Pete Mathew             | International Assembly of God  | International AG            | 970   | 107.78 | 7  |
+| 3  | Zachery Lickey          | Neighborhood                   | Neighborhood AG             | 780   | 86.67  | 3  |
+| 4  | Joanna Moses            | God\'s Jewels                  | North Scottsdale Christian  | 775   | 86.11  | 3  |
+| 5  | Nate Demoff             | Brighton Assembly of God       | Brighton AG                 | 700   | 77.78  | 2  |
+| 6  | Jackson Convis          | Greater Lansing                | First AG of Greater Lansing | 670   | 74.44  | 7  |
+| 7  | Gabriella Connelly      | BC United Too                  | Bethany Church              | 645   | 71.67  | 2  |
+| 8  | Caleb Jones             | The Bridge                     | Princeton The Bridge        | 635   | 70.56  | 2  |
+| 9  | Darcie Harr             | Greater Lansing                | First AG of Greater Lansing | 595   | 66.11  | 1  |
+| 10 | Makayla Demoff          | Brighton Assembly of God       | Brighton AG                 | 535   | 59.44  |    |
+| 11 | Seth Swain              | McArthur\'s Mighty Men & WomAn | Jacksonvill McArthur Church | 450   | 50.00  | 1  |
+| 12 | Nathaniel Ward          | BC United Too                  | Bethany Church              | 425   | 47.22  | 1  |
+| 13 | Makayla Jones           | The Bridge                     | Princeton The Bridge        | 395   | 43.89  | 5  |
+| 14 | Jared Demoff            | Brighton Assembly of God       | Brighton AG                 | 360   | 40.00  | 4  |
+| 15 | Ashlyn Wilson           | McArthur\'s Mighty Men & WomAn | Jacksonvill McArthur Church | 355   | 39.44  | 5  |
+| 16 | Ethan Rosenbaum         | McArthur\'s Mighty Men & WomAn | Jacksonvill McArthur Church | 330   | 36.67  |    |
+| 17 | Remiel Brigilin Stanley | Knights 4 Christ               | Tamil Gospel Church         | 280   | 31.11  |    |
+| 18 | James Pettibone         | BC United Too                  | Bethany Church              | 270   | 30.00  | 1  |
+| 19 | Deborah Devaraj         | Knights 4 Christ               | Tamil Gospel Church         | 220   | 24.44  |    |
+| 20 | Jerell Gipson           | Knights 4 Christ               | Tamil Gospel Church         | 215   | 23.89  | 1  |
+| 21 | Alaura Hawley           | Havre Assembly of God          | Havre AG                    | 210   | 23.33  |    |
+| 22 | Julia Correa            | Neighborhood                   | Neighborhood AG             | 205   | 22.78  |    |
+| 22 | Nathaniel Jebaraj       | Knights 4 Christ               | Tamil Gospel Church         | 205   | 22.78  |    |
+| 23 | Lucas Veronee           | The Bridge                     | Princeton The Bridge        | 200   | 22.22  |    |
+| 24 | Madeline Lickey         | Neighborhood                   | Neighborhood AG             | 190   | 21.11  |    |
+| 25 | Josiah Boe              | Havre Assembly of God          | Havre AG                    | 185   | 20.56  |    |
+| 26 | Joshua Senthil          | Knights 4 Christ               | Tamil Gospel Church         | 180   | 20.00  | 1  |
+| 27 | Tawny Audi              | God\'s Jewels                  | North Scottsdale Christian  | 175   | 19.44  | 1  |
+| 28 | Onome Oghor             | Greater Lansing                | First AG of Greater Lansing | 170   | 18.89  |    |
+| 29 | Holly Garrett           | God\'s Jewels                  | North Scottsdale Christian  | 165   | 18.33  |    |
+| 30 | Joshua Kuruvilla        | International Assembly of God  | International AG            | 135   | 15.00  |    |
+| 31 | Reuben Abraham          | International Assembly of God  | International AG            | 115   | 12.78  |    |
+| 32 | Joseph Skinner          | McArthur\'s Mighty Men & WomAn | Jacksonvill McArthur Church | 70    | 7.78   |    |
+| 32 | Ashton Johnson          | McArthur\'s Mighty Men & WomAn | Jacksonvill McArthur Church | 70    | 7.78   |    |
+| 33 | Hannah Kuruvilla        | International Assembly of God  | International AG            | 60    | 6.67   |    |
+| 34 | Maia Gheorghiu          | God\'s Jewels                  | North Scottsdale Christian  | 35    | 3.89   |    |
+| 35 | Cierra Convis           | Greater Lansing                | First AG of Greater Lansing | 10    | 1.11   |    |
+| 35 | Brianna Connelly        | BC United Too                  | Bethany Church              | 10    | 1.11   |    |
+| 36 | Rachel Nadia Dhinakar   | Knights 4 Christ               | Tamil Gospel Church         |       | .00    |    |
+| 36 | Joshua Raj              | Knights 4 Christ               | Tamil Gospel Church         |       | .00    |    |
+| 36 | Kaitlyn Edward          | Knights 4 Christ               | Tamil Gospel Church         |       | .00    |    |
+| 36 | Melody Ward             | BC United Too                  | Bethany Church              |       | .00    |    |
+| 36 | Naomi Ward              | BC United Too                  | Bethany Church              |       | .00    |    |
+| 36 | Britta Andrews          | Greater Lansing                | First AG of Greater Lansing |       | .00    |    |
+
+
+### Mint
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team              | Church                      | W/L | Total | Avg    |
+|---:|-------------------|-----------------------------|-----|------:|-------:|
+| 1  | Gushers           | Chapel Springs Church       | 7/2 | 1560  | 173.33 |
+| 2  | Reign of Fire     | Bethesda AG                 | 7/2 | 1540  | 171.11 |
+| 3  | Tribulation Force | The Oaks Fellowship         | 6/3 | 1665  | 185.00 |
+| 4  | Naperville        | Calvary Church - C          | 6/3 | 1345  | 149.44 |
+| 5  | The J.A.M.        | Brightmoor Christian Church | 6/3 | 1170  | 130.00 |
+| 6  | Love Boldly       | Freedom Church Tallahassee  | 4/5 | 1265  | 140.56 |
+| 7  | Quizzing Quartet  | Versailles King\'s Way AG   | 3/6 | 1090  | 121.11 |
+| 8  | The Chosen Ones   | Houston - Braeswood AG      | 3/6 | 1030  | 114.44 |
+| 9  | WoL Swordbearers  | Word of Life                | 3/6 | 950   | 105.56 |
+| 10 | River of Life     | River of Life Fellowship    | 0/9 | 845   | 93.89  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team              | Church                      | Total | Avg    | QO |
+|---:|---------------------|-------------------|-----------------------------|------:|-------:|---:|
+| 1  | Ty Silas            | Naperville        | Calvary Church - C          | 995   | 110.56 | 5  |
+| 2  | David Hipshire      | Tribulation Force | The Oaks Fellowship         | 760   | 84.44  | 3  |
+| 3  | Jeremy Dapaah       | Gushers           | Chapel Springs Church       | 760   | 84.44  | 1  |
+| 4  | Reuben Deemy        | Reign of Fire     | Bethesda AG                 | 695   | 77.22  | 2  |
+| 5  | Megan Holleman      | The J.A.M.        | Brightmoor Christian Church | 690   | 76.67  | 1  |
+| 6  | Mateo Cuadros       | River of Life     | River of Life Fellowship    | 605   | 67.22  | 1  |
+| 7  | Kenan Flores        | Quizzing Quartet  | Versailles King\'s Way AG   | 575   | 63.89  |    |
+| 8  | Gunnar Bundrick     | Tribulation Force | The Oaks Fellowship         | 545   | 60.56  | 7  |
+| 9  | Vinton Deemy        | Reign of Fire     | Bethesda AG                 | 495   | 55.00  | 1  |
+| 10 | Omrane Ouedraogo    | WoL Swordbearers  | Word of Life                | 470   | 52.22  |    |
+| 11 | Emma Stewart        | Love Boldly       | Freedom Church Tallahassee  | 455   | 50.56  | 1  |
+| 12 | Ethan Stewart       | Love Boldly       | Freedom Church Tallahassee  | 440   | 48.89  |    |
+| 13 | Collin Nester       | Love Boldly       | Freedom Church Tallahassee  | 370   | 41.11  | 1  |
+| 14 | Jaqueline Martinez  | Reign of Fire     | Bethesda AG                 | 350   | 38.89  | 3  |
+| 15 | Justiss Silas       | Naperville        | Calvary Church - C          | 340   | 37.78  | 2  |
+| 16 | Brady Coleman       | Tribulation Force | The Oaks Fellowship         | 340   | 37.78  |    |
+| 17 | Sarah Onwudinjo     | The Chosen Ones   | Houston - Braeswood AG      | 305   | 33.89  |    |
+| 18 | Bronte Mora         | Gushers           | Chapel Springs Church       | 300   | 33.33  | 1  |
+| 19 | Samuel Tran         | Gushers           | Chapel Springs Church       | 290   | 32.22  | 1  |
+| 20 | Austin Chmiel       | The J.A.M.        | Brightmoor Christian Church | 275   | 30.56  | 1  |
+| 21 | Daniel Ejim         | The Chosen Ones   | Houston - Braeswood AG      | 245   | 27.22  |    |
+| 22 | Andrea Bosteder     | River of Life     | River of Life Fellowship    | 240   | 26.67  |    |
+| 23 | Olivia Lee          | Quizzing Quartet  | Versailles King\'s Way AG   | 230   | 25.56  | 1  |
+| 24 | Wesley Self         | Quizzing Quartet  | Versailles King\'s Way AG   | 220   | 24.44  | 1  |
+| 25 | Nigus Dawit         | WoL Swordbearers  | Word of Life                | 175   | 19.44  |    |
+| 26 | Daniel Solomon      | WoL Swordbearers  | Word of Life                | 165   | 18.33  | 1  |
+| 27 | Michael Ukonu       | The Chosen Ones   | Houston - Braeswood AG      | 165   | 18.33  |    |
+| 28 | Sedenia Dawit       | WoL Swordbearers  | Word of Life                | 140   | 15.56  |    |
+| 29 | Emmanuel Umoekpo    | The Chosen Ones   | Houston - Braeswood AG      | 130   | 14.44  |    |
+| 30 | Jonathon Bonzelaar  | The J.A.M.        | Brightmoor Christian Church | 125   | 13.89  |    |
+| 31 | David Ubak          | The Chosen Ones   | Houston - Braeswood AG      | 105   | 11.67  |    |
+| 32 | Cavan McIntyre      | The J.A.M.        | Brightmoor Christian Church | 95    | 10.56  |    |
+| 33 | Brandon Ukonu       | The Chosen Ones   | Houston - Braeswood AG      | 80    | 8.89   |    |
+| 34 | Sebastian Steinbach | Gushers           | Chapel Springs Church       | 70    | 7.78   |    |
+| 34 | Cora Self           | Quizzing Quartet  | Versailles King\'s Way AG   | 70    | 7.78   |    |
+| 35 | Chloe Mora          | Gushers           | Chapel Springs Church       | 60    | 6.67   |    |
+| 35 | John Hull           | Gushers           | Chapel Springs Church       | 60    | 6.67   |    |
+| 36 | Carys Mora          | Gushers           | Chapel Springs Church       | 20    | 2.22   |    |
+| 36 | Elyssa Fulfer       | Tribulation Force | The Oaks Fellowship         | 20    | 2.22   |    |
+| 37 | Michelle Aum        | Naperville        | Calvary Church - C          | 10    | 1.11   |    |
+| 38 | Caleb Sessoms       | River of Life     | River of Life Fellowship    | 5     | .56    |    |
+| 39 | Stephen Bough       | Naperville        | Calvary Church - C          |       | .00    |    |
+| 39 | Hana Tariku         | WoL Swordbearers  | Word of Life                |       | .00    |    |
+| 39 | Eden Stokes         | The J.A.M.        | Brightmoor Christian Church |       | .00    |    |
+| 39 | Garrett Richardson  | Gushers           | Chapel Springs Church       |       | .00    |    |
+| 39 | Ian Rehmel          | Quizzing Quartet  | Versailles King\'s Way AG   |       | .00    |    |
+| 40 | Blake Chmiel        | The J.A.M.        | Brightmoor Christian Church | -5    | -0.56  |    |
+| 40 | Zach Sessoms        | River of Life     | River of Life Fellowship    | -5    | -0.56  |    |
+| 40 | Hailey Chmiel       | The J.A.M.        | Brightmoor Christian Church | -5    | -0.56  |    |
+| 40 | Aniyah Stokes       | The J.A.M.        | Brightmoor Christian Church | -5    | -0.56  |    |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                     | Church                        | W/L | Total | Avg    |
+|---:|--------------------------|-------------------------------|-----|------:|-------:|
+| 1  | ACTSelerators            | Fort Wayne 1st AG             | 7/2 | 1725  | 191.67 |
+| 2  | Transformed              | Garland-First@Firewheel       | 6/3 | 1570  | 174.44 |
+| 3  | Jedis for Jesus          | River Valley Church           | 5/4 | 1305  | 145.00 |
+| 4  | Carmel Apples            | Carmel AG                     | 5/4 | 1275  | 141.67 |
+| 5  | Fire Bible Investigators | Tucson Victory Worship Center | 5/4 | 1255  | 139.44 |
+| 6  | Life Church BRATS        | Life Church AG Church         | 5/4 | 1235  | 137.22 |
+| 7  | Quizzer Connection       | Lubbock 1st AG                | 4/5 | 1180  | 131.11 |
+| 8  | Armor Up                 | Oswego AG                     | 3/6 | 980   | 108.89 |
+| 9  | Kingsport Kidz           | Kingsport 1st AG              | 3/6 | 1095  | 121.67 |
+| 10 | The Purple Prophetesses  | Lindale Church                | 2/7 | 965   | 107.22 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                     | Church                        | Total | Avg    | QO |
+|---:|---------------------|--------------------------|-------------------------------|------:|-------:|---:|
+| 1  | Zane Brown          | Transformed              | Garland-First@Firewheel       | 1110  | 123.33 | 7  |
+| 2  | Vinicius Lupas      | ACTSelerators            | Fort Wayne 1st AG             | 855   | 95.00  | 5  |
+| 3  | Ethan Small         | Life Church BRATS        | Life Church AG Church         | 660   | 73.33  | 1  |
+| 4  | Micah Maynard       | Kingsport Kidz           | Kingsport 1st AG              | 650   | 72.22  | 2  |
+| 5  | Abbi Good           | Life Church BRATS        | Life Church AG Church         | 525   | 58.33  | 6  |
+| 6  | Alex Koch           | Jedis for Jesus          | River Valley Church           | 525   | 58.33  | 2  |
+| 7  | Tate Putman         | Jedis for Jesus          | River Valley Church           | 455   | 50.56  |    |
+| 8  | Kelton Johnson      | Quizzer Connection       | Lubbock 1st AG                | 440   | 48.89  |    |
+| 9  | Sydney Cummins      | The Purple Prophetesses  | Lindale Church                | 405   | 45.00  |    |
+| 10 | Angel McNeil        | Quizzer Connection       | Lubbock 1st AG                | 395   | 43.89  | 3  |
+| 11 | Isaac Wolf          | ACTSelerators            | Fort Wayne 1st AG             | 380   | 42.22  |    |
+| 12 | Kayden Vasquez      | The Purple Prophetesses  | Lindale Church                | 370   | 41.11  | 2  |
+| 13 | Brendon Johnson     | Quizzer Connection       | Lubbock 1st AG                | 345   | 38.33  |    |
+| 14 | Madeline Berkey     | Fire Bible Investigators | Tucson Victory Worship Center | 325   | 36.11  |    |
+| 15 | Shobby Enakpene     | Fire Bible Investigators | Tucson Victory Worship Center | 315   | 35.00  | 1  |
+| 16 | Good News Iwuamadi  | Transformed              | Garland-First@Firewheel       | 310   | 34.44  | 2  |
+| 17 | Cecillia Newby      | Armor Up                 | Oswego AG                     | 310   | 34.44  | 1  |
+| 18 | Marjorie Ehrman     | ACTSelerators            | Fort Wayne 1st AG             | 265   | 29.44  | 2  |
+| 19 | Amelia Gephart      | Fire Bible Investigators | Tucson Victory Worship Center | 265   | 29.44  |    |
+| 20 | Maison Ealum        | Carmel Apples            | Carmel AG                     | 260   | 28.89  | 2  |
+| 20 | Carmen Eisenbrandt  | Armor Up                 | Oswego AG                     | 260   | 28.89  | 2  |
+| 21 | Cecilia Eisenbrandt | Armor Up                 | Oswego AG                     | 250   | 27.78  |    |
+| 22 | Bradley Beall       | Carmel Apples            | Carmel AG                     | 245   | 27.22  | 2  |
+| 23 | Benjamin Lupus      | ACTSelerators            | Fort Wayne 1st AG             | 225   | 25.00  | 1  |
+| 24 | Morgan Zepp         | Carmel Apples            | Carmel AG                     | 220   | 24.44  |    |
+| 25 | KaAnna Salyer       | Kingsport Kidz           | Kingsport 1st AG              | 205   | 22.78  | 1  |
+| 26 | Dakota Caldwell     | Kingsport Kidz           | Kingsport 1st AG              | 200   | 22.22  | 1  |
+| 27 | Kara Justice        | Carmel Apples            | Carmel AG                     | 200   | 22.22  |    |
+| 28 | David Warren        | Carmel Apples            | Carmel AG                     | 190   | 21.11  |    |
+| 29 | Hannah Royer        | Fire Bible Investigators | Tucson Victory Worship Center | 185   | 20.56  | 2  |
+| 30 | Abigail Chapa       | The Purple Prophetesses  | Lindale Church                | 170   | 18.89  |    |
+| 31 | Delaney Reynolds    | Armor Up                 | Oswego AG                     | 160   | 17.78  |    |
+| 31 | Faith Dillon        | Carmel Apples            | Carmel AG                     | 160   | 17.78  |    |
+| 32 | Cade Romine         | Jedis for Jesus          | River Valley Church           | 145   | 16.11  |    |
+| 33 | Michelle Lobato     | Fire Bible Investigators | Tucson Victory Worship Center | 100   | 11.11  |    |
+| 33 | Nathan Koch         | Jedis for Jesus          | River Valley Church           | 100   | 11.11  |    |
+| 33 | Faithful Iwuamadi   | Transformed              | Garland-First@Firewheel       | 100   | 11.11  |    |
+| 34 | Lindsey Schmidt     | Jedis for Jesus          | River Valley Church           | 80    | 8.89   |    |
+| 35 | Omosiuwa Enakpene   | Fire Bible Investigators | Tucson Victory Worship Center | 70    | 7.78   |    |
+| 36 | Amarachi Ayozie     | Transformed              | Garland-First@Firewheel       | 40    | 4.44   |    |
+| 37 | Jillian Kennard     | Kingsport Kidz           | Kingsport 1st AG              | 30    | 3.33   |    |
+| 38 | Jadon Lantz         | Life Church BRATS        | Life Church AG Church         | 25    | 2.78   |    |
+| 39 | London Cummins      | The Purple Prophetesses  | Lindale Church                | 20    | 2.22   |    |
+| 40 | Morgan Gibson       | Kingsport Kidz           | Kingsport 1st AG              | 15    | 1.67   |    |
+| 40 | Noah Small          | Life Church BRATS        | Life Church AG Church         | 15    | 1.67   |    |
+| 41 | Malinda White       | Life Church BRATS        | Life Church AG Church         | 10    | 1.11   |    |
+| 41 | Chi Chi Otah        | Transformed              | Garland-First@Firewheel       | 10    | 1.11   |    |
+| 42 | Grace Noel          | Armor Up                 | Oswego AG                     |       | .00    |    |
+| 42 | Michael Ikechukwu   | Transformed              | Garland-First@Firewheel       |       | .00    |    |
+| 42 | Raqeem Graves       | Kingsport Kidz           | Kingsport 1st AG              |       | .00    |    |
+| 42 | Vanessa Gomez       | Fire Bible Investigators | Tucson Victory Worship Center |       | .00    |    |
+| 42 | Kylee White         | Life Church BRATS        | Life Church AG Church         |       | .00    |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                      | Church                    | W/L | Total | Avg    |
+|---:|---------------------------|---------------------------|-----|------:|-------:|
+| 1  | Cedar Park                | Cedar Park                | 6/3 | 1485  | 165.00 |
+| 2  | 360 Quizzers              | Life360 Church            | 5/4 | 1370  | 152.22 |
+| 3  | Lawson Son Worshippers #1 | Lawson AG                 | 5/4 | 1320  | 146.67 |
+| 4  | Quiz Commanders           | Proventus Academy         | 5/4 | 1265  | 140.56 |
+| 5  | God Squad                 | International AG Mesa Az  | 5/4 | 1250  | 138.89 |
+| 6  | Wilmington warriors       | Church on the cape        | 5/4 | 1205  | 133.89 |
+| 7  | Naperville                | Calvary Church - S        | 4/5 | 1240  | 137.78 |
+| 8  | Lawson Son Worshippers #2 | Lawson AG                 | 4/5 | 1175  | 130.56 |
+| 9  | Team A                    | Portland Christian Center | 4/5 | 1115  | 123.89 |
+| 10 | Agents of Knowledge       | Baxter Heritage AG        | 2/7 | 1080  | 120.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                      | Church                    | Total | Avg   | QO |
+|---:|------------------------|---------------------------|---------------------------|------:|------:|---:|
+| 1  | Trinity Garza          | Quiz Commanders           | Proventus Academy         | 895   | 99.44 | 4  |
+| 2  | Alex Jarrell           | Cedar Park                | Cedar Park                | 875   | 97.22 | 6  |
+| 2  | Breanna Cole           | Lawson Son Worshippers #1 | Lawson AG                 | 875   | 97.22 | 6  |
+| 3  | Jonathan Archer        | Lawson Son Worshippers #2 | Lawson AG                 | 800   | 88.89 | 3  |
+| 4  | Shawn Timothy          | Naperville                | Calvary Church - S        | 610   | 67.78 | 6  |
+| 5  | Cameron Ramsey         | 360 Quizzers              | Life360 Church            | 600   | 66.67 | 3  |
+| 6  | Jackson Loschko        | Agents of Knowledge       | Baxter Heritage AG        | 560   | 62.22 | 6  |
+| 7  | Ari Lauthner           | Team A                    | Portland Christian Center | 555   | 61.67 | 1  |
+| 8  | Harrison Stevens       | Naperville                | Calvary Church - S        | 535   | 59.44 | 1  |
+| 9  | AC Borowicz            | Agents of Knowledge       | Baxter Heritage AG        | 520   | 57.78 | 3  |
+| 10 | Gavin Kuruvilla        | God Squad                 | International AG Mesa Az  | 500   | 55.56 |    |
+| 11 | Jomi Malayil           | God Squad                 | International AG Mesa Az  | 470   | 52.22 |    |
+| 12 | Zachary Leake          | Wilmington warriors       | Church on the cape        | 450   | 50.00 |    |
+| 13 | Joanne Sinniah         | 360 Quizzers              | Life360 Church            | 435   | 48.33 |    |
+| 14 | Christian Shelton      | Wilmington warriors       | Church on the cape        | 370   | 41.11 | 1  |
+| 15 | Nick Cook              | Lawson Son Worshippers #2 | Lawson AG                 | 310   | 34.44 | 2  |
+| 16 | Laken Manns            | Lawson Son Worshippers #1 | Lawson AG                 | 310   | 34.44 | 1  |
+| 17 | Emiliano Duran         | Team A                    | Portland Christian Center | 305   | 33.89 | 2  |
+| 18 | Carter Garza           | Quiz Commanders           | Proventus Academy         | 270   | 30.00 |    |
+| 19 | Kierstin Child\'s      | Wilmington warriors       | Church on the cape        | 245   | 27.22 | 1  |
+| 20 | Austin Ramsey          | 360 Quizzers              | Life360 Church            | 225   | 25.00 | 1  |
+| 21 | Christiaan West        | Cedar Park                | Cedar Park                | 210   | 23.33 | 1  |
+| 22 | Cecily Houser          | Cedar Park                | Cedar Park                | 200   | 22.22 |    |
+| 22 | Sarah Mathew           | God Squad                 | International AG Mesa Az  | 200   | 22.22 |    |
+| 22 | Grace Waggoner         | Cedar Park                | Cedar Park                | 200   | 22.22 |    |
+| 23 | Katya Brodsky          | Team A                    | Portland Christian Center | 145   | 16.11 | 1  |
+| 24 | Broxton Cole           | Lawson Son Worshippers #1 | Lawson AG                 | 135   | 15.00 |    |
+| 25 | Ethan Phillips         | Team A                    | Portland Christian Center | 110   | 12.22 |    |
+| 25 | Caleb Black            | 360 Quizzers              | Life360 Church            | 110   | 12.22 |    |
+| 25 | Brock boehling         | Wilmington warriors       | Church on the cape        | 110   | 12.22 |    |
+| 26 | Blake Garza            | Quiz Commanders           | Proventus Academy         | 100   | 11.11 |    |
+| 27 | Reagan Stevens         | Naperville                | Calvary Church - S        | 70    | 7.78  |    |
+| 28 | Seth Archer            | Lawson Son Worshippers #2 | Lawson AG                 | 65    | 7.22  |    |
+| 29 | Joshua Malayil         | God Squad                 | International AG Mesa Az  | 50    | 5.56  |    |
+| 30 | Jeremy Varghese        | God Squad                 | International AG Mesa Az  | 30    | 3.33  |    |
+| 30 | Luke Shelton           | Wilmington warriors       | Church on the cape        | 30    | 3.33  |    |
+| 31 | McKinley Stevens       | Naperville                | Calvary Church - S        | 25    | 2.78  |    |
+| 32 | Abrianna Hoyle- Harris | Wilmington warriors       | Church on the cape        |       | .00   |    |
+| 32 | Heather Thompson       | Wilmington warriors       | Church on the cape        |       | .00   |    |
+| 32 | Corrie Lee Boehling    | Wilmington warriors       | Church on the cape        |       | .00   |    |
+| 32 | Catie Wolfe            | 360 Quizzers              | Life360 Church            |       | .00   |    |
+| 32 | Kaitlyn Ramsey         | 360 Quizzers              | Life360 Church            |       | .00   |    |
+| 32 | Mckenna Black          | 360 Quizzers              | Life360 Church            |       | .00   |    |
+
+
+### Silver
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                 | Church                     | W/L | Total | Avg    |
+|---:|----------------------|----------------------------|-----|------:|-------:|
+| 1  | Powdered Donuts      | Central AG                 | 8/1 | 1730  | 192.22 |
+| 2  | CRK Almighty         | Church of the Risen King   | 7/2 | 1505  | 167.22 |
+| 3  | Kung Fu Quizzers     | Benton 1st AG              | 7/2 | 1585  | 176.11 |
+| 4  | Askewville           | Bethel AG - Askewville, NC | 6/3 | 1485  | 165.00 |
+| 5  | One 8                | 1st AG                     | 4/5 | 1010  | 112.22 |
+| 6  | Bismarck Blitz       | Evangel AG                 | 4/5 | 1275  | 141.67 |
+| 7  | CIA - Special Agents | Bethany Community Church   | 3/6 | 1275  | 141.67 |
+| 8  | Brickmasters         | Racine AG                  | 3/6 | 985   | 109.44 |
+| 9  | Eagles               | North Little Rock 1st AG   | 2/7 | 895   | 99.44  |
+| 10 | Seekers of Truth     | Charleston 1st AG          | 1/8 | 1045  | 116.11 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                 | Church                     | Total | Avg    | QO |
+|---:|--------------------|----------------------|----------------------------|------:|-------:|---:|
+| 1  | Landon Clark       | Powdered Donuts      | Central AG                 | 1140  | 126.67 | 6  |
+| 2  | Bobbie Jean Barnes | Kung Fu Quizzers     | Benton 1st AG              | 930   | 103.33 | 5  |
+| 3  | Faith Caughey      | CIA - Special Agents | Bethany Community Church   | 750   | 83.33  | 1  |
+| 4  | Jacob Flores       | CRK Almighty         | Church of the Risen King   | 730   | 81.11  | 4  |
+| 5  | Micah Hill         | Askewville           | Bethel AG - Askewville, NC | 710   | 78.89  | 1  |
+| 6  | David Shepard      | Seekers of Truth     | Charleston 1st AG          | 700   | 77.78  | 3  |
+| 7  | Kaylee Freyer      | Bismarck Blitz       | Evangel AG                 | 570   | 63.33  | 2  |
+| 8  | Connor Jackson     | Brickmasters         | Racine AG                  | 570   | 63.33  |    |
+| 9  | Eric Bender        | Bismarck Blitz       | Evangel AG                 | 505   | 56.11  | 7  |
+| 10 | Jared Watson       | Kung Fu Quizzers     | Benton 1st AG              | 465   | 51.67  | 5  |
+| 11 | Aedan Moore        | Eagles               | North Little Rock 1st AG   | 405   | 45.00  |    |
+| 12 | Hannah Jones       | Powdered Donuts      | Central AG                 | 380   | 42.22  | 3  |
+| 13 | Hezekiah Reynes    | CRK Almighty         | Church of the Risen King   | 375   | 41.67  | 4  |
+| 14 | Bethany Escobar    | CRK Almighty         | Church of the Risen King   | 365   | 40.56  |    |
+| 15 | Payton Astorga     | One 8                | 1st AG                     | 345   | 38.33  |    |
+| 16 | David Pesce        | Askewville           | Bethel AG - Askewville, NC | 340   | 37.78  |    |
+| 17 | Michelle Vannelli  | CIA - Special Agents | Bethany Community Church   | 330   | 36.67  |    |
+| 18 | Eliana Bazemore    | Askewville           | Bethel AG - Askewville, NC | 325   | 36.11  | 3  |
+| 19 | Izlia Shepard      | Seekers of Truth     | Charleston 1st AG          | 315   | 35.00  | 2  |
+| 20 | Kevin Sowers       | One 8                | 1st AG                     | 250   | 27.78  | 2  |
+| 21 | Alexis Sharps      | Eagles               | North Little Rock 1st AG   | 240   | 26.67  | 1  |
+| 22 | Ariana Klein       | Brickmasters         | Racine AG                  | 205   | 22.78  |    |
+| 23 | Ryan Astorga       | One 8                | 1st AG                     | 200   | 22.22  | 1  |
+| 24 | Nathan Bender      | Bismarck Blitz       | Evangel AG                 | 200   | 22.22  |    |
+| 25 | Elizabeth Jones    | Powdered Donuts      | Central AG                 | 190   | 21.11  |    |
+| 26 | Hannah Hall        | Eagles               | North Little Rock 1st AG   | 165   | 18.33  |    |
+| 27 | Emily Greenwell    | Kung Fu Quizzers     | Benton 1st AG              | 120   | 13.33  |    |
+| 28 | Sam David          | Brickmasters         | Racine AG                  | 110   | 12.22  | 1  |
+| 29 | Haven Hoggard      | Askewville           | Bethel AG - Askewville, NC | 110   | 12.22  |    |
+| 30 | Skylar Sides       | One 8                | 1st AG                     | 105   | 11.67  |    |
+| 31 | Sieanna Sowers     | One 8                | 1st AG                     | 90    | 10.00  |    |
+| 32 | Morgan Liles       | Eagles               | North Little Rock 1st AG   | 70    | 7.78   |    |
+| 32 | Elizabeth Fugere   | CIA - Special Agents | Bethany Community Church   | 70    | 7.78   |    |
+| 33 | Riley Longacre     | CIA - Special Agents | Bethany Community Church   | 65    | 7.22   |    |
+| 34 | John Hamel         | CIA - Special Agents | Bethany Community Church   | 60    | 6.67   |    |
+| 34 | Ryan Smithkey      | Brickmasters         | Racine AG                  | 60    | 6.67   |    |
+| 35 | Alexis Rowland     | Kung Fu Quizzers     | Benton 1st AG              | 50    | 5.56   |    |
+| 36 | Josiah Hopple      | Seekers of Truth     | Charleston 1st AG          | 40    | 4.44   |    |
+| 36 | Ethan Walker       | Brickmasters         | Racine AG                  | 40    | 4.44   |    |
+| 37 | Cameron Ramos      | CRK Almighty         | Church of the Risen King   | 35    | 3.89   |    |
+| 38 | Lilly Powell       | One 8                | 1st AG                     | 20    | 2.22   |    |
+| 38 | Brittyn Glover     | Kung Fu Quizzers     | Benton 1st AG              | 20    | 2.22   |    |
+| 38 | Luke Nash          | Eagles               | North Little Rock 1st AG   | 20    | 2.22   |    |
+| 39 | Elli Woodward      | Powdered Donuts      | Central AG                 | 15    | 1.67   |    |
+| 40 | Abby Jones         | Powdered Donuts      | Central AG                 | 10    | 1.11   |    |
+| 41 | Austin Green       | Kung Fu Quizzers     | Benton 1st AG              |       | .00    |    |
+| 41 | Chloe Clemons      | Eagles               | North Little Rock 1st AG   |       | .00    |    |
+| 41 | Andrew Dippel      | Eagles               | North Little Rock 1st AG   |       | .00    |    |
+| 41 | Elijah Escobar     | CRK Almighty         | Church of the Risen King   |       | .00    |    |
+| 41 | Katie O\'Connor    | Seekers of Truth     | Charleston 1st AG          |       | .00    |    |
+| 41 | Peyton Shuffitt    | One 8                | 1st AG                     |       | .00    |    |
+| 41 | Daniel Sils        | Seekers of Truth     | Charleston 1st AG          |       | .00    |    |
+| 41 | Austin Shuffitt    | One 8                | 1st AG                     |       | .00    |    |
+| 41 | Calista Gotos      | CRK Almighty         | Church of the Risen King   |       | .00    |    |
+| 41 | Madison Rutherford | Seekers of Truth     | Charleston 1st AG          |       | .00    |    |
+| 42 | Savannah Stricklin | Eagles               | North Little Rock 1st AG   | -5    | -0.56  |    |
+| 42 | Jackson Woodward   | Powdered Donuts      | Central AG                 | -5    | -0.56  |    |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                 | Church                          | W/L | Total | Avg    |
+|---:|----------------------|---------------------------------|-----|------:|-------:|
+| 1  | Bible Avengers       | Mechanicsville Christian Center | 7/2 | 1420  | 157.78 |
+| 2  | Bible Minions        | Mechanicsville Christian Center | 6/3 | 1430  | 158.89 |
+| 3  | Boyz of the Word     | New Albany, One Church          | 5/4 | 1435  | 159.44 |
+| 4  | Celebration Quizzers | Celebration Church              | 5/4 | 1320  | 146.67 |
+| 5  | Funky Town Monkeys   | Life AG                         | 5/4 | 1225  | 136.11 |
+| 6  | HeRose               | Rogers 1st AG                   | 4/5 | 1265  | 140.56 |
+| 7  | West Ridge Warriors  | West Ridge Church               | 4/5 | 1005  | 111.67 |
+| 8  | Kinston Tanglewood   | Kinston Tanglewood              | 3/6 | 1205  | 133.89 |
+| 9  | Bethlehem Church     | Bethlehem Church                | 3/6 | 1170  | 130.00 |
+| 10 | JAG                  | Jefferson AG                    | 3/6 | 990   | 110.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                 | Church                          | Total | Avg    | QO |
+|---:|----------------------|----------------------|---------------------------------|------:|-------:|---:|
+| 1  | Josiah Mair          | Boyz of the Word     | New Albany, One Church          | 1065  | 118.33 | 6  |
+| 2  | Madison Steele       | Bible Minions        | Mechanicsville Christian Center | 770   | 85.56  | 5  |
+| 3  | Brock Eder           | Celebration Quizzers | Celebration Church              | 755   | 83.89  | 4  |
+| 4  | Maelee Becton        | Kinston Tanglewood   | Kinston Tanglewood              | 675   | 75.00  | 2  |
+| 5  | Angelia Whitfield    | Bible Avengers       | Mechanicsville Christian Center | 655   | 72.78  | 3  |
+| 6  | Sydney Shockley      | HeRose               | Rogers 1st AG                   | 530   | 58.89  | 1  |
+| 7  | Ethan Lancelot       | HeRose               | Rogers 1st AG                   | 530   | 58.89  |    |
+| 8  | Justice Schwickerath | Bible Avengers       | Mechanicsville Christian Center | 465   | 51.67  | 2  |
+| 9  | Josh Broxterman      | JAG                  | Jefferson AG                    | 420   | 46.67  | 1  |
+| 10 | Emma Hoffmann        | Funky Town Monkeys   | Life AG                         | 380   | 42.22  |    |
+| 10 | Simeon McCune        | West Ridge Warriors  | West Ridge Church               | 380   | 42.22  |    |
+| 11 | Madisen McCune       | West Ridge Warriors  | West Ridge Church               | 330   | 36.67  | 1  |
+| 12 | Casey Powell         | Kinston Tanglewood   | Kinston Tanglewood              | 320   | 35.56  | 1  |
+| 13 | Sean Wallis          | Celebration Quizzers | Celebration Church              | 315   | 35.00  | 2  |
+| 14 | Godson Massene       | Bethlehem Church     | Bethlehem Church                | 295   | 32.78  | 2  |
+| 15 | Braden Adams         | Bible Minions        | Mechanicsville Christian Center | 290   | 32.22  | 1  |
+| 16 | Zach Rothwell        | Funky Town Monkeys   | Life AG                         | 285   | 31.67  |    |
+| 17 | Tom Hoffmann         | Funky Town Monkeys   | Life AG                         | 265   | 29.44  | 2  |
+| 18 | Kyler Kaniper        | JAG                  | Jefferson AG                    | 265   | 29.44  |    |
+| 19 | Chloe Smith          | West Ridge Warriors  | West Ridge Church               | 260   | 28.89  | 1  |
+| 20 | Ashley Okafor        | Bethlehem Church     | Bethlehem Church                | 250   | 27.78  |    |
+| 21 | Will Rittenhouse     | Bible Minions        | Mechanicsville Christian Center | 220   | 24.44  |    |
+| 22 | Morgan Peltz         | Funky Town Monkeys   | Life AG                         | 210   | 23.33  |    |
+| 23 | Samuel Mair          | Boyz of the Word     | New Albany, One Church          | 205   | 22.78  |    |
+| 24 | Daynah Dyal          | Bethlehem Church     | Bethlehem Church                | 200   | 22.22  |    |
+| 25 | Abeni Feurbacher     | JAG                  | Jefferson AG                    | 195   | 21.67  | 2  |
+| 26 | Brianna Boodram      | Bethlehem Church     | Bethlehem Church                | 190   | 21.11  |    |
+| 27 | Jayne Weber          | Bible Avengers       | Mechanicsville Christian Center | 170   | 18.89  |    |
+| 27 | Elylah Stager        | Celebration Quizzers | Celebration Church              | 170   | 18.89  |    |
+| 28 | Noah Zananiri        | Boyz of the Word     | New Albany, One Church          | 165   | 18.33  | 1  |
+| 29 | Justin Arocho        | Bethlehem Church     | Bethlehem Church                | 145   | 16.11  | 1  |
+| 30 | Angel Walker         | Bible Avengers       | Mechanicsville Christian Center | 135   | 15.00  |    |
+| 30 | Kennedy Santes       | Kinston Tanglewood   | Kinston Tanglewood              | 135   | 15.00  |    |
+| 31 | Tinley Boysen        | HeRose               | Rogers 1st AG                   | 120   | 13.33  |    |
+| 32 | Seth Christopher     | Bible Minions        | Mechanicsville Christian Center | 110   | 12.22  |    |
+| 33 | Joseph Subrath       | Bethlehem Church     | Bethlehem Church                | 90    | 10.00  |    |
+| 33 | Matthias Moore       | JAG                  | Jefferson AG                    | 90    | 10.00  |    |
+| 34 | Chloe Eder           | Celebration Quizzers | Celebration Church              | 80    | 8.89   |    |
+| 35 | Karen Geddie         | Kinston Tanglewood   | Kinston Tanglewood              | 75    | 8.33   |    |
+| 36 | Noah Rothwell        | Funky Town Monkeys   | Life AG                         | 65    | 7.22   |    |
+| 36 | Rebecca Longtin      | HeRose               | Rogers 1st AG                   | 65    | 7.22   |    |
+| 37 | Britt Adams          | Bible Minions        | Mechanicsville Christian Center | 40    | 4.44   |    |
+| 38 | Avryl Weiland        | West Ridge Warriors  | West Ridge Church               | 35    | 3.89   |    |
+| 39 | Morgan Giese         | HeRose               | Rogers 1st AG                   | 20    | 2.22   |    |
+| 39 | Megan Bartlett       | Funky Town Monkeys   | Life AG                         | 20    | 2.22   |    |
+| 39 | Sam Broxterman       | JAG                  | Jefferson AG                    | 20    | 2.22   |    |
+| 40 | Isaac Myhal          | Boyz of the Word     | New Albany, One Church          |       | .00    |    |
+| 40 | Kamryn Kaniper       | JAG                  | Jefferson AG                    |       | .00    |    |
+| 40 | Michael Alexander    | Bethlehem Church     | Bethlehem Church                |       | .00    |    |
+| 40 | Sofia Marks          | Celebration Quizzers | Celebration Church              |       | .00    |    |
+| 40 | Riley Marks          | Celebration Quizzers | Celebration Church              |       | .00    |    |
+| 41 | Honey Schwickerath   | Bible Avengers       | Mechanicsville Christian Center | -5    | -0.56  |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                               | Church                                     | W/L | Total | Avg    |
+|---:|------------------------------------|--------------------------------------------|-----|------:|-------:|
+| 1  | Collierville Freedom Fighters      | Collierville 1st AG                        | 8/1 | 1580  | 175.56 |
+| 2  | Noble Christians In Service (NCIS) | Glad Tidings Church - Hanford, CA          | 7/2 | 1440  | 160.00 |
+| 3  | Crazy Conquerors 4 Christ          | Victory International Fellowship           | 6/3 | 1455  | 161.67 |
+| 4  | UFC- United For Christ             | The Bridge                                 | 5/4 | 1600  | 177.78 |
+| 5  | #hashtag                           | LifeChurch AG                              | 4/5 | 1295  | 143.89 |
+| 6  | NHF Super Quizzers                 | New Hope Fellowship                        | 4/5 | 1210  | 134.44 |
+| 7  | OCCEC                              | Orange County Christian Evangelical Church | 4/5 | 1155  | 128.33 |
+| 8  | Victory Warriors                   | Universal City - Victory AG                | 3/6 | 1230  | 136.67 |
+| 9  | Righteous Refusers                 | Walnut Grove                               | 2/7 | 1020  | 113.33 |
+| 10 | COTN                               | Church of the Nations                      | 2/7 | 1160  | 128.89 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                   | Team                               | Church                                     | Total | Avg    | QO |
+|---:|---------------------------|------------------------------------|--------------------------------------------|------:|-------:|---:|
+| 1  | Samy Paul                 | Collierville Freedom Fighters      | Collierville 1st AG                        | 1145  | 127.22 | 7  |
+| 2  | Nathan Mills              | Victory Warriors                   | Universal City - Victory AG                | 955   | 106.11 | 4  |
+| 3  | Kevin Ju                  | OCCEC                              | Orange County Christian Evangelical Church | 890   | 98.89  | 3  |
+| 4  | Miles Kastner             | Crazy Conquerors 4 Christ          | Victory International Fellowship           | 885   | 98.33  | 4  |
+| 5  | Mark Grogan               | NHF Super Quizzers                 | New Hope Fellowship                        | 775   | 86.11  | 5  |
+| 6  | Aryana Campbell           | UFC- United For Christ             | The Bridge                                 | 770   | 85.56  | 1  |
+| 7  | Tabitha Joanna Nirmal     | Noble Christians In Service (NCIS) | Glad Tidings Church - Hanford, CA          | 700   | 77.78  | 6  |
+| 8  | Ezekiel (Zeke) Loper      | COTN                               | Church of the Nations                      | 650   | 72.22  | 3  |
+| 9  | Hayden Alford             | Noble Christians In Service (NCIS) | Glad Tidings Church - Hanford, CA          | 590   | 65.56  |    |
+| 10 | Katelyn Hall              | #hashtag                           | LifeChurch AG                              | 535   | 59.44  | 2  |
+| 11 | Joey Paul                 | Collierville Freedom Fighters      | Collierville 1st AG                        | 420   | 46.67  | 2  |
+| 12 | Landon Grisham            | UFC- United For Christ             | The Bridge                                 | 415   | 46.11  | 4  |
+| 13 | Wesley Horn               | UFC- United For Christ             | The Bridge                                 | 415   | 46.11  |    |
+| 14 | Isaac Ubert               | Crazy Conquerors 4 Christ          | Victory International Fellowship           | 410   | 45.56  | 4  |
+| 15 | Jordan Nix                | #hashtag                           | LifeChurch AG                              | 385   | 42.78  |    |
+| 16 | Dallas Pitman             | #hashtag                           | LifeChurch AG                              | 375   | 41.67  | 4  |
+| 17 | Dominique Siegler         | NHF Super Quizzers                 | New Hope Fellowship                        | 360   | 40.00  | 4  |
+| 18 | Kendra Winkleblech        | Righteous Refusers                 | Walnut Grove                               | 285   | 31.67  |    |
+| 19 | Kathryn Ouyang            | COTN                               | Church of the Nations                      | 280   | 31.11  |    |
+| 20 | Reagan McCreary           | Righteous Refusers                 | Walnut Grove                               | 270   | 30.00  | 2  |
+| 21 | Raymond Harris            | Righteous Refusers                 | Walnut Grove                               | 245   | 27.22  | 2  |
+| 22 | Tyler Chang               | OCCEC                              | Orange County Christian Evangelical Church | 220   | 24.44  | 1  |
+| 23 | Aiden McCreary            | Righteous Refusers                 | Walnut Grove                               | 220   | 24.44  |    |
+| 24 | Adam Shuman               | COTN                               | Church of the Nations                      | 210   | 23.33  |    |
+| 25 | Skylar Fleming            | Victory Warriors                   | Universal City - Victory AG                | 135   | 15.00  |    |
+| 26 | Gabrielle (Gabby) Mendoza | Noble Christians In Service (NCIS) | Glad Tidings Church - Hanford, CA          | 105   | 11.67  |    |
+| 27 | Samuel Dimmock            | Crazy Conquerors 4 Christ          | Victory International Fellowship           | 100   | 11.11  |    |
+| 28 | Faith Horne               | Victory Warriors                   | Universal City - Victory AG                | 80    | 8.89   |    |
+| 28 | Joy Fambrough             | NHF Super Quizzers                 | New Hope Fellowship                        | 80    | 8.89   |    |
+| 29 | Elizabeth Murray          | Crazy Conquerors 4 Christ          | Victory International Fellowship           | 60    | 6.67   |    |
+| 29 | Bailen Goodwin            | Victory Warriors                   | Universal City - Victory AG                | 60    | 6.67   |    |
+| 30 | Michele Zheng             | OCCEC                              | Orange County Christian Evangelical Church | 45    | 5.00   |    |
+| 30 | Addison (Addy) McCullough | Noble Christians In Service (NCIS) | Glad Tidings Church - Hanford, CA          | 45    | 5.00   |    |
+| 31 | Linden Bowden             | COTN                               | Church of the Nations                      | 20    | 2.22   |    |
+| 32 | Josiah Murphy             | Collierville Freedom Fighters      | Collierville 1st AG                        | 15    | 1.67   |    |
+| 33 | John Adams                | Righteous Refusers                 | Walnut Grove                               |       | .00    |    |
+| 34 | Chloe Mitchell            | NHF Super Quizzers                 | New Hope Fellowship                        | -5    | -0.56  |    |
+

--- a/_pages/jbq/2015/index.md
+++ b/_pages/jbq/2015/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2015 JBQ Season"
+permalink: /jbq/2015/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+<a href="{% link _pages/jbq/2015/nationals.md %}" class="button is-primary">National Finals</a>
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2015/nationals.md
+++ b/_pages/jbq/2015/nationals.md
@@ -1,0 +1,1131 @@
+---
+layout: page
+title: "2015 National Festival: Naperville, IL"
+permalink: /jbq/2015/nationals/
+date: "2017-05-17"
+toc_title: Results
+menubar_toc: true
+---
+
+## Friday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                          | Church                | W/L  | Total | Avg    |
+|---:|-------------------------------|-----------------------|------|------:|-------:|
+| 1  | Sanford-FL                    | God\'s Incredibles    | 13/2 | 3155  | 210.33 |
+| 2  | San Jose-CA                   | Souled Out            | 12/3 | 2545  | 169.67 |
+| 3  | Mechanicsville-VA - Obedience | Contagious Obedience  | 10/5 | 2595  | 173.00 |
+| 4  | New Albany-OH                 | Fluffy Panda Quizzers | 10/5 | 2250  | 150.00 |
+| 5  | Tallahassee-FL                | More than Conquerers  | 9/6  | 2510  | 167.33 |
+| 6  | Warren-MI                     | IAG Eagles            | 9/6  | 2290  | 152.67 |
+| 7  | Red Oak-TX                    | Tribulation Force     | 9/6  | 2215  | 147.67 |
+| 8  | Bothell-WA                    | Cedar Park Eagles     | 8/7  | 2440  | 162.67 |
+| 9  | Shakopee-MN                   | Minds of the Bible    | 7/8  | 2045  | 136.33 |
+| 10 | Omaha-NE                      | Agents of the Shield  | 6/9  | 2140  | 142.67 |
+| 11 | Meriden-KS                    | JAG Jaguars           | 6/9  | 1995  | 133.00 |
+| 12 | Gloucester City-NJ            | CRK Almighty          | 6/9  | 1910  | 127.33 |
+| 13 | Benton-AR                     | Kung Fu Quizzers      | 5/10 | 1925  | 128.33 |
+| 14 | Springfield -MO - Dau         | Daughters of the King | 4/11 | 1985  | 132.33 |
+| 15 | Montgomery-AL                 | Montgomery 1st        | 4/11 | 1555  | 103.67 |
+| 16 | Mendon-MA                     | CIA Special Agents    | 2/13 | 1290  | 86.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                          | Church                | Total | Avg    | QO |
+|---:|-------------------|-------------------------------|-----------------------|------:|-------:|---:|
+| 1  | Toby Robinson     | Sanford-FL                    | God\'s Incredibles    | 2000  | 133.33 | 12 |
+| 2  | Samuel Jebaraj    | San Jose-CA                   | Souled Out            | 1770  | 118.00 | 11 |
+| 3  | Josiah Mair       | New Albany-OH                 | Fluffy Panda Quizzers | 1590  | 106.00 | 9  |
+| 4  | Ethan Stewart     | Tallahassee-FL                | More than Conquerers  | 1450  | 96.67  | 7  |
+| 5  | Alex Jarrell      | Bothell-WA                    | Cedar Park Eagles     | 1440  | 96.00  | 9  |
+| 6  | Madison Steele    | Mechanicsville-VA - Obedience | Contagious Obedience  | 1395  | 93.00  | 9  |
+| 7  | Pete Mathew       | Warren-MI                     | IAG Eagles            | 1355  | 90.33  | 6  |
+| 8  | Bobbie Barnes     | Benton-AR                     | Kung Fu Quizzers      | 1265  | 84.33  | 2  |
+| 9  | Elizabeth Jones   | Springfield -MO - Dau         | Daughters of the King | 1095  | 73.00  | 3  |
+| 10 | Josh Broxterman   | Meriden-KS                    | JAG Jaguars           | 1070  | 71.33  | 2  |
+| 11 | Jordan Perez      | Sanford-FL                    | God\'s Incredibles    | 810   | 54.00  | 3  |
+| 12 | Preston Hoggard   | Red Oak-TX                    | Tribulation Force     | 790   | 52.67  | 11 |
+| 13 | Christiaan West   | Bothell-WA                    | Cedar Park Eagles     | 735   | 49.00  | 5  |
+| 14 | Elyssa Fulfer     | Red Oak-TX                    | Tribulation Force     | 730   | 48.67  |    |
+| 15 | Janelle Angeles   | Gloucester City-NJ            | CRK Almighty          | 715   | 47.67  |    |
+| 16 | Tate Putman       | Shakopee-MN                   | Minds of the Bible    | 700   | 46.67  | 1  |
+| 17 | Victor Fonov      | Red Oak-TX                    | Tribulation Force     | 695   | 46.33  | 1  |
+| 18 | Kevin Sowers      | Montgomery-AL                 | Montgomery 1st        | 670   | 44.67  | 1  |
+| 19 | Lademi Davies     | Omaha-NE                      | Agents of the Shield  | 665   | 44.33  |    |
+| 20 | Braden Adams      | Mechanicsville-VA - Obedience | Contagious Obedience  | 640   | 42.67  | 2  |
+| 21 | Samuel Borja      | Gloucester City-NJ            | CRK Almighty          | 605   | 40.33  |    |
+| 22 | Collin Nester     | Tallahassee-FL                | More than Conquerers  | 600   | 40.00  | 2  |
+| 23 | Gabby Pahl        | Shakopee-MN                   | Minds of the Bible    | 570   | 38.00  | 1  |
+| 24 | Will Addler       | Shakopee-MN                   | Minds of the Bible    | 560   | 37.33  | 5  |
+| 25 | Cameron Ramos     | Gloucester City-NJ            | CRK Almighty          | 555   | 37.00  | 5  |
+| 26 | Shekinah Phelps   | Springfield -MO - Dau         | Daughters of the King | 545   | 36.33  | 5  |
+| 27 | John Hamel        | Mendon-MA                     | CIA Special Agents    | 500   | 33.33  | 3  |
+| 27 | Aaron Martin      | Omaha-NE                      | Agents of the Shield  | 500   | 33.33  | 3  |
+| 28 | Iakona Fern       | Omaha-NE                      | Agents of the Shield  | 450   | 30.00  |    |
+| 29 | Will Rittenhouse  | Mechanicsville-VA - Obedience | Contagious Obedience  | 445   | 29.67  | 3  |
+| 30 | Bittyn Glover     | Benton-AR                     | Kung Fu Quizzers      | 435   | 29.00  | 2  |
+| 31 | Michelle Vannelli | Mendon-MA                     | CIA Special Agents    | 420   | 28.00  |    |
+| 32 | Matthias Moore    | Meriden-KS                    | JAG Jaguars           | 410   | 27.33  |    |
+| 33 | Ryan Astorga      | Montgomery-AL                 | Montgomery 1st        | 405   | 27.00  | 1  |
+| 34 | Sieanna Sowers    | Montgomery-AL                 | Montgomery 1st        | 385   | 25.67  |    |
+| 35 | Aaron Bumbaca     | San Jose-CA                   | Souled Out            | 380   | 25.33  | 1  |
+| 36 | Charlotte Elliott | Omaha-NE                      | Agents of the Shield  | 380   | 25.33  |    |
+| 37 | Wesley Thomas     | Sanford-FL                    | God\'s Incredibles    | 345   | 23.00  | 1  |
+| 38 | Jasmine Sirvent   | San Jose-CA                   | Souled Out            | 325   | 21.67  |    |
+| 39 | Joshua Kuruvilla  | Warren-MI                     | IAG Eagles            | 310   | 20.67  |    |
+| 40 | Noah Zananiri     | New Albany-OH                 | Fluffy Panda Quizzers | 300   | 20.00  | 2  |
+| 41 | Elijah Stewart    | Tallahassee-FL                | More than Conquerers  | 290   | 19.33  | 2  |
+| 42 | Reuben Abraham    | Warren-MI                     | IAG Eagles            | 280   | 18.67  |    |
+| 43 | Gracie Frank      | Bothell-WA                    | Cedar Park Eagles     | 265   | 17.67  | 1  |
+| 44 | Krister George    | Warren-MI                     | IAG Eagles            | 265   | 17.67  |    |
+| 45 | Sam Broxterman    | Meriden-KS                    | JAG Jaguars           | 260   | 17.33  |    |
+| 46 | Hannah Plake      | Springfield -MO - Dau         | Daughters of the King | 255   | 17.00  |    |
+| 46 | Kamryn Kaniper    | Meriden-KS                    | JAG Jaguars           | 255   | 17.00  |    |
+| 47 | Abel Karthik      | New Albany-OH                 | Fluffy Panda Quizzers | 235   | 15.67  |    |
+| 48 | Kimbre Earnest    | Benton-AR                     | Kung Fu Quizzers      | 195   | 13.00  | 1  |
+| 49 | Emma Stewart      | Tallahassee-FL                | More than Conquerers  | 170   | 11.33  |    |
+| 50 | Melany Ravitz     | Mendon-MA                     | CIA Special Agents    | 165   | 11.00  |    |
+| 51 | Hannah Massard    | Shakopee-MN                   | Minds of the Bible    | 150   | 10.00  |    |
+| 52 | Josie Dague       | Omaha-NE                      | Agents of the Shield  | 145   | 9.67   |    |
+| 53 | Samuel Mair       | New Albany-OH                 | Fluffy Panda Quizzers | 125   | 8.33   |    |
+| 54 | Riley Longacre    | Mendon-MA                     | CIA Special Agents    | 110   | 7.33   |    |
+| 55 | Hayden Monti      | Mendon-MA                     | CIA Special Agents    | 95    | 6.33   |    |
+| 56 | Brooks Adams      | Mechanicsville-VA - Obedience | Contagious Obedience  | 90    | 6.00   |    |
+| 56 | Skylor Astorga    | Montgomery-AL                 | Montgomery 1st        | 90    | 6.00   |    |
+| 57 | Abigail Jones     | Springfield -MO - Dau         | Daughters of the King | 85    | 5.67   |    |
+| 58 | Rachel Nadia      | Warren-MI                     | IAG Eagles            | 80    | 5.33   |    |
+| 59 | Alyssa Bumbaca    | San Jose-CA                   | Souled Out            | 70    | 4.67   |    |
+| 60 | Lauren Pahl       | Shakopee-MN                   | Minds of the Bible    | 65    | 4.33   |    |
+| 61 | Jeweleann Davis   | Benton-AR                     | Kung Fu Quizzers      | 30    | 2.00   |    |
+| 61 | Elijah Escobar    | Gloucester City-NJ            | CRK Almighty          | 30    | 2.00   |    |
+| 62 | Christian Steele  | Mechanicsville-VA - Obedience | Contagious Obedience  | 25    | 1.67   |    |
+| 63 | Trinity Phelps    | Springfield -MO - Dau         | Daughters of the King | 5     | .33    |    |
+| 63 | Calista Gotos     | Gloucester City-NJ            | CRK Almighty          | 5     | .33    |    |
+| 63 | Peyton Shuffitt   | Montgomery-AL                 | Montgomery 1st        | 5     | .33    |    |
+| 64 | Hope Alford       | Tallahassee-FL                | More than Conquerers  |       | .00    |    |
+| 64 | Aidan Fulfer      | Red Oak-TX                    | Tribulation Force     |       | .00    |    |
+| 64 | Tyler Kelly       | Benton-AR                     | Kung Fu Quizzers      |       | .00    |    |
+| 64 | Alyssa Jenks      | Sanford-FL                    | God\'s Incredibles    |       | .00    |    |
+| 64 | Chalice sanders   | Benton-AR                     | Kung Fu Quizzers      |       | .00    |    |
+| 64 | Lauren Green      | Benton-AR                     | Kung Fu Quizzers      |       | .00    |    |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                     | Church                         | W/L  | Total | Avg    |
+|---:|--------------------------|--------------------------------|------|------:|-------:|
+| 1  | Bellevue-WA              | Neighborhood Church            | 12/3 | 2720  | 181.33 |
+| 2  | East Lansing-MI          | Greater Lansing                | 12/3 | 2380  | 158.67 |
+| 3  | Naperville-IL - S        | Naperville S                   | 11/4 | 2730  | 182.00 |
+| 4  | St. Cloud-MN             | Gods Lighthouse                | 11/4 | 2420  | 161.33 |
+| 5  | Wilmington-NC - Red      | Wilmington Warriors Red Swords | 9/6  | 2145  | 143.00 |
+| 6  | Bowling Green-OH         | Team Olaf                      | 9/6  | 2590  | 172.67 |
+| 7  | Midland-GA               | Hard Core Quizzers             | 8/7  | 2065  | 137.67 |
+| 8  | Springfield-MO           | QuizMasters                    | 7/8  | 2310  | 154.00 |
+| 9  | Tucson-AZ                | Girls of Christ                | 7/8  | 2005  | 133.67 |
+| 10 | Monmouth Junction-NJ     | Knights 4 Christ               | 6/9  | 2135  | 142.33 |
+| 11 | Garland-TX               | Transformed                    | 6/9  | 2105  | 140.33 |
+| 12 | Overland Park-KS         | Coca-Cola Quizzers             | 6/9  | 1865  | 124.33 |
+| 13 | Bismarck-ND              | Power Up                       | 6/9  | 1810  | 120.67 |
+| 14 | West Mifflin-PA          | Light Knights                  | 5/10 | 1605  | 107.00 |
+| 15 | Mechanicsville-VA - Hope | Contagious Hope                | 5/10 | 1945  | 129.67 |
+| 16 | Shreveport-LA            | Shreveport Bible Investigators | 0/15 | 735   | 49.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                     | Church                         | Total | Avg    | QO |
+|---:|----------------------|--------------------------|--------------------------------|------:|-------:|---:|
+| 1  | Ty Silas             | Naperville-IL - S        | Naperville S                   | 1745  | 116.33 | 11 |
+| 2  | Darcie Harr          | East Lansing-MI          | Greater Lansing                | 1435  | 95.67  | 9  |
+| 3  | Samuel Clinston      | Bellevue-WA              | Neighborhood Church            | 1415  | 94.33  | 5  |
+| 4  | Cameron Ramsey       | Springfield-MO           | QuizMasters                    | 1390  | 92.67  | 6  |
+| 5  | Samuel Broeker       | Overland Park-KS         | Coca-Cola Quizzers             | 1345  | 89.67  | 5  |
+| 6  | Zane Brown           | Garland-TX               | Transformed                    | 1325  | 88.33  | 4  |
+| 7  | Angelia Whitfield    | Mechanicsville-VA - Hope | Contagious Hope                | 1160  | 77.33  | 4  |
+| 8  | Megan Bartlett       | St. Cloud-MN             | Gods Lighthouse                | 1150  | 76.67  | 3  |
+| 9  | Christopher Johnson  | Midland-GA               | Hard Core Quizzers             | 1075  | 71.67  | 3  |
+| 10 | Zachary leake        | Wilmington-NC - Red      | Wilmington Warriors Red Swords | 1000  | 66.67  | 1  |
+| 11 | Remiel Brigilin      | Monmouth Junction-NJ     | Knights 4 Christ               | 975   | 65.00  | 2  |
+| 12 | Hannah Facer         | Bowling Green-OH         | Team Olaf                      | 890   | 59.33  | 2  |
+| 13 | Zachariah Rothwell   | St. Cloud-MN             | Gods Lighthouse                | 820   | 54.67  | 1  |
+| 14 | Madeline Berkey      | Tucson-AZ                | Girls of Christ                | 780   | 52.00  | 1  |
+| 15 | Julia Correa         | Bellevue-WA              | Neighborhood Church            | 770   | 51.33  | 8  |
+| 16 | Abigail Slembarski   | Bowling Green-OH         | Team Olaf                      | 750   | 50.00  | 1  |
+| 17 | Justiss Silas        | Naperville-IL - S        | Naperville S                   | 745   | 49.67  | 8  |
+| 18 | Ethan Sipes          | Bismarck-ND              | Power Up                       | 655   | 43.67  |    |
+| 19 | Nathaniel Jebaraj    | Monmouth Junction-NJ     | Knights 4 Christ               | 595   | 39.67  |    |
+| 20 | Joshua Senthil       | Monmouth Junction-NJ     | Knights 4 Christ               | 565   | 37.67  | 3  |
+| 21 | Noah Smith           | Bowling Green-OH         | Team Olaf                      | 560   | 37.33  | 5  |
+| 22 | Eric Bender          | Bismarck-ND              | Power Up                       | 555   | 37.00  | 1  |
+| 23 | Kaitlyn Ramsey       | Springfield-MO           | QuizMasters                    | 545   | 36.33  | 5  |
+| 24 | Amelia Gephart       | Tucson-AZ                | Girls of Christ                | 545   | 36.33  |    |
+| 25 | Madeline Lickey      | Bellevue-WA              | Neighborhood Church            | 540   | 36.00  |    |
+| 26 | Truett Van Slyke     | Overland Park-KS         | Coca-Cola Quizzers             | 520   | 34.67  | 5  |
+| 27 | Christian Shelton    | Wilmington-NC - Red      | Wilmington Warriors Red Swords | 520   | 34.67  | 1  |
+| 28 | Isaac Erickson       | Shreveport-LA            | Shreveport Bible Investigators | 520   | 34.67  |    |
+| 29 | Michael Holland      | Midland-GA               | Hard Core Quizzers             | 510   | 34.00  | 3  |
+| 30 | Jackson Convis       | East Lansing-MI          | Greater Lansing                | 500   | 33.33  | 3  |
+| 31 | Kendra Winkleblech   | West Mifflin-PA          | Light Knights                  | 495   | 33.00  |    |
+| 32 | Good News Iwuamadi   | Garland-TX               | Transformed                    | 480   | 32.00  | 3  |
+| 33 | Raymond Harris       | West Mifflin-PA          | Light Knights                  | 475   | 31.67  | 1  |
+| 34 | Olivia Neerudu       | Bowling Green-OH         | Team Olaf                      | 390   | 26.00  |    |
+| 35 | Kierstin childs      | Wilmington-NC - Red      | Wilmington Warriors Red Swords | 375   | 25.00  | 1  |
+| 36 | Zachary Dennis       | Midland-GA               | Hard Core Quizzers             | 360   | 24.00  |    |
+| 36 | Ezekiel Bohlen       | Bismarck-ND              | Power Up                       | 360   | 24.00  |    |
+| 37 | Michelle Lobato      | Tucson-AZ                | Girls of Christ                | 355   | 23.67  |    |
+| 38 | Hannah Royer         | Tucson-AZ                | Girls of Christ                | 330   | 22.00  |    |
+| 39 | Anthony Raygoza      | West Mifflin-PA          | Light Knights                  | 325   | 21.67  | 2  |
+| 40 | Adrianna Raygoza     | West Mifflin-PA          | Light Knights                  | 310   | 20.67  |    |
+| 41 | Caleb Roos           | St. Cloud-MN             | Gods Lighthouse                | 290   | 19.33  | 1  |
+| 42 | Britt Adams          | Mechanicsville-VA - Hope | Contagious Hope                | 285   | 19.00  | 2  |
+| 43 | Seth Christopher     | Mechanicsville-VA - Hope | Contagious Hope                | 275   | 18.33  | 1  |
+| 44 | Britta Andrews       | East Lansing-MI          | Greater Lansing                | 270   | 18.00  |    |
+| 45 | Elijah Bohlen        | Bismarck-ND              | Power Up                       | 245   | 16.33  |    |
+| 46 | Gannon Breig         | Springfield-MO           | QuizMasters                    | 215   | 14.33  |    |
+| 47 | Braden Tew           | Shreveport-LA            | Shreveport Bible Investigators | 200   | 13.33  |    |
+| 48 | Chi Chi Otah         | Garland-TX               | Transformed                    | 170   | 11.33  |    |
+| 49 | Samuel March         | St. Cloud-MN             | Gods Lighthouse                | 160   | 10.67  |    |
+| 50 | Catie Wolfe          | Springfield-MO           | QuizMasters                    | 150   | 10.00  |    |
+| 51 | Anna scott witzenman | Wilmington-NC - Red      | Wilmington Warriors Red Swords | 145   | 9.67   |    |
+| 52 | Angel Walker         | Mechanicsville-VA - Hope | Contagious Hope                | 140   | 9.33   |    |
+| 53 | David Biruduganti    | Naperville-IL - S        | Naperville S                   | 130   | 8.67   |    |
+| 53 | Amarachi Ayozie      | Garland-TX               | Transformed                    | 130   | 8.67   |    |
+| 54 | Onome Oghor          | East Lansing-MI          | Greater Lansing                | 115   | 7.67   |    |
+| 55 | McKinley Stevens     | Naperville-IL - S        | Naperville S                   | 110   | 7.33   |    |
+| 56 | Kora Beth witzenman  | Wilmington-NC - Red      | Wilmington Warriors Red Swords | 105   | 7.00   |    |
+| 57 | Marcus Mesis         | Midland-GA               | Hard Core Quizzers             | 90    | 6.00   |    |
+| 58 | Savannah Harper      | Mechanicsville-VA - Hope | Contagious Hope                | 85    | 5.67   | 1  |
+| 59 | Cierra Convis        | East Lansing-MI          | Greater Lansing                | 60    | 4.00   |    |
+| 60 | Ethan Herrera        | Midland-GA               | Hard Core Quizzers             | 30    | 2.00   |    |
+| 60 | Ethan Paredes        | Shreveport-LA            | Shreveport Bible Investigators | 30    | 2.00   |    |
+| 61 | Riley Breig          | Springfield-MO           | QuizMasters                    | 10    | .67    |    |
+| 62 | Caroline Tew         | Shreveport-LA            | Shreveport Bible Investigators |       | .00    |    |
+| 62 | Nathaniel Joseph     | Midland-GA               | Hard Core Quizzers             |       | .00    |    |
+| 62 | Isabelle Erickson    | Shreveport-LA            | Shreveport Bible Investigators |       | .00    |    |
+| 62 | Zechariah Broeker    | Overland Park-KS         | Coca-Cola Quizzers             |       | .00    |    |
+| 62 | James Ragains        | Bismarck-ND              | Power Up                       |       | .00    |    |
+| 62 | Josh Moore           | West Mifflin-PA          | Light Knights                  |       | .00    |    |
+| 62 | Josiah Broeker       | Overland Park-KS         | Coca-Cola Quizzers             |       | .00    |    |
+| 62 | McKenna Black        | Springfield-MO           | QuizMasters                    |       | .00    |    |
+| 63 | John Cooley          | Tucson-AZ                | Girls of Christ                | -5    | -0.33  |    |
+| 63 | Arielle Erickson     | Shreveport-LA            | Shreveport Bible Investigators | -5    | -0.33  |    |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                 | Church                           | W/L  | Total | Avg    |
+|---:|----------------------|----------------------------------|------|------:|-------:|
+| 1  | Akron-OH             | Celebration Quizzers             | 13/2 | 2950  | 196.67 |
+| 2  | Naperville-IL - D    | Naperville D                     | 12/3 | 2690  | 179.33 |
+| 3  | Cedar Hill-TX        | Triple Threat                    | 11/4 | 2870  | 191.33 |
+| 4  | Havre-MT             | Havre Assembly Rebels            | 11/4 | 2725  | 181.67 |
+| 5  | Rochester-MN         | Unstoppable                      | 10/5 | 2635  | 175.67 |
+| 6  | Phoenix-AZ           | Phoenix First Bible Warriors     | 9/6  | 2435  | 162.33 |
+| 7  | Ozark-MO             | Voices of Victory                | 8/7  | 2590  | 172.67 |
+| 8  | Jacksonville-AR      | Ablaze                           | 7/8  | 2385  | 159.00 |
+| 9  | Swedesboro-NJ        | Resurrection Sunday              | 7/8  | 2225  | 148.33 |
+| 10 | Leesburg-VA          | S.P.Y. Dudes                     | 7/8  | 2215  | 147.67 |
+| 11 | Sparta-WI            | Sparta                           | 6/9  | 1570  | 104.67 |
+| 12 | Griffin-GA           | Griffin First Gospel Gang        | 6/9  | 2030  | 135.33 |
+| 13 | Wilmingon-NC - White | Wilmington Warriors White Swords | 5/10 | 2100  | 140.00 |
+| 14 | Irvine-CA            | OCCEC Eagles                     | 4/11 | 1845  | 123.00 |
+| 15 | Dumas-TX             | Undignified                      | 4/11 | 1655  | 110.33 |
+| 16 | Rapid City-SD        | Sanctified Sisters               | 0/15 | 935   | 62.33  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                 | Church                           | Total | Avg    | QO |
+|---:|----------------------|----------------------|----------------------------------|------:|-------:|---:|
+| 1  | Alaynee Hawley       | Havre-MT             | Havre Assembly Rebels            | 1940  | 129.33 | 12 |
+| 2  | Brock Eder           | Akron-OH             | Celebration Quizzers             | 1865  | 124.33 | 12 |
+| 3  | Shawn Timothy        | Naperville-IL - D    | Naperville D                     | 1580  | 105.33 | 9  |
+| 4  | Josh Barajas         | Cedar Hill-TX        | Triple Threat                    | 1280  | 85.33  | 5  |
+| 5  | Brock Boehling       | Wilmingon-NC - White | Wilmington Warriors White Swords | 1265  | 84.33  | 4  |
+| 6  | Cole Muscari         | Phoenix-AZ           | Phoenix First Bible Warriors     | 1245  | 83.00  | 8  |
+| 7  | Rayanne Danso        | Rochester-MN         | Unstoppable                      | 1200  | 80.00  | 3  |
+| 8  | Mercy Germany        | Ozark-MO             | Voices of Victory                | 1185  | 79.00  | 7  |
+| 9  | Annie Akins          | Dumas-TX             | Undignified                      | 1140  | 76.00  | 4  |
+| 10 | Emma Miller          | Cedar Hill-TX        | Triple Threat                    | 1135  | 75.67  | 3  |
+| 11 | Cole Abbott          | Sparta-WI            | Sparta                           | 1115  | 74.33  | 6  |
+| 12 | Lyric Coker          | Griffin-GA           | Griffin First Gospel Gang        | 1045  | 69.67  | 3  |
+| 13 | Truman Griessel      | Ozark-MO             | Voices of Victory                | 990   | 66.00  | 6  |
+| 14 | Seth Swain           | Jacksonville-AR      | Ablaze                           | 990   | 66.00  | 1  |
+| 15 | Jason Li             | Irvine-CA            | OCCEC Eagles                     | 915   | 61.00  | 7  |
+| 16 | Toby Hill            | Swedesboro-NJ        | Resurrection Sunday              | 900   | 60.00  | 4  |
+| 17 | Ethan Gates          | Rochester-MN         | Unstoppable                      | 765   | 51.00  | 9  |
+| 17 | Nicola Betz          | Naperville-IL - D    | Naperville D                     | 765   | 51.00  | 9  |
+| 18 | Andrew Judd          | Leesburg-VA          | S.P.Y. Dudes                     | 720   | 48.00  | 6  |
+| 19 | McKenna Cape         | Rochester-MN         | Unstoppable                      | 670   | 44.67  |    |
+| 19 | Micah DeSanto        | Swedesboro-NJ        | Resurrection Sunday              | 670   | 44.67  |    |
+| 20 | Chloe Eder           | Akron-OH             | Celebration Quizzers             | 655   | 43.67  | 4  |
+| 21 | Caleb Whitener       | Jacksonville-AR      | Ablaze                           | 625   | 41.67  |    |
+| 22 | Ashton Johnson       | Jacksonville-AR      | Ablaze                           | 620   | 41.33  | 8  |
+| 23 | Tyler Trexler        | Phoenix-AZ           | Phoenix First Bible Warriors     | 615   | 41.00  | 5  |
+| 24 | Phillip Bozzay       | Leesburg-VA          | S.P.Y. Dudes                     | 600   | 40.00  |    |
+| 25 | Kristin Schmidt      | Phoenix-AZ           | Phoenix First Bible Warriors     | 575   | 38.33  |    |
+| 26 | M\'Kayla McDaniel    | Dumas-TX             | Undignified                      | 515   | 34.33  | 3  |
+| 27 | Casey McDermitt      | Griffin-GA           | Griffin First Gospel Gang        | 490   | 32.67  |    |
+| 28 | Patrick Norris       | Swedesboro-NJ        | Resurrection Sunday              | 485   | 32.33  | 5  |
+| 29 | Annabel Tiong        | Irvine-CA            | OCCEC Eagles                     | 485   | 32.33  |    |
+| 29 | Samuel Otchere       | Leesburg-VA          | S.P.Y. Dudes                     | 485   | 32.33  |    |
+| 30 | Jude Calvery         | Cedar Hill-TX        | Triple Threat                    | 455   | 30.33  | 3  |
+| 31 | Jocelyn Coker        | Griffin-GA           | Griffin First Gospel Gang        | 450   | 30.00  | 1  |
+| 32 | Cate Wilhelm         | Rapid City-SD        | Sanctified Sisters               | 440   | 29.33  |    |
+| 33 | Alaura Hawley        | Havre-MT             | Havre Assembly Rebels            | 410   | 27.33  |    |
+| 33 | Joshua Daniel        | Leesburg-VA          | S.P.Y. Dudes                     | 410   | 27.33  |    |
+| 34 | Corrie Lee Boehlinig | Wilmingon-NC - White | Wilmington Warriors White Swords | 395   | 26.33  | 2  |
+| 35 | Elylah Stager        | Akron-OH             | Celebration Quizzers             | 370   | 24.67  |    |
+| 36 | Gracee Langstaff     | Rapid City-SD        | Sanctified Sisters               | 345   | 23.00  |    |
+| 37 | Bryce Helgerson      | Sparta-WI            | Sparta                           | 315   | 21.00  | 1  |
+| 38 | Adalina Ma           | Irvine-CA            | OCCEC Eagles                     | 315   | 21.00  |    |
+| 39 | Isabell McClanahan   | Ozark-MO             | Voices of Victory                | 260   | 17.33  |    |
+| 39 | Breydon Hawley       | Havre-MT             | Havre Assembly Rebels            | 260   | 17.33  |    |
+| 40 | Stephen Bough        | Naperville-IL - D    | Naperville D                     | 205   | 13.67  |    |
+| 41 | Luke Shelton         | Wilmingon-NC - White | Wilmington Warriors White Swords | 200   | 13.33  | 1  |
+| 42 | Nathaniel Dowdy      | Swedesboro-NJ        | Resurrection Sunday              | 145   | 9.67   |    |
+| 43 | Rachel McDonald      | Wilmingon-NC - White | Wilmington Warriors White Swords | 140   | 9.33   |    |
+| 43 | Samuel Biruduganti   | Naperville-IL - D    | Naperville D                     | 140   | 9.33   |    |
+| 44 | Michele Zheng        | Irvine-CA            | OCCEC Eagles                     | 135   | 9.00   |    |
+| 45 | Adam Murdock         | Jacksonville-AR      | Ablaze                           | 130   | 8.67   |    |
+| 45 | Chuck Myers          | Ozark-MO             | Voices of Victory                | 130   | 8.67   |    |
+| 46 | Corbin Frydenlund    | Sparta-WI            | Sparta                           | 125   | 8.33   |    |
+| 47 | Josiah Boe           | Havre-MT             | Havre Assembly Rebels            | 115   | 7.67   |    |
+| 48 | Justice Glassgow     | Rapid City-SD        | Sanctified Sisters               | 100   | 6.67   |    |
+| 49 | Luke Ertzberger      | Wilmingon-NC - White | Wilmington Warriors White Swords | 90    | 6.00   |    |
+| 50 | Anna Ligtenberg      | Rapid City-SD        | Sanctified Sisters               | 50    | 3.33   |    |
+| 51 | Sofia Marks          | Akron-OH             | Celebration Quizzers             | 40    | 2.67   |    |
+| 52 | Sofie McClanahan     | Ozark-MO             | Voices of Victory                | 30    | 2.00   |    |
+| 52 | Madelyn Grant        | Griffin-GA           | Griffin First Gospel Gang        | 30    | 2.00   |    |
+| 53 | Riley Marks          | Akron-OH             | Celebration Quizzers             | 20    | 1.33   |    |
+| 53 | Angel Johnson        | Jacksonville-AR      | Ablaze                           | 20    | 1.33   |    |
+| 54 | Jiana Speir          | Griffin-GA           | Griffin First Gospel Gang        | 15    | 1.00   |    |
+| 54 | Samantha Rowe        | Sparta-WI            | Sparta                           | 15    | 1.00   |    |
+| 54 | Joel Samuel          | Swedesboro-NJ        | Resurrection Sunday              | 15    | 1.00   |    |
+| 55 | Carly McDonald       | Wilmingon-NC - White | Wilmington Warriors White Swords | 10    | .67    |    |
+| 55 | Jessica Samuel       | Swedesboro-NJ        | Resurrection Sunday              | 10    | .67    |    |
+| 56 | Jayda Butts          | Rapid City-SD        | Sanctified Sisters               |       | .00    |    |
+| 56 | Gracelyn Daniel      | Leesburg-VA          | S.P.Y. Dudes                     |       | .00    |    |
+| 56 | Jacob Burke          | Sparta-WI            | Sparta                           |       | .00    |    |
+| 56 | Mariela Trujiillo    | Leesburg-VA          | S.P.Y. Dudes                     |       | .00    |    |
+| 56 | Leah Hodge           | Leesburg-VA          | S.P.Y. Dudes                     |       | .00    |    |
+| 56 | Sean Wallis          | Akron-OH             | Celebration Quizzers             |       | .00    |    |
+| 56 | Hannah Judd          | Leesburg-VA          | S.P.Y. Dudes                     |       | .00    |    |
+| 57 | Noelle Germany       | Ozark-MO             | Voices of Victory                | -5    | -0.33  |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team               | Church                        | W/L  | Total | Avg    |
+|---:|--------------------|-------------------------------|------|------:|-------:|
+| 1  | Houston-TX         | The Chosen Ones               | 12/3 | 2810  | 187.33 |
+| 2  | Naperville-IL - M  | Naperville M                  | 12/3 | 2500  | 166.67 |
+| 3  | Lawson-MO - Connie | Lawson Connie                 | 11/4 | 2350  | 156.67 |
+| 4  | Hamburg-PA         | Lightning Hawks               | 11/4 | 2410  | 160.67 |
+| 5  | Greensboro-NC      | Biblecraft                    | 10/5 | 2565  | 171.00 |
+| 6  | Billings-MT        | Billings New Life             | 9/6  | 2490  | 166.00 |
+| 7  | Chandler-AZ        | Christ Ambassadors            | 8/7  | 2425  | 161.67 |
+| 8  | Rockwall-TX        | Wind of the Word              | 7/8  | 1925  | 128.33 |
+| 9  | Fortville-IN       | Wonderful Wizards of Words    | 7/8  | 2095  | 139.67 |
+| 10 | Rogers-AR          | He-Rose                       | 6/9  | 2135  | 142.33 |
+| 11 | Versailles-KY      | The J-Walkers                 | 6/9  | 2265  | 151.00 |
+| 12 | Collierville-TN    | Collierville Freedom Fighters | 5/10 | 2050  | 136.67 |
+| 13 | Suwanee-GA         | Proventus Academy             | 5/10 | 1785  | 119.00 |
+| 14 | Springfield-VA     | Swordbearers                  | 4/11 | 1930  | 128.67 |
+| 15 | Racine-WI          | Racine Deeper Kids            | 4/11 | 1855  | 123.67 |
+| 16 | Las Vegas-NV       | Champion Center               | 3/12 | 1430  | 95.33  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team               | Church                        | Total | Avg    | QO |
+|---:|-------------------|--------------------|-------------------------------|------:|-------:|---:|
+| 1  | Sheldon Powell    | Naperville-IL - M  | Naperville M                  | 1770  | 118.00 | 11 |
+| 2  | Samuel Paul       | Collierville-TN    | Collierville Freedom Fighters | 1565  | 104.33 | 4  |
+| 3  | Hans Holzhausen   | Fortville-IN       | Wonderful Wizards of Words    | 1530  | 102.00 | 6  |
+| 4  | Daniel Ejim       | Houston-TX         | The Chosen Ones               | 1480  | 98.67  | 7  |
+| 5  | Laken Manns       | Lawson-MO - Connie | Lawson Connie                 | 1465  | 97.67  | 9  |
+| 6  | Gavin Kuruvilla   | Chandler-AZ        | Christ Ambassadors            | 1460  | 97.33  | 4  |
+| 7  | Aidan Rajesh      | Greensboro-NC      | Biblecraft                    | 1325  | 88.33  | 5  |
+| 8  | Wesley Self       | Versailles-KY      | The J-Walkers                 | 1165  | 77.67  | 3  |
+| 9  | Trey Crowley      | Hamburg-PA         | Lightning Hawks               | 1070  | 71.33  | 3  |
+| 10 | Alex Koch         | Rockwall-TX        | Wind of the Word              | 1010  | 67.33  | 3  |
+| 11 | Micah Houde       | Billings-MT        | Billings New Life             | 1000  | 66.67  | 3  |
+| 12 | Blake Garza       | Suwanee-GA         | Proventus Academy             | 980   | 65.33  | 5  |
+| 13 | Ethan Lancelot    | Rogers-AR          | He-Rose                       | 970   | 64.67  | 1  |
+| 14 | Sydney Shockley   | Rogers-AR          | He-Rose                       | 895   | 59.67  | 5  |
+| 15 | Jayda Houde       | Billings-MT        | Billings New Life             | 895   | 59.67  | 1  |
+| 16 | Ariana Klein      | Racine-WI          | Racine Deeper Kids            | 880   | 58.67  | 1  |
+| 17 | Carter Garza      | Suwanee-GA         | Proventus Academy             | 805   | 53.67  | 3  |
+| 18 | Brandon Ukonu     | Houston-TX         | The Chosen Ones               | 785   | 52.33  | 9  |
+| 19 | Cora Self         | Versailles-KY      | The J-Walkers                 | 750   | 50.00  | 3  |
+| 20 | Levi Dawit        | Springfield-VA     | Swordbearers                  | 750   | 50.00  | 1  |
+| 21 | Aicha Fitzgerald  | Hamburg-PA         | Lightning Hawks               | 740   | 49.33  | 1  |
+| 22 | Lizzie Biek       | Las Vegas-NV       | Champion Center               | 705   | 47.00  |    |
+| 23 | Shaymis Powell    | Naperville-IL - M  | Naperville M                  | 665   | 44.33  | 6  |
+| 24 | Nick Cook         | Lawson-MO - Connie | Lawson Connie                 | 650   | 43.33  | 4  |
+| 25 | Sam David         | Racine-WI          | Racine Deeper Kids            | 610   | 40.67  | 1  |
+| 26 | Thomas Pospisil   | Hamburg-PA         | Lightning Hawks               | 600   | 40.00  | 5  |
+| 27 | Amelia Stieb      | Las Vegas-NV       | Champion Center               | 555   | 37.00  | 1  |
+| 28 | Trenton Morris    | Greensboro-NC      | Biblecraft                    | 535   | 35.67  | 4  |
+| 29 | Joanna Joseph     | Chandler-AZ        | Christ Ambassadors            | 510   | 34.00  | 1  |
+| 30 | Nathan Koch       | Rockwall-TX        | Wind of the Word              | 505   | 33.67  | 4  |
+| 31 | Bethel Dawit      | Springfield-VA     | Swordbearers                  | 495   | 33.00  | 1  |
+| 32 | Timothy Mathew    | Chandler-AZ        | Christ Ambassadors            | 455   | 30.33  | 2  |
+| 33 | Nathaniel Prejean | Greensboro-NC      | Biblecraft                    | 445   | 29.67  |    |
+| 34 | Delaney Jones     | Fortville-IN       | Wonderful Wizards of Words    | 425   | 28.33  | 3  |
+| 35 | Sedenia Dawit     | Springfield-VA     | Swordbearers                  | 425   | 28.33  |    |
+| 36 | Michael Ukonu     | Houston-TX         | The Chosen Ones               | 350   | 23.33  |    |
+| 37 | Olivia Lee        | Versailles-KY      | The J-Walkers                 | 300   | 20.00  | 1  |
+| 37 | Nevaeh Walker     | Billings-MT        | Billings New Life             | 300   | 20.00  | 1  |
+| 38 | Makenna Koch      | Rockwall-TX        | Wind of the Word              | 235   | 15.67  |    |
+| 38 | Taylen Manns      | Lawson-MO - Connie | Lawson Connie                 | 235   | 15.67  |    |
+| 39 | Joel Paul         | Collierville-TN    | Collierville Freedom Fighters | 225   | 15.00  | 1  |
+| 40 | Matthew Baloga    | Greensboro-NC      | Biblecraft                    | 220   | 14.67  | 1  |
+| 41 | Aaliyah Landers   | Billings-MT        | Billings New Life             | 210   | 14.00  |    |
+| 41 | Corban Stewart    | Collierville-TN    | Collierville Freedom Fighters | 210   | 14.00  |    |
+| 42 | Caitlyn Jackson   | Racine-WI          | Racine Deeper Kids            | 205   | 13.67  |    |
+| 43 | Sarah Onwudinjo   | Houston-TX         | The Chosen Ones               | 195   | 13.00  |    |
+| 44 | Christian Dawit   | Springfield-VA     | Swordbearers                  | 180   | 12.00  |    |
+| 45 | Becca Longtin     | Rogers-AR          | He-Rose                       | 175   | 11.67  | 1  |
+| 46 | Mckenna Walker    | Racine-WI          | Racine Deeper Kids            | 160   | 10.67  |    |
+| 47 | Talayeh Rush      | Las Vegas-NV       | Champion Center               | 145   | 9.67   |    |
+| 48 | Annie Keerns      | Fortville-IN       | Wonderful Wizards of Words    | 140   | 9.33   |    |
+| 49 | Andrew Lopez      | Rockwall-TX        | Wind of the Word              | 130   | 8.67   |    |
+| 50 | Hana Tariku       | Springfield-VA     | Swordbearers                  | 80    | 5.33   |    |
+| 51 | Rylin Taylor      | Billings-MT        | Billings New Life             | 75    | 5.00   |    |
+| 52 | Tinley Boysen     | Rogers-AR          | He-Rose                       | 55    | 3.67   |    |
+| 53 | Josiah Murphy     | Collierville-TN    | Collierville Freedom Fighters | 50    | 3.33   |    |
+| 53 | Eliana Lee        | Versailles-KY      | The J-Walkers                 | 50    | 3.33   |    |
+| 54 | Braden Pugh       | Rockwall-TX        | Wind of the Word              | 45    | 3.00   |    |
+| 55 | Savannah Robinson | Greensboro-NC      | Biblecraft                    | 40    | 2.67   |    |
+| 55 | Shaylee Powell    | Naperville-IL - M  | Naperville M                  | 40    | 2.67   |    |
+| 55 | Morgan Giese      | Rogers-AR          | He-Rose                       | 40    | 2.67   |    |
+| 56 | Jed Koss          | Naperville-IL - M  | Naperville M                  | 30    | 2.00   |    |
+| 57 | Elijah Hicks      | Las Vegas-NV       | Champion Center               | 25    | 1.67   |    |
+| 58 | Brooke Bentz      | Billings-MT        | Billings New Life             | 10    | .67    |    |
+| 59 | Tru Young         | Las Vegas-NV       | Champion Center               | 5     | .33    |    |
+| 60 | Adalia Abinteh    | Collierville-TN    | Collierville Freedom Fighters |       | .00    |    |
+| 60 | Darla Holzhausen  | Fortville-IN       | Wonderful Wizards of Words    |       | .00    |    |
+| 60 | Travis Leavitt    | Las Vegas-NV       | Champion Center               |       | .00    |    |
+| 60 | Joshua Malayil    | Chandler-AZ        | Christ Ambassadors            |       | .00    |    |
+| 60 | Josiah Self       | Versailles-KY      | The J-Walkers                 |       | .00    |    |
+| 60 | Daniel Solomon    | Springfield-VA     | Swordbearers                  |       | .00    |    |
+| 60 | Solomon Kefyalew  | Springfield-VA     | Swordbearers                  |       | .00    |    |
+| 60 | Joshua Baloga     | Greensboro-NC      | Biblecraft                    |       | .00    |    |
+| 60 | Blen Hailu        | Springfield-VA     | Swordbearers                  |       | .00    |    |
+| 60 | Lily Robinson     | Billings-MT        | Billings New Life             |       | .00    |    |
+| 61 | Kylee Hicks       | Las Vegas-NV       | Champion Center               | -5    | -0.33  |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                   | Church                      | W/L  | Total | Avg    |
+|---:|------------------------|-----------------------------|------|------:|-------:|
+| 1  | Scotch Plains-NJ       | Quiz Kids                   | 12/3 | 2585  | 172.33 |
+| 2  | Brookfield-WI          | FBI - Flaming Buzzers, Inc. | 12/3 | 2780  | 185.33 |
+| 3  | Richmond Hill-NY       | Bethlehem Church            | 11/4 | 2490  | 166.00 |
+| 4  | Naperville-IL - C      | Naperville C                | 10/5 | 2625  | 175.00 |
+| 5  | Kinston-NC             | Tanglewood - Kinston        | 9/6  | 2525  | 168.33 |
+| 6  | Beulah-ND              | New Creatures               | 9/6  | 2475  | 165.00 |
+| 7  | Lawson-MO - Wendy      | Lawson AG Wendy             | 8/7  | 2470  | 164.67 |
+| 8  | Springfield-MO - Candy | Candy Crush                 | 8/7  | 2455  | 163.67 |
+| 9  | Norcross-GA            | ATC Flames                  | 8/7  | 2310  | 154.00 |
+| 10 | Tucson-AZ              | Interrupting Odd Squad      | 8/7  | 1910  | 127.33 |
+| 11 | Ravenna-OH             | Smarties                    | 7/8  | 1860  | 124.00 |
+| 12 | Colorado Springs-CO    | Knights of Christ           | 6/9  | 2090  | 139.33 |
+| 13 | Waxahachie-TX          | En-Fuego                    | 5/10 | 2110  | 140.67 |
+| 14 | Oswego-KS              | God Girls                   | 4/11 | 1690  | 112.67 |
+| 15 | North Little Rock-AR   | Eagles                      | 3/12 | 1660  | 110.67 |
+| 16 | Mustang-OK             | Blood Bought Brothers       | 0/15 | 1160  | 77.33  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                   | Church                      | Total | Avg    | QO |
+|---:|------------------------|------------------------|-----------------------------|------:|-------:|---:|
+| 1  | Jonathan Archer        | Lawson-MO - Wendy      | Lawson AG Wendy             | 1910  | 127.33 | 10 |
+| 2  | David Blomberg         | Brookfield-WI          | FBI - Flaming Buzzers, Inc. | 1710  | 114.00 | 8  |
+| 3  | Maelee Becton          | Kinston-NC             | Tanglewood - Kinston        | 1680  | 112.00 | 9  |
+| 4  | Caleb Shackelford      | Colorado Springs-CO    | Knights of Christ           | 1570  | 104.67 | 6  |
+| 5  | Landon Clark           | Springfield-MO - Candy | Candy Crush                 | 1560  | 104.00 | 7  |
+| 6  | Harrison Stevens       | Naperville-IL - C      | Naperville C                | 1550  | 103.33 | 7  |
+| 7  | Rylan Sago             | Beulah-ND              | New Creatures               | 1425  | 95.00  | 6  |
+| 8  | Joshua Daniel Dupati   | Norcross-GA            | ATC Flames                  | 1295  | 86.33  | 4  |
+| 9  | Simeon Thomas          | Scotch Plains-NJ       | Quiz Kids                   | 1055  | 70.33  | 1  |
+| 10 | Ronald George          | Norcross-GA            | ATC Flames                  | 1015  | 67.67  | 11 |
+| 11 | Shobby Enakpene        | Tucson-AZ              | Interrupting Odd Squad      | 975   | 65.00  | 2  |
+| 12 | Jacob Blackburn        | North Little Rock-AR   | Eagles                      | 910   | 60.67  | 1  |
+| 13 | Alexis Carrozzi        | Ravenna-OH             | Smarties                    | 890   | 59.33  |    |
+| 14 | Joy Escobar            | Waxahachie-TX          | En-Fuego                    | 840   | 56.00  | 1  |
+| 15 | Faith Buchanan         | Richmond Hill-NY       | Bethlehem Church            | 820   | 54.67  | 8  |
+| 16 | Erin Laboy             | Naperville-IL - C      | Naperville C                | 810   | 54.00  | 10 |
+| 17 | Ismael Rodriguez       | Waxahachie-TX          | En-Fuego                    | 715   | 47.67  |    |
+| 18 | Bianca Hernandez       | Scotch Plains-NJ       | Quiz Kids                   | 705   | 47.00  | 5  |
+| 19 | Hannah Jones           | Springfield-MO - Candy | Candy Crush                 | 700   | 46.67  | 4  |
+| 20 | Hannah Hall            | North Little Rock-AR   | Eagles                      | 685   | 45.67  | 5  |
+| 21 | Samuel Enget           | Beulah-ND              | New Creatures               | 655   | 43.67  | 6  |
+| 22 | Cecillia Newby         | Oswego-KS              | God Girls                   | 565   | 37.67  | 1  |
+| 23 | Hector Rivera          | Waxahachie-TX          | En-Fuego                    | 555   | 37.00  | 2  |
+| 24 | Annabelle Kumar        | Scotch Plains-NJ       | Quiz Kids                   | 535   | 35.67  |    |
+| 25 | Godson Massene         | Richmond Hill-NY       | Bethlehem Church            | 530   | 35.33  |    |
+| 26 | Miles Kastner          | Brookfield-WI          | FBI - Flaming Buzzers, Inc. | 520   | 34.67  | 5  |
+| 27 | Ethan Shackelford      | Colorado Springs-CO    | Knights of Christ           | 520   | 34.67  | 1  |
+| 28 | Sarah Clements         | Kinston-NC             | Tanglewood - Kinston        | 490   | 32.67  | 3  |
+| 29 | Carmen Eisenbrandt     | Oswego-KS              | God Girls                   | 490   | 32.67  |    |
+| 30 | Emily Sawastuk         | Ravenna-OH             | Smarties                    | 485   | 32.33  | 1  |
+| 31 | Daynah Dyal            | Richmond Hill-NY       | Bethlehem Church            | 485   | 32.33  |    |
+| 32 | Max Ortega             | Tucson-AZ              | Interrupting Odd Squad      | 445   | 29.67  | 5  |
+| 33 | Josh Rose              | Mustang-OK             | Blood Bought Brothers       | 430   | 28.67  |    |
+| 34 | Ayden Rush             | Mustang-OK             | Blood Bought Brothers       | 410   | 27.33  | 2  |
+| 35 | Delaney Reynolds       | Oswego-KS              | God Girls                   | 365   | 24.33  |    |
+| 36 | Meleah Sawastuk        | Ravenna-OH             | Smarties                    | 360   | 24.00  |    |
+| 37 | Adyson Whaley          | Kinston-NC             | Tanglewood - Kinston        | 355   | 23.67  | 1  |
+| 38 | Brianna Cypcar         | Brookfield-WI          | FBI - Flaming Buzzers, Inc. | 350   | 23.33  |    |
+| 39 | Justin Arocho          | Richmond Hill-NY       | Bethlehem Church            | 325   | 21.67  |    |
+| 40 | Jaydon Dimitrov        | Lawson-MO - Wendy      | Lawson AG Wendy             | 320   | 21.33  | 2  |
+| 41 | Jett King              | Mustang-OK             | Blood Bought Brothers       | 320   | 21.33  |    |
+| 42 | Victoria Hernandez     | Scotch Plains-NJ       | Quiz Kids                   | 290   | 19.33  | 1  |
+| 43 | Trevin Sago            | Beulah-ND              | New Creatures               | 260   | 17.33  |    |
+| 44 | Reagan Stevens         | Naperville-IL - C      | Naperville C                | 245   | 16.33  |    |
+| 45 | Grace Noel             | Oswego-KS              | God Girls                   | 240   | 16.00  |    |
+| 46 | Seth Archer            | Lawson-MO - Wendy      | Lawson AG Wendy             | 230   | 15.33  |    |
+| 47 | Omosuiwa Enakpene      | Tucson-AZ              | Interrupting Odd Squad      | 210   | 14.00  |    |
+| 48 | Isaac Ubert            | Brookfield-WI          | FBI - Flaming Buzzers, Inc. | 190   | 12.67  |    |
+| 49 | Ashley Okafor          | Richmond Hill-NY       | Bethlehem Church            | 180   | 12.00  |    |
+| 50 | Ayden Sorensen         | Tucson-AZ              | Interrupting Odd Squad      | 140   | 9.33   |    |
+| 50 | Vanessa Gomez          | Tucson-AZ              | Interrupting Odd Squad      | 140   | 9.33   |    |
+| 51 | Nico Georgiades        | Springfield-MO - Candy | Candy Crush                 | 120   | 8.00   | 1  |
+| 52 | Colson Sago            | Beulah-ND              | New Creatures               | 120   | 8.00   |    |
+| 52 | Aubrey Carrozzi        | Ravenna-OH             | Smarties                    | 120   | 8.00   |    |
+| 53 | Brianna Boodram        | Richmond Hill-NY       | Bethlehem Church            | 90    | 6.00   |    |
+| 54 | Savannah Stricklin     | North Little Rock-AR   | Eagles                      | 60    | 4.00   |    |
+| 54 | Jon Luc Jobson Larkin  | Richmond Hill-NY       | Bethlehem Church            | 60    | 4.00   |    |
+| 55 | Jackson Woodward       | Springfield-MO - Candy | Candy Crush                 | 45    | 3.00   |    |
+| 56 | Elli Woodward          | Springfield-MO - Candy | Candy Crush                 | 30    | 2.00   |    |
+| 56 | Kacey Mayfield         | Oswego-KS              | God Girls                   | 30    | 2.00   |    |
+| 57 | Michelle Aum           | Naperville-IL - C      | Naperville C                | 20    | 1.33   |    |
+| 58 | Jadyn Archer           | Lawson-MO - Wendy      | Lawson AG Wendy             | 15    | 1.00   |    |
+| 58 | John Kruger            | Beulah-ND              | New Creatures               | 15    | 1.00   |    |
+| 59 | Aliyah Gibson          | North Little Rock-AR   | Eagles                      | 10    | .67    |    |
+| 59 | Elizabeth Murray       | Brookfield-WI          | FBI - Flaming Buzzers, Inc. | 10    | .67    |    |
+| 60 | Ashton Mearns          | Ravenna-OH             | Smarties                    | 5     | .33    |    |
+| 61 | Maddie Higgins         | North Little Rock-AR   | Eagles                      |       | .00    |    |
+| 61 | Hannah Noel            | Oswego-KS              | God Girls                   |       | .00    |    |
+| 61 | Zachary Dupati         | Norcross-GA            | ATC Flames                  |       | .00    |    |
+| 61 | Robert Trout 3 (Jacob) | Richmond Hill-NY       | Bethlehem Church            |       | .00    |    |
+
+## Saturday
+
+### Blue (L1)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team              | Church                      | W/L | Total | Avg    |
+|---:|-------------------|-----------------------------|-----|------:|-------:|
+| 1  | Houston-TX        | The Chosen Ones             | 8/1 | 1760  | 195.56 |
+| 2  | Sanford-FL        | God\'s Incredibles          | 6/3 | 1585  | 176.11 |
+| 3  | Scotch Plains-NJ  | Quiz Kids                   | 6/3 | 1535  | 170.56 |
+| 4  | Naperville-IL - M | Naperville M                | 6/3 | 1505  | 167.22 |
+| 5  | Akron-OH          | Celebration Quizzers        | 5/4 | 1325  | 147.22 |
+| 6  | Brookfield-WI     | FBI - Flaming Buzzers, Inc. | 5/4 | 1490  | 165.56 |
+| 7  | East Lansing-MI   | Greater Lansing             | 4/5 | 1345  | 149.44 |
+| 8  | Naperville-IL - D | Naperville D                | 3/6 | 1010  | 112.22 |
+| 9  | San Jose-CA       | Souled Out                  | 1/8 | 1080  | 120.00 |
+| 10 | Bellevue-WA       | Neighborhood Church         | 1/8 | 965   | 107.22 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team              | Church                      | Total | Avg    | QO |
+|---:|--------------------|-------------------|-----------------------------|------:|-------:|---:|
+| 1  | Toby Robinson      | Sanford-FL        | God\'s Incredibles          | 1135  | 126.11 | 7  |
+| 2  | David Blomberg     | Brookfield-WI     | FBI - Flaming Buzzers, Inc. | 1015  | 112.78 | 2  |
+| 3  | Sheldon Powell     | Naperville-IL - M | Naperville M                | 965   | 107.22 | 4  |
+| 4  | Darcie Harr        | East Lansing-MI   | Greater Lansing             | 960   | 106.67 | 4  |
+| 5  | Brock Eder         | Akron-OH          | Celebration Quizzers        | 960   | 106.67 | 2  |
+| 6  | Samuel Jebaraj     | San Jose-CA       | Souled Out                  | 855   | 95.00  | 5  |
+| 7  | Daniel Ejim        | Houston-TX        | The Chosen Ones             | 810   | 90.00  | 3  |
+| 8  | Brandon Ukonu      | Houston-TX        | The Chosen Ones             | 615   | 68.33  | 9  |
+| 9  | Simeon Thomas      | Scotch Plains-NJ  | Quiz Kids                   | 570   | 63.33  |    |
+| 10 | Shawn Timothy      | Naperville-IL - D | Naperville D                | 535   | 59.44  | 2  |
+| 11 | Samuel Clinston    | Bellevue-WA       | Neighborhood Church         | 520   | 57.78  | 1  |
+| 12 | Annabelle Kumar    | Scotch Plains-NJ  | Quiz Kids                   | 440   | 48.89  | 1  |
+| 13 | Shaymis Powell     | Naperville-IL - M | Naperville M                | 410   | 45.56  | 6  |
+| 14 | Nicola Betz        | Naperville-IL - D | Naperville D                | 365   | 40.56  | 4  |
+| 15 | Chloe Eder         | Akron-OH          | Celebration Quizzers        | 330   | 36.67  | 2  |
+| 16 | Julia Correa       | Bellevue-WA       | Neighborhood Church         | 315   | 35.00  | 2  |
+| 17 | Victoria Hernandez | Scotch Plains-NJ  | Quiz Kids                   | 295   | 32.78  | 1  |
+| 18 | Jordan Perez       | Sanford-FL        | God\'s Incredibles          | 265   | 29.44  | 1  |
+| 19 | Miles Kastner      | Brookfield-WI     | FBI - Flaming Buzzers, Inc. | 260   | 28.89  | 2  |
+| 20 | Bianca Hernandez   | Scotch Plains-NJ  | Quiz Kids                   | 230   | 25.56  | 1  |
+| 20 | Jackson Convis     | East Lansing-MI   | Greater Lansing             | 230   | 25.56  | 1  |
+| 21 | Sarah Onwudinjo    | Houston-TX        | The Chosen Ones             | 210   | 23.33  |    |
+| 22 | Wesley Thomas      | Sanford-FL        | God\'s Incredibles          | 190   | 21.11  |    |
+| 23 | Isaac Ubert        | Brookfield-WI     | FBI - Flaming Buzzers, Inc. | 155   | 17.22  |    |
+| 24 | Madeline Lickey    | Bellevue-WA       | Neighborhood Church         | 130   | 14.44  |    |
+| 25 | Michael Ukonu      | Houston-TX        | The Chosen Ones             | 125   | 13.89  |    |
+| 25 | Jasmine Sirvent    | San Jose-CA       | Souled Out                  | 125   | 13.89  |    |
+| 26 | Shaylee Powell     | Naperville-IL - M | Naperville M                | 90    | 10.00  |    |
+| 27 | Aaron Bumbaca      | San Jose-CA       | Souled Out                  | 80    | 8.89   |    |
+| 27 | Britta Andrews     | East Lansing-MI   | Greater Lansing             | 80    | 8.89   |    |
+| 27 | Stephen Bough      | Naperville-IL - D | Naperville D                | 80    | 8.89   |    |
+| 28 | Onome Oghor        | East Lansing-MI   | Greater Lansing             | 75    | 8.33   |    |
+| 29 | Brianna Cypcar     | Brookfield-WI     | FBI - Flaming Buzzers, Inc. | 60    | 6.67   |    |
+| 30 | Jed Koss           | Naperville-IL - M | Naperville M                | 40    | 4.44   |    |
+| 31 | Samuel Biruduganti | Naperville-IL - D | Naperville D                | 30    | 3.33   |    |
+| 32 | Elylah Stager      | Akron-OH          | Celebration Quizzers        | 25    | 2.78   |    |
+| 33 | Alyssa Bumbaca     | San Jose-CA       | Souled Out                  | 20    | 2.22   |    |
+| 34 | Sofia Marks        | Akron-OH          | Celebration Quizzers        | 10    | 1.11   |    |
+| 35 | Cierra Convis      | East Lansing-MI   | Greater Lansing             |       | .00    |    |
+| 35 | Elizabeth Murray   | Brookfield-WI     | FBI - Flaming Buzzers, Inc. |       | .00    |    |
+| 35 | Sean Wallis        | Akron-OH          | Celebration Quizzers        |       | .00    |    |
+| 35 | Riley Marks        | Akron-OH          | Celebration Quizzers        |       | .00    |    |
+| 35 | Alyssa Jenks       | Sanford-FL        | God\'s Incredibles          |       | .00    |    |
+
+### Green (L2)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                          | Church                | W/L | Total | Avg    |
+|---:|-------------------------------|-----------------------|-----|------:|-------:|
+| 1  | Lawson-MO - Connie            | Lawson Connie         | 6/3 | 1560  | 173.33 |
+| 2  | Mechanicsville-VA - Obedience | Contagious Obedience  | 6/3 | 1435  | 159.44 |
+| 3  | Richmond Hill-NY              | Bethlehem Church      | 6/3 | 1290  | 143.33 |
+| 4  | Naperville-IL - S             | Naperville S          | 5/4 | 1395  | 155.00 |
+| 5  | Naperville-IL - C             | Naperville C          | 5/4 | 1365  | 151.67 |
+| 6  | New Albany-OH                 | Fluffy Panda Quizzers | 5/4 | 1340  | 148.89 |
+| 7  | St. Cloud-MN                  | Gods Lighthouse       | 5/4 | 1215  | 135.00 |
+| 8  | Havre-MT                      | Havre Assembly Rebels | 3/6 | 1200  | 133.33 |
+| 9  | Cedar Hill-TX                 | Triple Threat         | 2/7 | 990   | 110.00 |
+| 10 | Hamburg-PA                    | Lightning Hawks       | 2/7 | 1130  | 125.56 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                          | Church                | Total | Avg    | QO |
+|---:|------------------------|-------------------------------|-----------------------|------:|-------:|---:|
+| 1  | Laken Manns            | Lawson-MO - Connie            | Lawson Connie         | 980   | 108.89 | 5  |
+| 2  | Josiah Mair            | New Albany-OH                 | Fluffy Panda Quizzers | 920   | 102.22 | 6  |
+| 3  | Madison Steele         | Mechanicsville-VA - Obedience | Contagious Obedience  | 905   | 100.56 | 4  |
+| 4  | Harrison Stevens       | Naperville-IL - C             | Naperville C          | 900   | 100.00 | 5  |
+| 5  | Alaynee Hawley         | Havre-MT                      | Havre Assembly Rebels | 865   | 96.11  | 2  |
+| 6  | Ty Silas               | Naperville-IL - S             | Naperville S          | 840   | 93.33  | 5  |
+| 7  | Trey Crowley           | Hamburg-PA                    | Lightning Hawks       | 695   | 77.22  | 3  |
+| 8  | Zachariah Rothwell     | St. Cloud-MN                  | Gods Lighthouse       | 535   | 59.44  | 1  |
+| 9  | Godson Massene         | Richmond Hill-NY              | Bethlehem Church      | 470   | 52.22  |    |
+| 9  | Josh Barajas           | Cedar Hill-TX                 | Triple Threat         | 470   | 52.22  |    |
+| 10 | Nick Cook              | Lawson-MO - Connie            | Lawson Connie         | 430   | 47.78  | 3  |
+| 11 | Megan Bartlett         | St. Cloud-MN                  | Gods Lighthouse       | 420   | 46.67  |    |
+| 12 | Faith Buchanan         | Richmond Hill-NY              | Bethlehem Church      | 360   | 40.00  | 2  |
+| 13 | Justiss Silas          | Naperville-IL - S             | Naperville S          | 345   | 38.33  | 3  |
+| 14 | Emma Miller            | Cedar Hill-TX                 | Triple Threat         | 340   | 37.78  |    |
+| 15 | Erin Laboy             | Naperville-IL - C             | Naperville C          | 320   | 35.56  | 4  |
+| 16 | Daynah Dyal            | Richmond Hill-NY              | Bethlehem Church      | 310   | 34.44  | 1  |
+| 17 | Noah Zananiri          | New Albany-OH                 | Fluffy Panda Quizzers | 275   | 30.56  | 2  |
+| 18 | Braden Adams           | Mechanicsville-VA - Obedience | Contagious Obedience  | 230   | 25.56  | 1  |
+| 19 | Aicha Fitzgerald       | Hamburg-PA                    | Lightning Hawks       | 230   | 25.56  |    |
+| 20 | Will Rittenhouse       | Mechanicsville-VA - Obedience | Contagious Obedience  | 210   | 23.33  | 1  |
+| 21 | Thomas Pospisil        | Hamburg-PA                    | Lightning Hawks       | 205   | 22.78  |    |
+| 22 | Caleb Roos             | St. Cloud-MN                  | Gods Lighthouse       | 200   | 22.22  | 1  |
+| 23 | David Biruduganti      | Naperville-IL - S             | Naperville S          | 190   | 21.11  |    |
+| 24 | Jude Calvery           | Cedar Hill-TX                 | Triple Threat         | 180   | 20.00  |    |
+| 25 | Taylen Manns           | Lawson-MO - Connie            | Lawson Connie         | 150   | 16.67  | 1  |
+| 26 | Reagan Stevens         | Naperville-IL - C             | Naperville C          | 145   | 16.11  |    |
+| 26 | Breydon Hawley         | Havre-MT                      | Havre Assembly Rebels | 145   | 16.11  |    |
+| 27 | Alaura Hawley          | Havre-MT                      | Havre Assembly Rebels | 110   | 12.22  |    |
+| 28 | Justin Arocho          | Richmond Hill-NY              | Bethlehem Church      | 95    | 10.56  |    |
+| 28 | Abel Karthik           | New Albany-OH                 | Fluffy Panda Quizzers | 95    | 10.56  |    |
+| 29 | Brooks Adams           | Mechanicsville-VA - Obedience | Contagious Obedience  | 85    | 9.44   |    |
+| 29 | Josiah Boe             | Havre-MT                      | Havre Assembly Rebels | 85    | 9.44   |    |
+| 30 | Samuel March           | St. Cloud-MN                  | Gods Lighthouse       | 60    | 6.67   |    |
+| 31 | Samuel Mair            | New Albany-OH                 | Fluffy Panda Quizzers | 50    | 5.56   |    |
+| 31 | Ashley Okafor          | Richmond Hill-NY              | Bethlehem Church      | 50    | 5.56   |    |
+| 32 | McKinley Stevens       | Naperville-IL - S             | Naperville S          | 20    | 2.22   |    |
+| 33 | Christian Steele       | Mechanicsville-VA - Obedience | Contagious Obedience  | 5     | .56    |    |
+| 33 | Jon Luc Jobson Larkin  | Richmond Hill-NY              | Bethlehem Church      | 5     | .56    |    |
+| 34 | Michelle Aum           | Naperville-IL - C             | Naperville C          |       | .00    |    |
+| 34 | Brianna Boodram        | Richmond Hill-NY              | Bethlehem Church      |       | .00    |    |
+| 34 | Robert Trout 3 (Jacob) | Richmond Hill-NY              | Bethlehem Church      |       | .00    |    |
+
+
+### Lavender (L3)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                | Church                         | W/L | Total | Avg    |
+|---:|---------------------|--------------------------------|-----|------:|-------:|
+| 1  | Kinston-NC          | Tanglewood - Kinston           | 6/3 | 1405  | 156.11 |
+| 2  | Beulah-ND           | New Creatures                  | 5/4 | 1480  | 164.44 |
+| 3  | Tallahassee-FL      | More than Conquerers           | 5/4 | 1405  | 156.11 |
+| 4  | Wilmington-NC - Red | Wilmington Warriors Red Swords | 5/4 | 1400  | 155.56 |
+| 5  | Billings-MT         | Billings New Life              | 5/4 | 1295  | 143.89 |
+| 6  | Rochester-MN        | Unstoppable                    | 4/5 | 1435  | 159.44 |
+| 7  | Bowling Green-OH    | Team Olaf                      | 4/5 | 1170  | 130.00 |
+| 8  | Phoenix-AZ          | Phoenix First Bible Warriors   | 4/5 | 1105  | 122.78 |
+| 9  | Greensboro-NC       | Biblecraft                     | 4/5 | 1055  | 117.22 |
+| 10 | Warren-MI           | IAG Eagles                     | 3/6 | 1280  | 142.22 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                | Church                         | Total | Avg    | QO |
+|---:|----------------------|---------------------|--------------------------------|------:|-------:|---:|
+| 1  | Maelee Becton        | Kinston-NC          | Tanglewood - Kinston           | 970   | 107.78 | 3  |
+| 2  | Ethan Stewart        | Tallahassee-FL      | More than Conquerers           | 960   | 106.67 | 4  |
+| 3  | Rylan Sago           | Beulah-ND           | New Creatures                  | 875   | 97.22  | 4  |
+| 4  | Pete Mathew          | Warren-MI           | IAG Eagles                     | 850   | 94.44  | 4  |
+| 5  | Zachary leake        | Wilmington-NC - Red | Wilmington Warriors Red Swords | 835   | 92.78  | 1  |
+| 6  | Rayanne Danso        | Rochester-MN        | Unstoppable                    | 690   | 76.67  | 2  |
+| 7  | Cole Muscari         | Phoenix-AZ          | Phoenix First Bible Warriors   | 505   | 56.11  | 1  |
+| 8  | Micah Houde          | Billings-MT         | Billings New Life              | 480   | 53.33  |    |
+| 9  | Aidan Rajesh         | Greensboro-NC       | Biblecraft                     | 405   | 45.00  | 1  |
+| 10 | Abigail Slembarski   | Bowling Green-OH    | Team Olaf                      | 400   | 44.44  |    |
+| 11 | Ethan Gates          | Rochester-MN        | Unstoppable                    | 390   | 43.33  | 4  |
+| 12 | Kierstin childs      | Wilmington-NC - Red | Wilmington Warriors Red Swords | 385   | 42.78  | 5  |
+| 13 | Jayda Houde          | Billings-MT         | Billings New Life              | 370   | 41.11  |    |
+| 14 | McKenna Cape         | Rochester-MN        | Unstoppable                    | 355   | 39.44  |    |
+| 15 | Noah Smith           | Bowling Green-OH    | Team Olaf                      | 350   | 38.89  | 3  |
+| 16 | Kristin Schmidt      | Phoenix-AZ          | Phoenix First Bible Warriors   | 340   | 37.78  |    |
+| 17 | Hannah Facer         | Bowling Green-OH    | Team Olaf                      | 330   | 36.67  |    |
+| 18 | Adyson Whaley        | Kinston-NC          | Tanglewood - Kinston           | 305   | 33.89  | 1  |
+| 19 | Samuel Enget         | Beulah-ND           | New Creatures                  | 300   | 33.33  | 4  |
+| 20 | Collin Nester        | Tallahassee-FL      | More than Conquerers           | 295   | 32.78  | 1  |
+| 21 | Aaliyah Landers      | Billings-MT         | Billings New Life              | 260   | 28.89  | 2  |
+| 22 | Tyler Trexler        | Phoenix-AZ          | Phoenix First Bible Warriors   | 260   | 28.89  | 1  |
+| 23 | Trenton Morris       | Greensboro-NC       | Biblecraft                     | 235   | 26.11  | 2  |
+| 24 | Nathaniel Prejean    | Greensboro-NC       | Biblecraft                     | 225   | 25.00  |    |
+| 25 | Reuben Abraham       | Warren-MI           | IAG Eagles                     | 185   | 20.56  |    |
+| 26 | Trevin Sago          | Beulah-ND           | New Creatures                  | 180   | 20.00  |    |
+| 27 | Nevaeh Walker        | Billings-MT         | Billings New Life              | 135   | 15.00  |    |
+| 28 | Sarah Clements       | Kinston-NC          | Tanglewood - Kinston           | 130   | 14.44  |    |
+| 29 | Matthew Baloga       | Greensboro-NC       | Biblecraft                     | 115   | 12.78  |    |
+| 30 | Joshua Kuruvilla     | Warren-MI           | IAG Eagles                     | 110   | 12.22  |    |
+| 31 | Krister George       | Warren-MI           | IAG Eagles                     | 95    | 10.56  |    |
+| 32 | Olivia Neerudu       | Bowling Green-OH    | Team Olaf                      | 90    | 10.00  |    |
+| 33 | Colson Sago          | Beulah-ND           | New Creatures                  | 85    | 9.44   |    |
+| 34 | Emma Stewart         | Tallahassee-FL      | More than Conquerers           | 80    | 8.89   |    |
+| 35 | Christian Shelton    | Wilmington-NC - Red | Wilmington Warriors Red Swords | 75    | 8.33   |    |
+| 36 | Anna scott witzenman | Wilmington-NC - Red | Wilmington Warriors Red Swords | 70    | 7.78   |    |
+| 37 | Savannah Robinson    | Greensboro-NC       | Biblecraft                     | 45    | 5.00   |    |
+| 38 | Rylin Taylor         | Billings-MT         | Billings New Life              | 40    | 4.44   |    |
+| 38 | John Kruger          | Beulah-ND           | New Creatures                  | 40    | 4.44   |    |
+| 38 | Rachel Nadia         | Warren-MI           | IAG Eagles                     | 40    | 4.44   |    |
+| 38 | Elijah Stewart       | Tallahassee-FL      | More than Conquerers           | 40    | 4.44   |    |
+| 39 | Kora Beth witzenman  | Wilmington-NC - Red | Wilmington Warriors Red Swords | 35    | 3.89   |    |
+| 40 | Hope Alford          | Tallahassee-FL      | More than Conquerers           | 30    | 3.33   |    |
+| 40 | Joshua Baloga        | Greensboro-NC       | Biblecraft                     | 30    | 3.33   |    |
+| 41 | Brooke Bentz         | Billings-MT         | Billings New Life              | 10    | 1.11   |    |
+| 42 | Lily Robinson        | Billings-MT         | Billings New Life              |       | .00    |    |
+
+
+### Orange (L4)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                   | Church             | W/L | Total | Avg    |
+|---:|------------------------|--------------------|-----|------:|-------:|
+| 1  | Bothell-WA             | Cedar Park Eagles  | 7/2 | 1675  | 186.11 |
+| 2  | Springfield-MO         | QuizMasters        | 6/3 | 1420  | 157.78 |
+| 3  | Lawson-MO - Wendy      | Lawson AG Wendy    | 5/4 | 1365  | 151.67 |
+| 4  | Springfield-MO - Candy | Candy Crush        | 5/4 | 1135  | 126.11 |
+| 5  | Midland-GA             | Hard Core Quizzers | 5/4 | 1075  | 119.44 |
+| 6  | Jacksonville-AR        | Ablaze             | 4/5 | 1140  | 126.67 |
+| 7  | Rockwall-TX            | Wind of the Word   | 4/5 | 1315  | 146.11 |
+| 8  | Ozark-MO               | Voices of Victory  | 3/6 | 1315  | 146.11 |
+| 9  | Red Oak-TX             | Tribulation Force  | 3/6 | 1210  | 134.44 |
+| 10 | Chandler-AZ            | Christ Ambassadors | 3/6 | 1195  | 132.78 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                   | Church             | Total | Avg    | QO |
+|---:|---------------------|------------------------|--------------------|------:|-------:|---:|
+| 1  | Alex Jarrell        | Bothell-WA             | Cedar Park Eagles  | 1205  | 133.89 | 8  |
+| 2  | Cameron Ramsey      | Springfield-MO         | QuizMasters        | 1020  | 113.33 | 5  |
+| 3  | Jonathan Archer     | Lawson-MO - Wendy      | Lawson AG Wendy    | 940   | 104.44 | 3  |
+| 4  | Alex Koch           | Rockwall-TX            | Wind of the Word   | 765   | 85.00  | 4  |
+| 5  | Mercy Germany       | Ozark-MO               | Voices of Victory  | 675   | 75.00  | 3  |
+| 6  | Landon Clark        | Springfield-MO - Candy | Candy Crush        | 670   | 74.44  | 2  |
+| 7  | Gavin Kuruvilla     | Chandler-AZ            | Christ Ambassadors | 570   | 63.33  | 2  |
+| 8  | Truman Griessel     | Ozark-MO               | Voices of Victory  | 500   | 55.56  | 2  |
+| 9  | Joanna Joseph       | Chandler-AZ            | Christ Ambassadors | 440   | 48.89  | 1  |
+| 9  | Christopher Johnson | Midland-GA             | Hard Core Quizzers | 440   | 48.89  | 1  |
+| 10 | Preston Hoggard     | Red Oak-TX             | Tribulation Force  | 430   | 47.78  | 5  |
+| 11 | Elyssa Fulfer       | Red Oak-TX             | Tribulation Force  | 400   | 44.44  |    |
+| 11 | Seth Swain          | Jacksonville-AR        | Ablaze             | 400   | 44.44  |    |
+| 12 | Victor Fonov        | Red Oak-TX             | Tribulation Force  | 380   | 42.22  |    |
+| 13 | Hannah Jones        | Springfield-MO - Candy | Candy Crush        | 365   | 40.56  | 3  |
+| 14 | Ashton Johnson      | Jacksonville-AR        | Ablaze             | 355   | 39.44  | 3  |
+| 15 | Caleb Whitener      | Jacksonville-AR        | Ablaze             | 345   | 38.33  |    |
+| 16 | Nathan Koch         | Rockwall-TX            | Wind of the Word   | 310   | 34.44  | 3  |
+| 17 | Michael Holland     | Midland-GA             | Hard Core Quizzers | 285   | 31.67  | 2  |
+| 18 | Gracie Frank        | Bothell-WA             | Cedar Park Eagles  | 265   | 29.44  | 1  |
+| 19 | Seth Archer         | Lawson-MO - Wendy      | Lawson AG Wendy    | 265   | 29.44  |    |
+| 20 | Gannon Breig        | Springfield-MO         | QuizMasters        | 240   | 26.67  |    |
+| 20 | Zachary Dennis      | Midland-GA             | Hard Core Quizzers | 240   | 26.67  |    |
+| 21 | Christiaan West     | Bothell-WA             | Cedar Park Eagles  | 205   | 22.78  |    |
+| 22 | Timothy Mathew      | Chandler-AZ            | Christ Ambassadors | 185   | 20.56  |    |
+| 23 | Makenna Koch        | Rockwall-TX            | Wind of the Word   | 165   | 18.33  |    |
+| 24 | Jaydon Dimitrov     | Lawson-MO - Wendy      | Lawson AG Wendy    | 160   | 17.78  |    |
+| 25 | Kaitlyn Ramsey      | Springfield-MO         | QuizMasters        | 120   | 13.33  |    |
+| 26 | Marcus Mesis        | Midland-GA             | Hard Core Quizzers | 100   | 11.11  |    |
+| 27 | Chuck Myers         | Ozark-MO               | Voices of Victory  | 70    | 7.78   |    |
+| 27 | Nico Georgiades     | Springfield-MO - Candy | Candy Crush        | 70    | 7.78   |    |
+| 28 | Isabell McClanahan  | Ozark-MO               | Voices of Victory  | 55    | 6.11   |    |
+| 29 | Andrew Lopez        | Rockwall-TX            | Wind of the Word   | 45    | 5.00   |    |
+| 30 | Adam Murdock        | Jacksonville-AR        | Ablaze             | 35    | 3.89   |    |
+| 31 | Catie Wolfe         | Springfield-MO         | QuizMasters        | 30    | 3.33   |    |
+| 31 | Jackson Woodward    | Springfield-MO - Candy | Candy Crush        | 30    | 3.33   |    |
+| 31 | Braden Pugh         | Rockwall-TX            | Wind of the Word   | 30    | 3.33   |    |
+| 32 | Ethan Herrera       | Midland-GA             | Hard Core Quizzers | 10    | 1.11   |    |
+| 32 | Sofie McClanahan    | Ozark-MO               | Voices of Victory  | 10    | 1.11   |    |
+| 32 | Angel Johnson       | Jacksonville-AR        | Ablaze             | 10    | 1.11   |    |
+| 32 | Riley Breig         | Springfield-MO         | QuizMasters        | 10    | 1.11   |    |
+| 33 | Noelle Germany      | Ozark-MO               | Voices of Victory  | 5     | .56    |    |
+| 34 | McKenna Black       | Springfield-MO         | QuizMasters        |       | .00    |    |
+| 34 | Aidan Fulfer        | Red Oak-TX             | Tribulation Force  |       | .00    |    |
+| 34 | Joshua Malayil      | Chandler-AZ            | Christ Ambassadors |       | .00    |    |
+| 34 | Jadyn Archer        | Lawson-MO - Wendy      | Lawson AG Wendy    |       | .00    |    |
+| 34 | Elli Woodward       | Springfield-MO - Candy | Candy Crush        |       | .00    |    |
+| 34 | Nathaniel Joseph    | Midland-GA             | Hard Core Quizzers |       | .00    |    |
+
+
+### Pink (L5)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                 | Church                     | W/L | Total | Avg    |
+|---:|----------------------|----------------------------|-----|------:|-------:|
+| 1  | Leesburg-VA          | S.P.Y. Dudes               | 7/2 | 1470  | 163.33 |
+| 2  | Tucson-AZ            | Girls of Christ            | 6/3 | 1350  | 150.00 |
+| 3  | Monmouth Junction-NJ | Knights 4 Christ           | 6/3 | 1375  | 152.78 |
+| 4  | Shakopee-MN          | Minds of the Bible         | 5/4 | 1500  | 166.67 |
+| 5  | Norcross-GA          | ATC Flames                 | 4/5 | 1355  | 150.56 |
+| 6  | Swedesboro-NJ        | Resurrection Sunday        | 4/5 | 1280  | 142.22 |
+| 7  | Omaha-NE             | Agents of the Shield       | 4/5 | 1190  | 132.22 |
+| 8  | Tucson-AZ            | Interrupting Odd Squad     | 4/5 | 890   | 98.89  |
+| 9  | Rogers-AR            | He-Rose                    | 3/6 | 1215  | 135.00 |
+| 10 | Fortville-IN         | Wonderful Wizards of Words | 2/7 | 925   | 102.78 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                 | Church                     | Total | Avg   | QO |
+|---:|----------------------|----------------------|----------------------------|------:|------:|---:|
+| 1  | Joshua Daniel Dupati | Norcross-GA          | ATC Flames                 | 780   | 86.67 | 1  |
+| 2  | Nathaniel Jebaraj    | Monmouth Junction-NJ | Knights 4 Christ           | 735   | 81.67 | 4  |
+| 3  | Tate Putman          | Shakopee-MN          | Minds of the Bible         | 720   | 80.00 |    |
+| 4  | Hans Holzhausen      | Fortville-IN         | Wonderful Wizards of Words | 650   | 72.22 | 1  |
+| 5  | Ronald George        | Norcross-GA          | ATC Flames                 | 575   | 63.89 | 6  |
+| 6  | Sydney Shockley      | Rogers-AR            | He-Rose                    | 570   | 63.33 | 3  |
+| 7  | Amelia Gephart       | Tucson-AZ            | Girls of Christ            | 500   | 55.56 | 1  |
+| 8  | Toby Hill            | Swedesboro-NJ        | Resurrection Sunday        | 480   | 53.33 | 2  |
+| 9  | Will Addler          | Shakopee-MN          | Minds of the Bible         | 455   | 50.56 | 5  |
+| 10 | Andrew Judd          | Leesburg-VA          | S.P.Y. Dudes               | 450   | 50.00 | 4  |
+| 11 | Remiel Brigilin      | Monmouth Junction-NJ | Knights 4 Christ           | 420   | 46.67 | 1  |
+| 12 | Lademi Davies        | Omaha-NE             | Agents of the Shield       | 405   | 45.00 |    |
+| 13 | Samuel Otchere       | Leesburg-VA          | S.P.Y. Dudes               | 400   | 44.44 |    |
+| 14 | Ethan Lancelot       | Rogers-AR            | He-Rose                    | 380   | 42.22 |    |
+| 15 | Madeline Berkey      | Tucson-AZ            | Girls of Christ            | 375   | 41.67 |    |
+| 16 | Phillip Bozzay       | Leesburg-VA          | S.P.Y. Dudes               | 350   | 38.89 |    |
+| 17 | Aaron Martin         | Omaha-NE             | Agents of the Shield       | 310   | 34.44 | 1  |
+| 18 | Hannah Royer         | Tucson-AZ            | Girls of Christ            | 290   | 32.22 | 3  |
+| 19 | Nathaniel Dowdy      | Swedesboro-NJ        | Resurrection Sunday        | 290   | 32.22 |    |
+| 20 | Joshua Daniel        | Leesburg-VA          | S.P.Y. Dudes               | 270   | 30.00 |    |
+| 21 | Gabby Pahl           | Shakopee-MN          | Minds of the Bible         | 260   | 28.89 |    |
+| 22 | Shobby Enakpene      | Tucson-AZ            | Interrupting Odd Squad     | 250   | 27.78 |    |
+| 23 | Joshua Senthil       | Monmouth Junction-NJ | Knights 4 Christ           | 225   | 25.00 |    |
+| 24 | Micah DeSanto        | Swedesboro-NJ        | Resurrection Sunday        | 220   | 24.44 |    |
+| 24 | Charlotte Elliott    | Omaha-NE             | Agents of the Shield       | 220   | 24.44 |    |
+| 25 | Patrick Norris       | Swedesboro-NJ        | Resurrection Sunday        | 200   | 22.22 | 1  |
+| 26 | Becca Longtin        | Rogers-AR            | He-Rose                    | 190   | 21.11 |    |
+| 26 | Max Ortega           | Tucson-AZ            | Interrupting Odd Squad     | 190   | 21.11 |    |
+| 26 | Iakona Fern          | Omaha-NE             | Agents of the Shield       | 190   | 21.11 |    |
+| 27 | Michelle Lobato      | Tucson-AZ            | Girls of Christ            | 165   | 18.33 |    |
+| 28 | Delaney Jones        | Fortville-IN         | Wonderful Wizards of Words | 155   | 17.22 | 1  |
+| 29 | Omosuiwa Enakpene    | Tucson-AZ            | Interrupting Odd Squad     | 155   | 17.22 |    |
+| 30 | Ayden Sorensen       | Tucson-AZ            | Interrupting Odd Squad     | 150   | 16.67 |    |
+| 31 | Vanessa Gomez        | Tucson-AZ            | Interrupting Odd Squad     | 145   | 16.11 |    |
+| 32 | Annie Keerns         | Fortville-IN         | Wonderful Wizards of Words | 120   | 13.33 |    |
+| 33 | Josie Dague          | Omaha-NE             | Agents of the Shield       | 70    | 7.78  |    |
+| 34 | Hannah Massard       | Shakopee-MN          | Minds of the Bible         | 60    | 6.67  |    |
+| 34 | Tinley Boysen        | Rogers-AR            | He-Rose                    | 60    | 6.67  |    |
+| 35 | Jessica Samuel       | Swedesboro-NJ        | Resurrection Sunday        | 50    | 5.56  |    |
+| 36 | Joel Samuel          | Swedesboro-NJ        | Resurrection Sunday        | 40    | 4.44  |    |
+| 37 | John Cooley          | Tucson-AZ            | Girls of Christ            | 20    | 2.22  |    |
+| 38 | Morgan Giese         | Rogers-AR            | He-Rose                    | 15    | 1.67  |    |
+| 39 | Lauren Pahl          | Shakopee-MN          | Minds of the Bible         | 5     | .56   |    |
+| 40 | Hannah Judd          | Leesburg-VA          | S.P.Y. Dudes               |       | .00   |    |
+| 40 | Mariela Trujiillo    | Leesburg-VA          | S.P.Y. Dudes               |       | .00   |    |
+| 40 | Zachary Dupati       | Norcross-GA          | ATC Flames                 |       | .00   |    |
+| 40 | Leah Hodge           | Leesburg-VA          | S.P.Y. Dudes               |       | .00   |    |
+| 40 | Gracelyn Daniel      | Leesburg-VA          | S.P.Y. Dudes               |       | .00   |    |
+| 40 | Darla Holzhausen     | Fortville-IN         | Wonderful Wizards of Words |       | .00   |    |
+
+
+### Silver (L6)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                | Church                        | W/L | Total | Avg    |
+|---:|---------------------|-------------------------------|-----|------:|-------:|
+| 1  | Garland-TX          | Transformed                   | 8/1 | 1605  | 178.33 |
+| 2  | Versailles-KY       | The J-Walkers                 | 7/2 | 1605  | 178.33 |
+| 3  | Overland Park-KS    | Coca-Cola Quizzers            | 6/3 | 1410  | 156.67 |
+| 4  | Ravenna-OH          | Smarties                      | 5/4 | 1415  | 157.22 |
+| 5  | Meriden-KS          | JAG Jaguars                   | 4/5 | 1280  | 142.22 |
+| 6  | Colorado Springs-CO | Knights of Christ             | 4/5 | 1095  | 121.67 |
+| 7  | Gloucester City-NJ  | CRK Almighty                  | 3/6 | 1335  | 148.33 |
+| 8  | Griffin-GA          | Griffin First Gospel Gang     | 3/6 | 1270  | 141.11 |
+| 9  | Collierville-TN     | Collierville Freedom Fighters | 3/6 | 1145  | 127.22 |
+| 10 | Sparta-WI           | Sparta                        | 2/7 | 885   | 98.33  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                | Church                        | Total | Avg    | QO |
+|---:|--------------------|---------------------|-------------------------------|------:|-------:|---:|
+| 1  | Samuel Broeker     | Overland Park-KS    | Coca-Cola Quizzers            | 965   | 107.22 | 4  |
+| 2  | Zane Brown         | Garland-TX          | Transformed                   | 885   | 98.33  | 5  |
+| 3  | Wesley Self        | Versailles-KY       | The J-Walkers                 | 880   | 97.78  | 4  |
+| 4  | Samuel Paul        | Collierville-TN     | Collierville Freedom Fighters | 750   | 83.33  | 2  |
+| 5  | Lyric Coker        | Griffin-GA          | Griffin First Gospel Gang     | 720   | 80.00  | 2  |
+| 6  | Cole Abbott        | Sparta-WI           | Sparta                        | 700   | 77.78  | 3  |
+| 7  | Caleb Shackelford  | Colorado Springs-CO | Knights of Christ             | 685   | 76.11  | 3  |
+| 8  | Alexis Carrozzi    | Ravenna-OH          | Smarties                      | 630   | 70.00  | 2  |
+| 9  | Josh Broxterman    | Meriden-KS          | JAG Jaguars                   | 535   | 59.44  | 2  |
+| 10 | Janelle Angeles    | Gloucester City-NJ  | CRK Almighty                  | 500   | 55.56  | 1  |
+| 11 | Good News Iwuamadi | Garland-TX          | Transformed                   | 470   | 52.22  | 5  |
+| 12 | Truett Van Slyke   | Overland Park-KS    | Coca-Cola Quizzers            | 445   | 49.44  | 7  |
+| 13 | Samuel Borja       | Gloucester City-NJ  | CRK Almighty                  | 420   | 46.67  |    |
+| 14 | Emily Sawastuk     | Ravenna-OH          | Smarties                      | 410   | 45.56  | 4  |
+| 15 | Ethan Shackelford  | Colorado Springs-CO | Knights of Christ             | 410   | 45.56  | 3  |
+| 16 | Cora Self          | Versailles-KY       | The J-Walkers                 | 410   | 45.56  | 2  |
+| 17 | Casey McDermitt    | Griffin-GA          | Griffin First Gospel Gang     | 400   | 44.44  |    |
+| 18 | Matthias Moore     | Meriden-KS          | JAG Jaguars                   | 390   | 43.33  | 3  |
+| 19 | Meleah Sawastuk    | Ravenna-OH          | Smarties                      | 300   | 33.33  |    |
+| 20 | Cameron Ramos      | Gloucester City-NJ  | CRK Almighty                  | 295   | 32.78  | 2  |
+| 21 | Olivia Lee         | Versailles-KY       | The J-Walkers                 | 255   | 28.33  | 1  |
+| 22 | Corban Stewart     | Collierville-TN     | Collierville Freedom Fighters | 225   | 25.00  | 2  |
+| 23 | Kamryn Kaniper     | Meriden-KS          | JAG Jaguars                   | 210   | 23.33  |    |
+| 24 | Amarachi Ayozie    | Garland-TX          | Transformed                   | 160   | 17.78  |    |
+| 25 | Sam Broxterman     | Meriden-KS          | JAG Jaguars                   | 145   | 16.11  |    |
+| 26 | Jocelyn Coker      | Griffin-GA          | Griffin First Gospel Gang     | 140   | 15.56  |    |
+| 27 | Corbin Frydenlund  | Sparta-WI           | Sparta                        | 105   | 11.67  |    |
+| 28 | Chi Chi Otah       | Garland-TX          | Transformed                   | 90    | 10.00  |    |
+| 29 | Joel Paul          | Collierville-TN     | Collierville Freedom Fighters | 85    | 9.44   |    |
+| 30 | Bryce Helgerson    | Sparta-WI           | Sparta                        | 75    | 8.33   |    |
+| 31 | Calista Gotos      | Gloucester City-NJ  | CRK Almighty                  | 70    | 7.78   |    |
+| 32 | Aubrey Carrozzi    | Ravenna-OH          | Smarties                      | 65    | 7.22   |    |
+| 33 | Eliana Lee         | Versailles-KY       | The J-Walkers                 | 60    | 6.67   |    |
+| 33 | Adalia Abinteh     | Collierville-TN     | Collierville Freedom Fighters | 60    | 6.67   |    |
+| 34 | Elijah Escobar     | Gloucester City-NJ  | CRK Almighty                  | 50    | 5.56   |    |
+| 35 | Josiah Murphy      | Collierville-TN     | Collierville Freedom Fighters | 25    | 2.78   |    |
+| 36 | Madelyn Grant      | Griffin-GA          | Griffin First Gospel Gang     | 10    | 1.11   |    |
+| 36 | Ashton Mearns      | Ravenna-OH          | Smarties                      | 10    | 1.11   |    |
+| 37 | Samantha Rowe      | Sparta-WI           | Sparta                        | 5     | .56    |    |
+| 38 | Josiah Broeker     | Overland Park-KS    | Coca-Cola Quizzers            |       | .00    |    |
+| 38 | Jacob Burke        | Sparta-WI           | Sparta                        |       | .00    |    |
+| 38 | Zechariah Broeker  | Overland Park-KS    | Coca-Cola Quizzers            |       | .00    |    |
+| 38 | Josiah Self        | Versailles-KY       | The J-Walkers                 |       | .00    |    |
+| 38 | Jiana Speir        | Griffin-GA          | Griffin First Gospel Gang     |       | .00    |    |
+
+
+### Tan (L7)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                  | Church                           | W/L | Total | Avg    |
+|---:|-----------------------|----------------------------------|-----|------:|-------:|
+| 1  | Irvine-CA             | OCCEC Eagles                     | 6/3 | 1525  | 169.44 |
+| 2  | Benton-AR             | Kung Fu Quizzers                 | 6/3 | 1440  | 160.00 |
+| 3  | Wilmingon-NC - White  | Wilmington Warriors White Swords | 6/3 | 1190  | 132.22 |
+| 4  | Bismarck-ND           | Power Up                         | 5/4 | 1380  | 153.33 |
+| 5  | Suwanee-GA            | Proventus Academy                | 5/4 | 1425  | 158.33 |
+| 6  | Waxahachie-TX         | En-Fuego                         | 4/5 | 1270  | 141.11 |
+| 7  | Oswego-KS             | God Girls                        | 4/5 | 1165  | 129.44 |
+| 8  | West Mifflin-PA       | Light Knights                    | 4/5 | 1015  | 112.78 |
+| 9  | Springfield-VA        | Swordbearers                     | 3/6 | 1185  | 131.67 |
+| 10 | Springfield -MO - Dau | Daughters of the King            | 2/7 | 1185  | 131.67 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                  | Church                           | Total | Avg    | QO |
+|---:|----------------------|-----------------------|----------------------------------|------:|-------:|---:|
+| 1  | Bobbie Barnes        | Benton-AR             | Kung Fu Quizzers                 | 930   | 103.33 | 4  |
+| 2  | Blake Garza          | Suwanee-GA            | Proventus Academy                | 825   | 91.67  | 4  |
+| 3  | Elizabeth Jones      | Springfield -MO - Dau | Daughters of the King            | 700   | 77.78  | 1  |
+| 4  | Brock Boehling       | Wilmingon-NC - White  | Wilmington Warriors White Swords | 645   | 71.67  | 3  |
+| 5  | Carter Garza         | Suwanee-GA            | Proventus Academy                | 605   | 67.22  | 2  |
+| 6  | Joy Escobar          | Waxahachie-TX         | En-Fuego                         | 595   | 66.11  | 1  |
+| 7  | Carmen Eisenbrandt   | Oswego-KS             | God Girls                        | 550   | 61.11  |    |
+| 8  | Ethan Sipes          | Bismarck-ND           | Power Up                         | 545   | 60.56  |    |
+| 9  | Jason Li             | Irvine-CA             | OCCEC Eagles                     | 480   | 53.33  | 4  |
+| 10 | Adalina Ma           | Irvine-CA             | OCCEC Eagles                     | 475   | 52.78  |    |
+| 11 | Raymond Harris       | West Mifflin-PA       | Light Knights                    | 465   | 51.67  |    |
+| 12 | Ismael Rodriguez     | Waxahachie-TX         | En-Fuego                         | 450   | 50.00  | 2  |
+| 13 | Annabel Tiong        | Irvine-CA             | OCCEC Eagles                     | 415   | 46.11  |    |
+| 14 | Cecillia Newby       | Oswego-KS             | God Girls                        | 380   | 42.22  | 1  |
+| 15 | Eric Bender          | Bismarck-ND           | Power Up                         | 350   | 38.89  |    |
+| 16 | Sedenia Dawit        | Springfield-VA        | Swordbearers                     | 330   | 36.67  | 1  |
+| 17 | Elijah Bohlen        | Bismarck-ND           | Power Up                         | 320   | 35.56  | 3  |
+| 18 | Levi Dawit           | Springfield-VA        | Swordbearers                     | 320   | 35.56  |    |
+| 19 | Corrie Lee Boehlinig | Wilmingon-NC - White  | Wilmington Warriors White Swords | 305   | 33.89  | 2  |
+| 20 | Kendra Winkleblech   | West Mifflin-PA       | Light Knights                    | 285   | 31.67  |    |
+| 21 | Bethel Dawit         | Springfield-VA        | Swordbearers                     | 265   | 29.44  | 2  |
+| 22 | Bittyn Glover        | Benton-AR             | Kung Fu Quizzers                 | 230   | 25.56  | 1  |
+| 23 | Rachel McDonald      | Wilmingon-NC - White  | Wilmington Warriors White Swords | 230   | 25.56  |    |
+| 24 | Hector Rivera        | Waxahachie-TX         | En-Fuego                         | 225   | 25.00  | 1  |
+| 25 | Delaney Reynolds     | Oswego-KS             | God Girls                        | 190   | 21.11  |    |
+| 26 | Hana Tariku          | Springfield-VA        | Swordbearers                     | 165   | 18.33  |    |
+| 27 | Shekinah Phelps      | Springfield -MO - Dau | Daughters of the King            | 160   | 17.78  | 1  |
+| 28 | Hannah Plake         | Springfield -MO - Dau | Daughters of the King            | 160   | 17.78  |    |
+| 28 | Anthony Raygoza      | West Mifflin-PA       | Light Knights                    | 160   | 17.78  |    |
+| 28 | Tyler Kelly          | Benton-AR             | Kung Fu Quizzers                 | 160   | 17.78  |    |
+| 29 | Abigail Jones        | Springfield -MO - Dau | Daughters of the King            | 155   | 17.22  | 1  |
+| 30 | Michele Zheng        | Irvine-CA             | OCCEC Eagles                     | 155   | 17.22  |    |
+| 31 | Ezekiel Bohlen       | Bismarck-ND           | Power Up                         | 150   | 16.67  | 1  |
+| 32 | Kimbre Earnest       | Benton-AR             | Kung Fu Quizzers                 | 120   | 13.33  |    |
+| 33 | Christian Dawit      | Springfield-VA        | Swordbearers                     | 110   | 12.22  |    |
+| 34 | Adrianna Raygoza     | West Mifflin-PA       | Light Knights                    | 105   | 11.67  |    |
+| 35 | Grace Noel           | Oswego-KS             | God Girls                        | 45    | 5.00   |    |
+| 36 | James Ragains        | Bismarck-ND           | Power Up                         | 15    | 1.67   |    |
+| 37 | Trinity Phelps       | Springfield -MO - Dau | Daughters of the King            | 10    | 1.11   |    |
+| 37 | Luke Ertzberger      | Wilmingon-NC - White  | Wilmington Warriors White Swords | 10    | 1.11   |    |
+| 38 | Carly McDonald       | Wilmingon-NC - White  | Wilmington Warriors White Swords |       | .00    |    |
+| 38 | Solomon Kefyalew     | Springfield-VA        | Swordbearers                     |       | .00    |    |
+| 38 | Daniel Solomon       | Springfield-VA        | Swordbearers                     |       | .00    |    |
+| 38 | Hannah Noel          | Oswego-KS             | God Girls                        |       | .00    |    |
+| 38 | Josh Moore           | West Mifflin-PA       | Light Knights                    |       | .00    |    |
+| 38 | Blen Hailu           | Springfield-VA        | Swordbearers                     |       | .00    |    |
+| 38 | Kacey Mayfield       | Oswego-KS             | God Girls                        |       | .00    |    |
+| 38 | Luke Shelton         | Wilmingon-NC - White  | Wilmington Warriors White Swords |       | .00    |    |
+| 38 | Jeweleann Davis      | Benton-AR             | Kung Fu Quizzers                 |       | .00    |    |
+| 38 | Chalice sanders      | Benton-AR             | Kung Fu Quizzers                 |       | .00    |    |
+| 38 | Lauren Green         | Benton-AR             | Kung Fu Quizzers                 |       | .00    |    |
+
+
+### Yellow (L8)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                     | Church                         | W/L | Total | Avg    |
+|---:|--------------------------|--------------------------------|-----|------:|-------:|
+| 1  | Mechanicsville-VA - Hope | Contagious Hope                | 7/2 | 1465  | 162.78 |
+| 2  | North Little Rock-AR     | Eagles                         | 6/3 | 1405  | 156.11 |
+| 3  | Las Vegas-NV             | Champion Center                | 6/3 | 1235  | 137.22 |
+| 4  | Racine-WI                | Racine Deeper Kids             | 5/4 | 1295  | 143.89 |
+| 5  | Rapid City-SD            | Sanctified Sisters             | 5/4 | 1290  | 143.33 |
+| 6  | Dumas-TX                 | Undignified                    | 5/4 | 1135  | 126.11 |
+| 7  | Montgomery-AL            | Montgomery 1st                 | 4/5 | 1355  | 150.56 |
+| 8  | Mustang-OK               | Blood Bought Brothers          | 4/5 | 1160  | 128.89 |
+| 9  | Mendon-MA                | CIA Special Agents             | 2/7 | 1080  | 120.00 |
+| 10 | Shreveport-LA            | Shreveport Bible Investigators | 1/8 | 710   | 78.89  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                     | Church                         | Total | Avg    | QO |
+|---:|--------------------|--------------------------|--------------------------------|------:|-------:|---:|
+| 1  | Jacob Blackburn    | North Little Rock-AR     | Eagles                         | 965   | 107.22 | 5  |
+| 2  | Angelia Whitfield  | Mechanicsville-VA - Hope | Contagious Hope                | 855   | 95.00  | 3  |
+| 3  | Annie Akins        | Dumas-TX                 | Undignified                    | 820   | 91.11  | 3  |
+| 4  | Kevin Sowers       | Montgomery-AL            | Montgomery 1st                 | 610   | 67.78  | 2  |
+| 5  | Cate Wilhelm       | Rapid City-SD            | Sanctified Sisters             | 585   | 65.00  |    |
+| 6  | Ariana Klein       | Racine-WI                | Racine Deeper Kids             | 540   | 60.00  | 2  |
+| 7  | Isaac Erickson     | Shreveport-LA            | Shreveport Bible Investigators | 495   | 55.00  | 1  |
+| 8  | Michelle Vannelli  | Mendon-MA                | CIA Special Agents             | 490   | 54.44  |    |
+| 8  | Lizzie Biek        | Las Vegas-NV             | Champion Center                | 490   | 54.44  |    |
+| 9  | Sam David          | Racine-WI                | Racine Deeper Kids             | 485   | 53.89  | 2  |
+| 10 | John Hamel         | Mendon-MA                | CIA Special Agents             | 445   | 49.44  | 3  |
+| 11 | Ayden Rush         | Mustang-OK               | Blood Bought Brothers          | 415   | 46.11  | 5  |
+| 12 | Elijah Hicks       | Las Vegas-NV             | Champion Center                | 410   | 45.56  |    |
+| 13 | Hannah Hall        | North Little Rock-AR     | Eagles                         | 385   | 42.78  | 2  |
+| 14 | Josh Rose          | Mustang-OK               | Blood Bought Brothers          | 385   | 42.78  |    |
+| 15 | Ryan Astorga       | Montgomery-AL            | Montgomery 1st                 | 365   | 40.56  | 4  |
+| 16 | Gracee Langstaff   | Rapid City-SD            | Sanctified Sisters             | 365   | 40.56  | 2  |
+| 17 | Jett King          | Mustang-OK               | Blood Bought Brothers          | 360   | 40.00  |    |
+| 18 | M\'Kayla McDaniel  | Dumas-TX                 | Undignified                    | 315   | 35.00  | 1  |
+| 19 | Sieanna Sowers     | Montgomery-AL            | Montgomery 1st                 | 285   | 31.67  |    |
+| 20 | Amelia Stieb       | Las Vegas-NV             | Champion Center                | 270   | 30.00  | 1  |
+| 21 | Britt Adams        | Mechanicsville-VA - Hope | Contagious Hope                | 240   | 26.67  | 1  |
+| 22 | Seth Christopher   | Mechanicsville-VA - Hope | Contagious Hope                | 190   | 21.11  |    |
+| 23 | Anna Ligtenberg    | Rapid City-SD            | Sanctified Sisters             | 180   | 20.00  |    |
+| 24 | Justice Glassgow   | Rapid City-SD            | Sanctified Sisters             | 160   | 17.78  | 1  |
+| 25 | Mckenna Walker     | Racine-WI                | Racine Deeper Kids             | 140   | 15.56  |    |
+| 26 | Braden Tew         | Shreveport-LA            | Shreveport Bible Investigators | 135   | 15.00  | 1  |
+| 27 | Caitlyn Jackson    | Racine-WI                | Racine Deeper Kids             | 130   | 14.44  |    |
+| 28 | Angel Walker       | Mechanicsville-VA - Hope | Contagious Hope                | 110   | 12.22  |    |
+| 29 | Travis Leavitt     | Las Vegas-NV             | Champion Center                | 105   | 11.67  | 1  |
+| 30 | Melany Ravitz      | Mendon-MA                | CIA Special Agents             | 80    | 8.89   |    |
+| 31 | Skylor Astorga     | Montgomery-AL            | Montgomery 1st                 | 75    | 8.33   |    |
+| 32 | Savannah Harper    | Mechanicsville-VA - Hope | Contagious Hope                | 70    | 7.78   |    |
+| 33 | Savannah Stricklin | North Little Rock-AR     | Eagles                         | 45    | 5.00   |    |
+| 33 | Caroline Tew       | Shreveport-LA            | Shreveport Bible Investigators | 45    | 5.00   |    |
+| 34 | Ethan Paredes      | Shreveport-LA            | Shreveport Bible Investigators | 40    | 4.44   |    |
+| 35 | Riley Longacre     | Mendon-MA                | CIA Special Agents             | 35    | 3.89   |    |
+| 36 | Hayden Monti       | Mendon-MA                | CIA Special Agents             | 30    | 3.33   |    |
+| 37 | Peyton Shuffitt    | Montgomery-AL            | Montgomery 1st                 | 20    | 2.22   |    |
+| 38 | Aliyah Gibson      | North Little Rock-AR     | Eagles                         | 10    | 1.11   |    |
+| 39 | Arielle Erickson   | Shreveport-LA            | Shreveport Bible Investigators |       | .00    |    |
+| 39 | Jayda Butts        | Rapid City-SD            | Sanctified Sisters             |       | .00    |    |
+| 39 | Maddie Higgins     | North Little Rock-AR     | Eagles                         |       | .00    |    |
+| 39 | Kylee Hicks        | Las Vegas-NV             | Champion Center                |       | .00    |    |
+| 40 | Talayeh Rush       | Las Vegas-NV             | Champion Center                | -25   | -2.78  |    |
+| 41 | Tru Young          | Las Vegas-NV             | Champion Center                | -15   | -1.67  |    |
+| 42 | Isabelle Erickson  | Shreveport-LA            | Shreveport Bible Investigators | -5    | -0.56  |    |
+

--- a/_pages/jbq/2016/index.md
+++ b/_pages/jbq/2016/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2016 JBQ Season"
+permalink: /jbq/2016/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+<a href="{% link _pages/jbq/2016/nationals.md %}" class="button is-primary">National Finals</a>
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2016/nationals.md
+++ b/_pages/jbq/2016/nationals.md
@@ -1,0 +1,1131 @@
+---
+layout: page
+title: "2016 National Festival: Kansas City, MO"
+permalink: /jbq/2016/nationals/
+date: "2017-05-17"
+toc_title: Results
+menubar_toc: true
+---
+
+## Friday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                           | Church             | W/L  | Total | Avg    |
+|---:|--------------------------------|--------------------|------|------:|-------:|
+| 1  | Jewels for Jesus               | Springfield, MO    | 14/1 | 2900  | 193.33 |
+| 2  | Fluffy Panda Quizzers          | Gahanna, OH        | 11/4 | 2635  | 175.67 |
+| 3  | Askewville Hashtags            | Askewville, NC     | 10/5 | 2785  | 185.67 |
+| 4  | Naperville (C)                 | Naperville, IL     | 10/5 | 2760  | 184.00 |
+| 5  | God\'s Incredibles             | Lakeville, MN      | 9/6  | 2480  | 165.33 |
+| 6  | Transformed                    | Garland, TX        | 9/6  | 2360  | 157.33 |
+| 7  | HRQ-Holy Righteous Quizzers    | Brookfield, WI     | 9/6  | 2180  | 145.33 |
+| 8  | S.P.Y. Kids                    | Leesburg, VA       | 8/7  | 2215  | 147.67 |
+| 9  | Glow Kids                      | San Antonio, TX    | 8/7  | 2175  | 145.00 |
+| 10 | The Dream Team                 | Phoenix, AZ        | 7/8  | 1955  | 130.33 |
+| 11 | Lawson - Chad                  | Lawson, MO         | 7/8  | 2065  | 137.67 |
+| 12 | 4 girls \'n the Houde          | Billings, MT       | 6/9  | 2020  | 134.67 |
+| 13 | Highpoint Quizzers             | Port St. Lucie, FL | 4/11 | 1580  | 105.33 |
+| 14 | Shreveport Bible Investigators | Shreveport, LA     | 3/12 | 1545  | 103.00 |
+| 15 | Champion Quizzers              | Las Vegas, NV      | 3/12 | 1205  | 80.33  |
+| 16 | Webster                        | Webster, NY        | 2/13 | 1505  | 100.33 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                           | Church             | Total | Avg    | QO |
+|---:|------------------------|--------------------------------|--------------------|------:|-------:|---:|
+| 1  | Elizabeth Jones        | Jewels for Jesus               | Springfield, MO    | 1730  | 115.33 | 7  |
+| 2  | Micah Hill             | Askewville Hashtags            | Askewville, NC     | 1720  | 114.67 | 8  |
+| 3  | Zane Brown             | Transformed                    | Garland, TX        | 1545  | 103.00 | 8  |
+| 4  | Isabella Kashubin      | God\'s Incredibles             | Lakeville, MN      | 1370  | 91.33  | 4  |
+| 5  | Micah Houde            | 4 girls \'n the Houde          | Billings, MT       | 1315  | 87.67  | 5  |
+| 6  | Miles Kastner          | HRQ-Holy Righteous Quizzers    | Brookfield, WI     | 1175  | 78.33  | 4  |
+| 7  | Jadyn Laila Thomas     | Glow Kids                      | San Antonio, TX    | 1165  | 77.67  | 3  |
+| 8  | Stephen Bough          | Naperville (C)                 | Naperville, IL     | 1150  | 76.67  | 11 |
+| 9  | Sammy Mair             | Fluffy Panda Quizzers          | Gahanna, OH        | 1130  | 75.33  | 3  |
+| 10 | Seth Archer            | Lawson - Chad                  | Lawson, MO         | 1125  | 75.00  | 6  |
+| 11 | Isaac Erickson         | Shreveport Bible Investigators | Shreveport, LA     | 1090  | 72.67  | 3  |
+| 12 | Nick Odle              | Webster                        | Webster, NY        | 1075  | 71.67  | 3  |
+| 13 | David Biruduganti      | Naperville (C)                 | Naperville, IL     | 1055  | 70.33  | 4  |
+| 14 | Abel Karthik           | Fluffy Panda Quizzers          | Gahanna, OH        | 1000  | 66.67  | 2  |
+| 15 | Phillip Bozzay         | S.P.Y. Kids                    | Leesburg, VA       | 990   | 66.00  | 3  |
+| 16 | Taylen Manns           | Lawson - Chad                  | Lawson, MO         | 900   | 60.00  | 9  |
+| 17 | PJ Ball                | Highpoint Quizzers             | Port St. Lucie, FL | 845   | 56.33  | 3  |
+| 18 | Aradhana SatheeshKumar | The Dream Team                 | Phoenix, AZ        | 720   | 48.00  | 1  |
+| 19 | Elijah Hicks           | Champion Quizzers              | Las Vegas, NV      | 720   | 48.00  |    |
+| 20 | Isaiah Kashubin        | God\'s Incredibles             | Lakeville, MN      | 710   | 47.33  | 7  |
+| 21 | Shekinah Phelps        | Jewels for Jesus               | Springfield, MO    | 690   | 46.00  | 8  |
+| 22 | Samuel Otchere         | S.P.Y. Kids                    | Leesburg, VA       | 670   | 44.67  | 1  |
+| 23 | Abhishek SatheeshKumar | The Dream Team                 | Phoenix, AZ        | 660   | 44.00  | 7  |
+| 24 | Tyler Trexler          | The Dream Team                 | Phoenix, AZ        | 575   | 38.33  |    |
+| 25 | Haven Hoggard          | Askewville Hashtags            | Askewville, NC     | 540   | 36.00  | 3  |
+| 26 | Liana Rachel Thomas    | Glow Kids                      | San Antonio, TX    | 510   | 34.00  | 1  |
+| 27 | Caleb Karthik          | Fluffy Panda Quizzers          | Gahanna, OH        | 505   | 33.67  | 5  |
+| 28 | Caris Marie Thomas     | Glow Kids                      | San Antonio, TX    | 475   | 31.67  | 3  |
+| 29 | Todimu Afolayan        | HRQ-Holy Righteous Quizzers    | Brookfield, WI     | 470   | 31.33  | 4  |
+| 30 | Faithful Iwuamadi      | Transformed                    | Garland, TX        | 440   | 29.33  |    |
+| 31 | Eliana Bazemore        | Askewville Hashtags            | Askewville, NC     | 425   | 28.33  | 2  |
+| 32 | Nevaeh Walker          | 4 girls \'n the Houde          | Billings, MT       | 380   | 25.33  | 2  |
+| 33 | Eden Castro            | Highpoint Quizzers             | Port St. Lucie, FL | 380   | 25.33  |    |
+| 34 | Jacob Kashuba          | God\'s Incredibles             | Lakeville, MN      | 365   | 24.33  |    |
+| 35 | Abby Jones             | Jewels for Jesus               | Springfield, MO    | 320   | 21.33  |    |
+| 36 | Conner Haddaway        | S.P.Y. Kids                    | Leesburg, VA       | 315   | 21.00  | 4  |
+| 37 | Samuel Biruduganti     | Naperville (C)                 | Naperville, IL     | 300   | 20.00  | 1  |
+| 38 | Elizabeth Murray       | HRQ-Holy Righteous Quizzers    | Brookfield, WI     | 300   | 20.00  |    |
+| 39 | Travis Leavitt         | Champion Quizzers              | Las Vegas, NV      | 280   | 18.67  | 2  |
+| 40 | Addison Odle           | Webster                        | Webster, NY        | 275   | 18.33  | 1  |
+| 41 | Reagan Stevens         | Naperville (C)                 | Naperville, IL     | 255   | 17.00  |    |
+| 42 | Michael Ikechukwu      | Transformed                    | Garland, TX        | 240   | 16.00  | 2  |
+| 43 | Aaliyah Landers        | 4 girls \'n the Houde          | Billings, MT       | 240   | 16.00  |    |
+| 43 | Alexis Wilson          | Highpoint Quizzers             | Port St. Lucie, FL | 240   | 16.00  |    |
+| 44 | Caroline Tew           | Shreveport Bible Investigators | Shreveport, LA     | 200   | 13.33  |    |
+| 45 | Braden Tew             | Shreveport Bible Investigators | Shreveport, LA     | 180   | 12.00  | 1  |
+| 46 | Isaiah Delaney         | HRQ-Holy Righteous Quizzers    | Brookfield, WI     | 165   | 11.00  | 1  |
+| 47 | Trinity Phelps         | Jewels for Jesus               | Springfield, MO    | 160   | 10.67  |    |
+| 48 | Luke Odle              | Webster                        | Webster, NY        | 155   | 10.33  |    |
+| 49 | Tru Young              | Champion Quizzers              | Las Vegas, NV      | 145   | 9.67   |    |
+| 50 | Chi Chi Otah           | Transformed                    | Garland, TX        | 135   | 9.00   |    |
+| 50 | Gracelyn Daniel        | S.P.Y. Kids                    | Leesburg, VA       | 135   | 9.00   |    |
+| 51 | David Freitas          | Highpoint Quizzers             | Port St. Lucie, FL | 115   | 7.67   |    |
+| 52 | Hannah Judd            | S.P.Y. Kids                    | Leesburg, VA       | 105   | 7.00   |    |
+| 53 | Lynsey Bazemore        | Askewville Hashtags            | Askewville, NC     | 100   | 6.67   |    |
+| 54 | Ethan Paredes          | Shreveport Bible Investigators | Shreveport, LA     | 80    | 5.33   |    |
+| 55 | Hannah Murray          | HRQ-Holy Righteous Quizzers    | Brookfield, WI     | 70    | 4.67   |    |
+| 56 | Brooke Bentz           | 4 girls \'n the Houde          | Billings, MT       | 60    | 4.00   |    |
+| 56 | KyLee Hicks            | Champion Quizzers              | Las Vegas, NV      | 60    | 4.00   |    |
+| 57 | Jadyn Archer           | Lawson - Chad                  | Lawson, MO         | 40    | 2.67   |    |
+| 58 | Lily Robinson          | 4 girls \'n the Houde          | Billings, MT       | 30    | 2.00   |    |
+| 59 | Mabry Haley            | Glow Kids                      | San Antonio, TX    | 25    | 1.67   |    |
+| 59 | Jason Fry              | God\'s Incredibles             | Lakeville, MN      | 25    | 1.67   |    |
+| 60 | Brandon Schommer       | God\'s Incredibles             | Lakeville, MN      | 10    | .67    |    |
+| 61 | Lizzie Biek            | Champion Quizzers              | Las Vegas, NV      |       | .00    |    |
+| 61 | Brenda Light           | Fluffy Panda Quizzers          | Gahanna, OH        |       | .00    |    |
+| 61 | Brookleyn Light        | Fluffy Panda Quizzers          | Gahanna, OH        |       | .00    |    |
+| 61 | Amelia Stieb           | Champion Quizzers              | Las Vegas, NV      |       | .00    |    |
+| 61 | Kyle Bryant            | Shreveport Bible Investigators | Shreveport, LA     |       | .00    |    |
+| 61 | Leah Hodge             | S.P.Y. Kids                    | Leesburg, VA       |       | .00    |    |
+| 61 | London Hamilton        | Shreveport Bible Investigators | Shreveport, LA     |       | .00    |    |
+| 61 | Jacob Coffey           | Highpoint Quizzers             | Port St. Lucie, FL |       | .00    |    |
+| 61 | Arielle Erickson       | Shreveport Bible Investigators | Shreveport, LA     |       | .00    |    |
+| 61 | Gabriel Otchere        | S.P.Y. Kids                    | Leesburg, VA       |       | .00    |    |
+| 61 | James Bozzay           | S.P.Y. Kids                    | Leesburg, VA       |       | .00    |    |
+| 61 | Isabelle Erickson      | Shreveport Bible Investigators | Shreveport, LA     |       | .00    |    |
+| 61 | Emma Lovejoy           | Highpoint Quizzers             | Port St. Lucie, FL |       | .00    |    |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                         | Church                | W/L  | Total | Avg    |
+|---:|------------------------------|-----------------------|------|------:|-------:|
+| 1  | Wilmington Warriors          | Wilmington, NC        | 13/2 | 2595  | 173.00 |
+| 2  | Contagious Havoc             | Mechanicsville, VA    | 13/2 | 2565  | 171.00 |
+| 3  | God\'s Mighty Warriors       | Milwaukee, WI         | 11/4 | 2760  | 184.00 |
+| 4  | Knights 4 Christ - Salvation | Monmouth Junction, NJ | 10/5 | 2560  | 170.67 |
+| 5  | The Chosen Ones              | Houston, TX           | 9/6  | 2340  | 156.00 |
+| 6  | Souled Out                   | San Jose, CA          | 9/6  | 2495  | 166.33 |
+| 7  | Naperville (D)               | Naperville, IL        | 8/7  | 2505  | 167.00 |
+| 8  | 360 Quizzers                 | Springfield, MO       | 8/7  | 2470  | 164.67 |
+| 8  | Kung Fu Quizzers             | Benton, AR            | 8/7  | 2470  | 164.67 |
+| 9  | Mighty Minions               | Cedar Hill, TX        | 7/8  | 2415  | 161.00 |
+| 10 | Minecraft Bible Builders     | Fortville, IN         | 7/8  | 2275  | 151.67 |
+| 11 | Kinetic Konnection           | Bismarck, ND          | 7/8  | 2075  | 138.33 |
+| 12 | Westminster Warriors         | Westminster, CA       | 4/11 | 1600  | 106.67 |
+| 13 | Parkway Christian Center     | Grants Pass, OR       | 3/12 | 1605  | 107.00 |
+| 14 | Heroes of Faith              | Orlando, FL           | 2/13 | 1470  | 98.00  |
+| 15 | Mount Hope Burlington        | Burlington, MA        | 1/14 | 1295  | 86.33  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                         | Church                | Total | Avg    | QO |
+|---:|----------------------|------------------------------|-----------------------|------:|-------:|---:|
+| 1  | Gabi Acevedo         | God\'s Mighty Warriors       | Milwaukee, WI         | 1865  | 124.33 | 10 |
+| 2  | Bobbie Barnes        | Kung Fu Quizzers             | Benton, AR            | 1745  | 116.33 | 8  |
+| 3  | Samuel Jebaraj       | Souled Out                   | San Jose, CA          | 1690  | 112.67 | 12 |
+| 4  | Braden Adams         | Contagious Havoc             | Mechanicsville, VA    | 1625  | 108.33 | 6  |
+| 5  | Cameron Ramsey       | 360 Quizzers                 | Springfield, MO       | 1540  | 102.67 | 8  |
+| 6  | Remi Brigilin        | Knights 4 Christ - Salvation | Monmouth Junction, NJ | 1315  | 87.67  | 3  |
+| 7  | Shawn Timothy        | Naperville (D)               | Naperville, IL        | 1195  | 79.67  | 4  |
+| 8  | Justiss Silas        | Naperville (D)               | Naperville, IL        | 1120  | 74.67  | 11 |
+| 9  | Michael Ukonu        | The Chosen Ones              | Houston, TX           | 1095  | 73.00  | 3  |
+| 10 | Zachary Leake        | Wilmington Warriors          | Wilmington, NC        | 1080  | 72.00  | 1  |
+| 11 | Noah Claunch         | Mighty Minions               | Cedar Hill, TX        | 1060  | 70.67  | 8  |
+| 12 | Adeline Keith        | Mighty Minions               | Cedar Hill, TX        | 1020  | 68.00  | 2  |
+| 13 | Hans Holzhausen      | Minecraft Bible Builders     | Fortville, IN         | 1015  | 67.67  | 2  |
+| 14 | David Schoening      | Westminster Warriors         | Westminster, CA       | 1010  | 67.33  | 3  |
+| 15 | Colton Doling        | Heroes of Faith              | Orlando, FL           | 865   | 57.67  | 5  |
+| 16 | Eric Bender          | Kinetic Konnection           | Bismarck, ND          | 845   | 56.33  | 2  |
+| 17 | Will Rittenhouse     | Contagious Havoc             | Mechanicsville, VA    | 805   | 53.67  | 7  |
+| 18 | Mark Orth            | Minecraft Bible Builders     | Fortville, IN         | 735   | 49.00  | 8  |
+| 19 | Brittyn Glover       | Kung Fu Quizzers             | Benton, AR            | 670   | 44.67  | 7  |
+| 20 | Brock Boehling       | Wilmington Warriors          | Wilmington, NC        | 630   | 42.00  | 1  |
+| 21 | Izabella Hendy       | Parkway Christian Center     | Grants Pass, OR       | 605   | 40.33  | 1  |
+| 22 | Daniel Tadigiri      | Mount Hope Burlington        | Burlington, MA        | 580   | 38.67  | 1  |
+| 23 | Ethan Sipes          | Kinetic Konnection           | Bismarck, ND          | 580   | 38.67  |    |
+| 24 | Brandon Ukonu        | The Chosen Ones              | Houston, TX           | 575   | 38.33  | 5  |
+| 25 | Kaitlin Slottke      | God\'s Mighty Warriors       | Milwaukee, WI         | 510   | 34.00  | 6  |
+| 26 | Elijah Bohlen        | Kinetic Konnection           | Bismarck, ND          | 510   | 34.00  | 5  |
+| 27 | Jason Theodore       | Knights 4 Christ - Salvation | Monmouth Junction, NJ | 510   | 34.00  | 1  |
+| 28 | Logan Orth           | Minecraft Bible Builders     | Fortville, IN         | 500   | 33.33  |    |
+| 29 | Kaitlyn Ramsey       | 360 Quizzers                 | Springfield, MO       | 495   | 33.00  | 3  |
+| 30 | Luke shelton         | Wilmington Warriors          | Wilmington, NC        | 475   | 31.67  | 4  |
+| 31 | Sarah Wiltrout       | Parkway Christian Center     | Grants Pass, OR       | 475   | 31.67  | 2  |
+| 32 | Keren Godson         | Souled Out                   | San Jose, CA          | 445   | 29.67  |    |
+| 33 | Danny Dominic        | Knights 4 Christ - Salvation | Monmouth Junction, NJ | 420   | 28.00  |    |
+| 34 | Ariel Tucker         | Heroes of Faith              | Orlando, FL           | 385   | 25.67  |    |
+| 35 | Jesse King           | Mount Hope Burlington        | Burlington, MA        | 375   | 25.00  | 2  |
+| 36 | William Adu-Gyamfi   | The Chosen Ones              | Houston, TX           | 360   | 24.00  |    |
+| 37 | Freya Brigilin       | Knights 4 Christ - Salvation | Monmouth Junction, NJ | 315   | 21.00  | 1  |
+| 38 | Iyanu Akanbi         | The Chosen Ones              | Houston, TX           | 310   | 20.67  |    |
+| 39 | Nathan Wiltrout      | Parkway Christian Center     | Grants Pass, OR       | 290   | 19.33  |    |
+| 40 | Jebi Sukumar         | Souled Out                   | San Jose, CA          | 285   | 19.00  | 1  |
+| 41 | Kora Beth witzenman  | Wilmington Warriors          | Wilmington, NC        | 280   | 18.67  | 1  |
+| 41 | Alyssa Ramsey        | 360 Quizzers                 | Springfield, MO       | 280   | 18.67  | 1  |
+| 42 | Joseph Barajas       | Mighty Minions               | Cedar Hill, TX        | 275   | 18.33  |    |
+| 43 | Michelle Muddasu     | Mount Hope Burlington        | Burlington, MA        | 260   | 17.33  |    |
+| 44 | Emersyn VanderVoort  | Westminster Warriors         | Westminster, CA       | 230   | 15.33  |    |
+| 45 | Zeke DeGeyter        | Parkway Christian Center     | Grants Pass, OR       | 225   | 15.00  |    |
+| 46 | Daniel Kyzer         | God\'s Mighty Warriors       | Milwaukee, WI         | 220   | 14.67  | 1  |
+| 47 | McKinley Stevens     | Naperville (D)               | Naperville, IL        | 190   | 12.67  |    |
+| 47 | Neyssia Feria        | Westminster Warriors         | Westminster, CA       | 190   | 12.67  |    |
+| 48 | Jonathan Schoening   | Westminster Warriors         | Westminster, CA       | 170   | 11.33  |    |
+| 49 | Catie Wolfe          | 360 Quizzers                 | Springfield, MO       | 155   | 10.33  |    |
+| 50 | Hailey Spence        | Heroes of Faith              | Orlando, FL           | 145   | 9.67   |    |
+| 51 | Hannah Bohlen        | Kinetic Konnection           | Bismarck, ND          | 140   | 9.33   |    |
+| 52 | Britt Adams          | Contagious Havoc             | Mechanicsville, VA    | 125   | 8.33   | 1  |
+| 53 | Zach Weidner         | God\'s Mighty Warriors       | Milwaukee, WI         | 105   | 7.00   |    |
+| 54 | Alayna Boy           | Heroes of Faith              | Orlando, FL           | 75    | 5.00   |    |
+| 54 | Jeremiah Godson      | Souled Out                   | San Jose, CA          | 75    | 5.00   |    |
+| 55 | Rachel McDonald      | Wilmington Warriors          | Wilmington, NC        | 70    | 4.67   |    |
+| 56 | Ronnie Slottke       | God\'s Mighty Warriors       | Milwaukee, WI         | 60    | 4.00   |    |
+| 56 | Joel Indipiginja     | Mount Hope Burlington        | Burlington, MA        | 60    | 4.00   |    |
+| 56 | Madison Claunch      | Mighty Minions               | Cedar Hill, TX        | 60    | 4.00   |    |
+| 57 | Anna Scott witzenman | Wilmington Warriors          | Wilmington, NC        | 50    | 3.33   |    |
+| 58 | Caden Sanders        | Kung Fu Quizzers             | Benton, AR            | 35    | 2.33   |    |
+| 59 | Keira Orth           | Minecraft Bible Builders     | Fortville, IN         | 25    | 1.67   |    |
+| 60 | Madison Weir         | Mount Hope Burlington        | Burlington, MA        | 20    | 1.33   |    |
+| 61 | Andee Ernest         | Kung Fu Quizzers             | Benton, AR            | 10    | .67    |    |
+| 61 | Olivia Moore         | Kung Fu Quizzers             | Benton, AR            | 10    | .67    |    |
+| 61 | Aaron Barlow         | Parkway Christian Center     | Grants Pass, OR       | 10    | .67    |    |
+| 61 | Angel Walker         | Contagious Havoc             | Mechanicsville, VA    | 10    | .67    |    |
+| 61 | Corrie lee Boehling  | Wilmington Warriors          | Wilmington, NC        | 10    | .67    |    |
+| 62 | Noah Sanders         | Kung Fu Quizzers             | Benton, AR            |       | .00    |    |
+| 62 | Jace White           | Mighty Minions               | Cedar Hill, TX        |       | .00    |    |
+| 62 | Joy Holzhausen       | Minecraft Bible Builders     | Fortville, IN         |       | .00    |    |
+| 62 | Kaia Orth            | Minecraft Bible Builders     | Fortville, IN         |       | .00    |    |
+| 62 | Darla Holzhausen     | Minecraft Bible Builders     | Fortville, IN         |       | .00    |    |
+| 62 | Elijah Lee           | Mighty Minions               | Cedar Hill, TX        |       | .00    |    |
+| 62 | Lauren Green         | Kung Fu Quizzers             | Benton, AR            |       | .00    |    |
+| 62 | Julia Loven          | Kinetic Konnection           | Bismarck, ND          |       | .00    |    |
+| 62 | Carley McDonald      | Wilmington Warriors          | Wilmington, NC        |       | .00    |    |
+| 62 | Brody Acra           | Minecraft Bible Builders     | Fortville, IN         |       | .00    |    |
+| 62 | Isaac Davenport      | Mighty Minions               | Cedar Hill, TX        |       | .00    |    |
+| 62 | Hannah Fry           | Westminster Warriors         | Westminster, CA       |       | .00    |    |
+| 62 | McKenna Black        | 360 Quizzers                 | Springfield, MO       |       | .00    |    |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                           | Church                | W/L  | Total | Avg    |
+|---:|--------------------------------|-----------------------|------|------:|-------:|
+| 1  | Naperville                     | Naperville, IL        | 13/2 | 3105  | 207.00 |
+| 2  | Knights 4 Christ- Faith        | Monmouth Junction, NJ | 10/5 | 2430  | 162.00 |
+| 3  | The Parable of 2 Boys & a Girl | Lakeland, FL          | 10/5 | 2650  | 176.67 |
+| 4  | Agents of the Shield           | Omaha, NE             | 9/6  | 2230  | 148.67 |
+| 5  | Gospel Girls                   | Rogers, AR            | 9/6  | 2185  | 145.67 |
+| 6  | Gushers                        | Bristow, VA           | 8/7  | 2485  | 165.67 |
+| 7  | Heart of a Lion                | Angleton, TX          | 8/7  | 2370  | 158.00 |
+| 8  | Sparta                         | Sparta, WI            | 8/7  | 2050  | 136.67 |
+| 9  | Lightning Quizzers             | Springfield, MO       | 8/7  | 2010  | 134.00 |
+| 10 | God\'s Girls                   | Oswego, KS            | 7/8  | 2200  | 146.67 |
+| 11 | FBI                            | Tucson, AZ            | 7/8  | 2250  | 150.00 |
+| 12 | Catching Fire                  | Montgomery, AL        | 6/9  | 2005  | 133.67 |
+| 13 | Dancing Disciples              | Fort Wayne, IN        | 6/9  | 1945  | 129.67 |
+| 14 | The Awakening Force            | Novi, MI              | 6/9  | 1755  | 117.00 |
+| 15 | Griffin First Gospel Gang      | Griffin, GA           | 4/11 | 1845  | 123.00 |
+| 16 | God\'s Property                | Riverside, CA         | 1/14 | 890   | 59.33  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                           | Church                | Total | Avg    | QO |
+|---:|--------------------|--------------------------------|-----------------------|------:|-------:|---:|
+| 1  | Sheldon Powell     | Naperville                     | Naperville, IL        | 1750  | 116.67 | 12 |
+| 2  | Hannah Alapati     | Heart of a Lion                | Angleton, TX          | 1700  | 113.33 | 7  |
+| 3  | MacKenzie Wright   | The Parable of 2 Boys & a Girl | Lakeland, FL          | 1555  | 103.67 | 3  |
+| 4  | Sydney Shockley    | Gospel Girls                   | Rogers, AR            | 1495  | 99.67  | 7  |
+| 5  | Nathaniel Jebaraj  | Knights 4 Christ- Faith        | Monmouth Junction, NJ | 1425  | 95.00  | 6  |
+| 6  | Cole Abbott        | Sparta                         | Sparta, WI            | 1250  | 83.33  | 6  |
+| 7  | Hannah Plake       | Lightning Quizzers             | Springfield, MO       | 1175  | 78.33  | 6  |
+| 8  | Max Ortega         | FBI                            | Tucson, AZ            | 1075  | 71.67  | 1  |
+| 9  | Kevin Sowers       | Catching Fire                  | Montgomery, AL        | 1070  | 71.33  | 3  |
+| 10 | Shaymis Powell     | Naperville                     | Naperville, IL        | 930   | 62.00  | 12 |
+| 11 | Marjorie Ehrman    | Dancing Disciples              | Fort Wayne, IN        | 870   | 58.00  | 8  |
+| 12 | Ellen Smith        | Gushers                        | Bristow, VA           | 870   | 58.00  | 3  |
+| 13 | Cavan McIntyre     | The Awakening Force            | Novi, MI              | 805   | 53.67  | 3  |
+| 14 | Charlotte Elliott  | Agents of the Shield           | Omaha, NE             | 770   | 51.33  | 3  |
+| 15 | Jiana Speir        | Griffin First Gospel Gang      | Griffin, GA           | 770   | 51.33  | 1  |
+| 16 | Iakona Fern        | Agents of the Shield           | Omaha, NE             | 745   | 49.67  | 5  |
+| 17 | Tinley Boysen      | Gospel Girls                   | Rogers, AR            | 690   | 46.00  | 6  |
+| 18 | Christian Alapati  | Heart of a Lion                | Angleton, TX          | 670   | 44.67  | 5  |
+| 19 | Casey McDermitt    | Griffin First Gospel Gang      | Griffin, GA           | 660   | 44.00  | 2  |
+| 20 | Joel Ravela        | The Parable of 2 Boys & a Girl | Lakeland, FL          | 655   | 43.67  | 3  |
+| 21 | Wubitu Ehrman      | Dancing Disciples              | Fort Wayne, IN        | 655   | 43.67  |    |
+| 22 | Carmen Eisenbrandt | God\'s Girls                   | Oswego, KS            | 650   | 43.33  | 1  |
+| 23 | Audrey Mason       | Gushers                        | Bristow, VA           | 645   | 43.00  | 5  |
+| 24 | Cecillia Newby     | God\'s Girls                   | Oswego, KS            | 630   | 42.00  |    |
+| 25 | Anthony Diaz       | FBI                            | Tucson, AZ            | 620   | 41.33  | 2  |
+| 26 | Samuel Jebaraj     | Knights 4 Christ- Faith        | Monmouth Junction, NJ | 595   | 39.67  | 7  |
+| 27 | Grace Bassey       | God\'s Property                | Riverside, CA         | 595   | 39.67  | 3  |
+| 28 | Grace Noel         | God\'s Girls                   | Oswego, KS            | 560   | 37.33  | 5  |
+| 29 | Abigail Yatooma    | The Awakening Force            | Novi, MI              | 555   | 37.00  | 1  |
+| 30 | Elli Woodward      | Lightning Quizzers             | Springfield, MO       | 540   | 36.00  | 3  |
+| 31 | Fionette Fefe King | Gushers                        | Bristow, VA           | 510   | 34.00  |    |
+| 32 | Lademi Davies      | Agents of the Shield           | Omaha, NE             | 460   | 30.67  |    |
+| 33 | Peyton Shuffitt    | Catching Fire                  | Montgomery, AL        | 450   | 30.00  |    |
+| 34 | Cristina Gonzalez  | Catching Fire                  | Montgomery, AL        | 445   | 29.67  | 1  |
+| 35 | Josiah Horst       | The Parable of 2 Boys & a Girl | Lakeland, FL          | 440   | 29.33  | 3  |
+| 36 | Shaylee Powell     | Naperville                     | Naperville, IL        | 425   | 28.33  |    |
+| 37 | Sawyer Grant       | Griffin First Gospel Gang      | Griffin, GA           | 415   | 27.67  | 2  |
+| 38 | Jocelyn Fredrick   | Knights 4 Christ- Faith        | Monmouth Junction, NJ | 410   | 27.33  |    |
+| 39 | Kathline Newland   | Gushers                        | Bristow, VA           | 370   | 24.67  |    |
+| 40 | Bryce Helgerson    | Sparta                         | Sparta, WI            | 365   | 24.33  | 2  |
+| 41 | Serenity Orozco    | FBI                            | Tucson, AZ            | 355   | 23.67  | 1  |
+| 42 | Corbin Frydenlund  | Sparta                         | Sparta, WI            | 345   | 23.00  |    |
+| 43 | Delaney Reynolds   | God\'s Girls                   | Oswego, KS            | 330   | 22.00  |    |
+| 44 | Isaac Wolf         | Dancing Disciples              | Fort Wayne, IN        | 325   | 21.67  | 1  |
+| 45 | Elizabeth Bassey   | God\'s Property                | Riverside, CA         | 295   | 19.67  |    |
+| 46 | Luke Swaggerty     | The Awakening Force            | Novi, MI              | 250   | 16.67  | 1  |
+| 47 | Andrew Le          | Lightning Quizzers             | Springfield, MO       | 180   | 12.00  |    |
+| 48 | Chrissy Hetrick    | Agents of the Shield           | Omaha, NE             | 145   | 9.67   |    |
+| 49 | John Cooley        | FBI                            | Tucson, AZ            | 135   | 9.00   |    |
+| 50 | Aaron Martin       | Agents of the Shield           | Omaha, NE             | 110   | 7.33   |    |
+| 51 | Bethany Plake      | Lightning Quizzers             | Springfield, MO       | 95    | 6.33   |    |
+| 51 | Chi-Chi Okezie     | The Awakening Force            | Novi, MI              | 95    | 6.33   |    |
+| 52 | Kolton Chasteen    | Sparta                         | Sparta, WI            | 90    | 6.00   |    |
+| 52 | Michael Newland    | Gushers                        | Bristow, VA           | 90    | 6.00   |    |
+| 53 | Ayden Sorensen     | FBI                            | Tucson, AZ            | 65    | 4.33   |    |
+| 54 | Abby Shinn         | Dancing Disciples              | Fort Wayne, IN        | 55    | 3.67   |    |
+| 55 | Ethan Swaggerty    | The Awakening Force            | Novi, MI              | 50    | 3.33   |    |
+| 56 | Allie Haynes       | Catching Fire                  | Montgomery, AL        | 40    | 2.67   |    |
+| 56 | Joy Wolf           | Dancing Disciples              | Fort Wayne, IN        | 40    | 2.67   |    |
+| 57 | Kacey Mayfield     | God\'s Girls                   | Oswego, KS            | 30    | 2.00   |    |
+| 58 | Anna Le            | Lightning Quizzers             | Springfield, MO       | 20    | 1.33   |    |
+| 59 | Adeline Powell     | Catching Fire                  | Montgomery, AL        |       | .00    |    |
+| 59 | Ana Gonzalez       | Catching Fire                  | Montgomery, AL        |       | .00    |    |
+| 59 | Owen Fleck         | Dancing Disciples              | Fort Wayne, IN        |       | .00    |    |
+| 59 | Carter Ehrman      | Dancing Disciples              | Fort Wayne, IN        |       | .00    |    |
+| 59 | Payton McIntyre    | The Awakening Force            | Novi, MI              |       | .00    |    |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                    | Church            | W/L  | Total | Avg    |
+|---:|-------------------------|-------------------|------|------:|-------:|
+| 1  | Changed Inside Out      | Bowling Green, OH | 12/3 | 2710  | 180.67 |
+| 2  | Tribulation Force       | Red Oak, TX       | 11/4 | 2525  | 168.33 |
+| 3  | Iron Sharp              | Normal, IL        | 11/4 | 2325  | 155.00 |
+| 4  | Bethlehem Church        | Richmond Hill, NY | 11/4 | 2195  | 146.33 |
+| 5  | More Than Conquerors    | Tallahassee, FL   | 10/5 | 2560  | 170.67 |
+| 6  | Quiz Kidz IX            | Scotch Plains, NJ | 9/6  | 2360  | 157.33 |
+| 7  | Mindcraft               | Fayetteville, AR  | 9/6  | 2495  | 166.33 |
+| 8  | Cedar Park Eagles       | Bothell, WA       | 8/7  | 2405  | 160.33 |
+| 9  | The Journey             | Charlotte, NC     | 7/8  | 2300  | 153.33 |
+| 10 | Marshmallow Cats        | Chesterfield, MO  | 7/8  | 2150  | 143.33 |
+| 11 | M&M\'s of Christ        | Tucson, AZ        | 6/9  | 1935  | 129.00 |
+| 12 | Racine Encouragers      | Racine, WI        | 6/9  | 2050  | 136.67 |
+| 13 | Undignified             | Dumas, TX         | 4/11 | 1920  | 128.00 |
+| 14 | Triple Threat           | Fruitland, FL     | 4/11 | 1650  | 110.00 |
+| 15 | New Creatures           | Beulah, ND        | 3/12 | 1915  | 127.67 |
+| 16 | Blazing Buzzer Breakers | Apple Valley, MN  | 2/13 | 1330  | 88.67  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                    | Church            | Total | Avg    | QO |
+|---:|------------------------|-------------------------|-------------------|------:|-------:|---:|
+| 1  | Ryan Yumang            | Mindcraft               | Fayetteville, AR  | 1760  | 117.33 | 8  |
+| 2  | Grace Dempsey          | Iron Sharp              | Normal, IL        | 1670  | 111.33 | 11 |
+| 3  | Ethan Stewart          | More Than Conquerors    | Tallahassee, FL   | 1545  | 103.00 | 9  |
+| 4  | Simeon Thomas          | Quiz Kidz IX            | Scotch Plains, NJ | 1425  | 95.00  | 2  |
+| 5  | Jehosh Jebaraj         | The Journey             | Charlotte, NC     | 1420  | 94.67  | 7  |
+| 6  | Elyssa Fulfer          | Tribulation Force       | Red Oak, TX       | 1240  | 82.67  | 5  |
+| 7  | Shekinah Isaiah        | Cedar Park Eagles       | Bothell, WA       | 1205  | 80.33  | 4  |
+| 8  | Abigail Slembarski     | Changed Inside Out      | Bowling Green, OH | 1065  | 71.00  | 2  |
+| 9  | Joseph Glaser          | Marshmallow Cats        | Chesterfield, MO  | 1005  | 67.00  | 4  |
+| 10 | McKenna Walker         | Racine Encouragers      | Racine, WI        | 990   | 66.00  | 3  |
+| 11 | Esther Zavala          | Undignified             | Dumas, TX         | 985   | 65.67  | 2  |
+| 12 | Jerusha Jebaraj        | The Journey             | Charlotte, NC     | 885   | 59.00  | 8  |
+| 13 | Colson Sago            | New Creatures           | Beulah, ND        | 870   | 58.00  | 3  |
+| 14 | Trevin Sago            | New Creatures           | Beulah, ND        | 760   | 50.67  | 1  |
+| 15 | Aidan Fulfer           | Tribulation Force       | Red Oak, TX       | 740   | 49.33  |    |
+| 16 | Noah Smith             | Changed Inside Out      | Bowling Green, OH | 720   | 48.00  | 8  |
+| 17 | Ashley Okafor          | Bethlehem Church        | Richmond Hill, NY | 665   | 44.33  | 2  |
+| 18 | Scotlynn Reinhold      | Triple Threat           | Fruitland, FL     | 660   | 44.00  | 1  |
+| 19 | Elijah Stewart         | More Than Conquerors    | Tallahassee, FL   | 645   | 43.00  | 6  |
+| 20 | Madeline Berkey        | M&M\'s of Christ        | Tucson, AZ        | 640   | 42.67  |    |
+| 21 | Spencer Morrison       | Blazing Buzzer Breakers | Apple Valley, MN  | 615   | 41.00  | 1  |
+| 22 | Michele Lobato         | M&M\'s of Christ        | Tucson, AZ        | 615   | 41.00  |    |
+| 23 | Clara Dempsey          | Iron Sharp              | Normal, IL        | 600   | 40.00  | 6  |
+| 24 | Olivia Neerudu         | Changed Inside Out      | Bowling Green, OH | 595   | 39.67  |    |
+| 25 | Dominic LoGiudice      | Triple Threat           | Fruitland, FL     | 585   | 39.00  | 1  |
+| 26 | Emma White             | Mindcraft               | Fayetteville, AR  | 555   | 37.00  | 3  |
+| 27 | Faith Buchanan         | Bethlehem Church        | Richmond Hill, NY | 550   | 36.67  | 2  |
+| 28 | Preston Hoggard        | Tribulation Force       | Red Oak, TX       | 545   | 36.33  | 7  |
+| 29 | Hannah Royer           | M&M\'s of Christ        | Tucson, AZ        | 520   | 34.67  | 3  |
+| 30 | Victoria Hernandez     | Quiz Kidz IX            | Scotch Plains, NJ | 520   | 34.67  |    |
+| 31 | Ariana Klein           | Racine Encouragers      | Racine, WI        | 495   | 33.00  |    |
+| 32 | Diamond Zavala         | Undignified             | Dumas, TX         | 445   | 29.67  | 3  |
+| 33 | Joshua Elliott         | Marshmallow Cats        | Chesterfield, MO  | 440   | 29.33  | 2  |
+| 34 | Josi Haugo             | Cedar Park Eagles       | Bothell, WA       | 435   | 29.00  | 4  |
+| 35 | Sancia Gladwin         | Cedar Park Eagles       | Bothell, WA       | 425   | 28.33  |    |
+| 36 | Laila Dasi             | Quiz Kidz IX            | Scotch Plains, NJ | 420   | 28.00  | 2  |
+| 37 | Brianna Boodram        | Bethlehem Church        | Richmond Hill, NY | 415   | 27.67  |    |
+| 38 | Will Thompson          | Triple Threat           | Fruitland, FL     | 405   | 27.00  | 1  |
+| 39 | Ben Elliott            | Marshmallow Cats        | Chesterfield, MO  | 380   | 25.33  | 1  |
+| 40 | Ian Poch               | Blazing Buzzer Breakers | Apple Valley, MN  | 360   | 24.00  |    |
+| 41 | Jayden Rodriquez       | Bethlehem Church        | Richmond Hill, NY | 355   | 23.67  | 3  |
+| 42 | Bella Reynolds         | Cedar Park Eagles       | Bothell, WA       | 340   | 22.67  |    |
+| 43 | Hannah Facer           | Changed Inside Out      | Bowling Green, OH | 330   | 22.00  | 1  |
+| 44 | Abigail Pedapudi       | Marshmallow Cats        | Chesterfield, MO  | 325   | 21.67  |    |
+| 45 | Sarai Zavala           | Undignified             | Dumas, TX         | 300   | 20.00  |    |
+| 46 | Aubryn Sago            | New Creatures           | Beulah, ND        | 285   | 19.00  | 1  |
+| 47 | Cienna Field           | Blazing Buzzer Breakers | Apple Valley, MN  | 255   | 17.00  |    |
+| 48 | Matthew Walker         | Racine Encouragers      | Racine, WI        | 250   | 16.67  |    |
+| 49 | Jon Luc Jobson- Larkin | Bethlehem Church        | Richmond Hill, NY | 205   | 13.67  |    |
+| 50 | Collin Nester          | More Than Conquerors    | Tallahassee, FL   | 190   | 12.67  |    |
+| 51 | Emma Stewart           | More Than Conquerors    | Tallahassee, FL   | 180   | 12.00  |    |
+| 51 | Jazlin Redding         | Mindcraft               | Fayetteville, AR  | 180   | 12.00  |    |
+| 52 | Hayley Vecchio         | Undignified             | Dumas, TX         | 170   | 11.33  |    |
+| 53 | Marianna Aguero        | Racine Encouragers      | Racine, WI        | 135   | 9.00   |    |
+| 54 | Myah Berkey            | M&M\'s of Christ        | Tucson, AZ        | 125   | 8.33   |    |
+| 55 | Brielle Field          | Blazing Buzzer Breakers | Apple Valley, MN  | 100   | 6.67   |    |
+| 56 | Miranda Moncayo        | Racine Encouragers      | Racine, WI        | 80    | 5.33   |    |
+| 57 | Nicholas Tait          | Racine Encouragers      | Racine, WI        | 65    | 4.33   |    |
+| 58 | Hannah Rumley          | Iron Sharp              | Normal, IL        | 40    | 2.67   |    |
+| 59 | Gabriella Lobato       | M&M\'s of Christ        | Tucson, AZ        | 35    | 2.33   |    |
+| 59 | Caitlyn Jackson        | Racine Encouragers      | Racine, WI        | 35    | 2.33   |    |
+| 60 | Olivia Houk            | Iron Sharp              | Normal, IL        | 20    | 1.33   |    |
+| 61 | M\'Kayla McDaniel      | Undignified             | Dumas, TX         | 10    | .67    |    |
+| 61 | Ramon Castillo         | Undignified             | Dumas, TX         | 10    | .67    |    |
+| 62 | James Jobson - Larkin  | Bethlehem Church        | Richmond Hill, NY | 5     | .33    |    |
+| 63 | Stephen Prakash        | The Journey             | Charlotte, NC     |       | .00    |    |
+| 63 | Elias Jacob            | Iron Sharp              | Normal, IL        |       | .00    |    |
+| 63 | Emma Kokora            | Bethlehem Church        | Richmond Hill, NY |       | .00    |    |
+| 63 | Ariel Boodhram         | Bethlehem Church        | Richmond Hill, NY |       | .00    |    |
+| 63 | Julian Castillo        | Undignified             | Dumas, TX         |       | .00    |    |
+| 64 | Marcos Martinez        | Iron Sharp              | Normal, IL        | -5    | -0.33  |    |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                                 | Church                | W/L  | Total | Avg    |
+|---:|--------------------------------------|-----------------------|------|------:|-------:|
+| 1  | Truth Seekers                        | Versailles, KY        | 12/3 | 2420  | 161.33 |
+| 2  | MJG Quizzers                         | Brighton, MI          | 11/4 | 2670  | 178.00 |
+| 3  | Bible Jedi                           | Greensboro, NC        | 9/6  | 2500  | 166.67 |
+| 4  | God\'s Mighty Defenders              | Waxahatchie, TX       | 9/6  | 2450  | 163.33 |
+| 5  | Full Armored Disciples               | Toledo, OH            | 9/6  | 2415  | 161.00 |
+| 5  | Minds of the Bible                   | Shakopee, MN          | 9/6  | 2415  | 161.00 |
+| 6  | CTI JOY                              | Wayne, NJ             | 9/6  | 2370  | 158.00 |
+| 7  | God Squad                            | Chandler, AZ          | 9/6  | 2270  | 151.33 |
+| 8  | The Overcomers                       | Houston, TX           | 8/7  | 2245  | 149.67 |
+| 9  | Lawson - Connie                      | Lawson, MO            | 8/7  | 2300  | 153.33 |
+| 10 | Renton Royals                        | Renton, WA            | 6/9  | 1905  | 127.00 |
+| 11 | ATC FLAMES                           | Norcross, GA          | 6/9  | 1920  | 128.00 |
+| 12 | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN           | 5/10 | 1715  | 114.33 |
+| 13 | Blood Bought Brothers                | Mustang, OK           | 5/10 | 1780  | 118.67 |
+| 14 | Eagles                               | North Little Rock, AR | 3/12 | 1740  | 116.00 |
+| 15 | CIA Special Agents                   | Mendon, MA            | 2/13 | 1570  | 104.67 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                                 | Church                | Total | Avg   | QO |
+|---:|----------------------|--------------------------------------|-----------------------|------:|------:|---:|
+| 1  | Aidan Rajesh         | Bible Jedi                           | Greensboro, NC        | 1460  | 97.33 | 7  |
+| 2  | Jet Blackburn        | Full Armored Disciples               | Toledo, OH            | 1440  | 96.00 | 6  |
+| 3  | Nick Cook            | Lawson - Connie                      | Lawson, MO            | 1350  | 90.00 | 9  |
+| 4  | Hannah G Daniel      | ATC FLAMES                           | Norcross, GA          | 1305  | 87.00 | 4  |
+| 5  | Makayla Demoff       | MJG Quizzers                         | Brighton, MI          | 1270  | 84.67 | 8  |
+| 6  | Chineme Oriaku       | CTI JOY                              | Wayne, NJ             | 1225  | 81.67 | 5  |
+| 7  | Cora Self            | Truth Seekers                        | Versailles, KY        | 1220  | 81.33 | 6  |
+| 8  | Joy Escobar          | God\'s Mighty Defenders              | Waxahatchie, TX       | 1205  | 80.33 | 5  |
+| 9  | Jaden Garland        | Renton Royals                        | Renton, WA            | 1125  | 75.00 | 5  |
+| 10 | Gabby Pahl           | Minds of the Bible                   | Shakopee, MN          | 1120  | 74.67 | 3  |
+| 11 | Timothy Mathew       | God Squad                            | Chandler, AZ          | 1110  | 74.00 | 2  |
+| 12 | Jared Demoff         | MJG Quizzers                         | Brighton, MI          | 1045  | 69.67 | 2  |
+| 13 | Hayden Monty         | CIA Special Agents                   | Mendon, MA            | 940   | 62.67 | 1  |
+| 14 | Wesley Self          | Truth Seekers                        | Versailles, KY        | 860   | 57.33 | 3  |
+| 15 | Samuel Deppe         | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN           | 835   | 55.67 | 1  |
+| 16 | Caleb Cook           | CTI JOY                              | Wayne, NJ             | 785   | 52.33 | 8  |
+| 17 | Jacob Blackburn      | Eagles                               | North Little Rock, AR | 740   | 49.33 | 1  |
+| 18 | Anyiah Odera         | The Overcomers                       | Houston, TX           | 740   | 49.33 |    |
+| 19 | Lauren Pahl          | Minds of the Bible                   | Shakopee, MN          | 730   | 48.67 | 8  |
+| 20 | Evangeline Antony    | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN           | 725   | 48.33 | 5  |
+| 21 | Grace Searcy         | Lawson - Connie                      | Lawson, MO            | 720   | 48.00 | 5  |
+| 22 | Ian Chilson          | Renton Royals                        | Renton, WA            | 650   | 43.33 | 6  |
+| 23 | Trenton Morris       | Bible Jedi                           | Greensboro, NC        | 620   | 41.33 | 6  |
+| 24 | Jack Douglass        | Full Armored Disciples               | Toledo, OH            | 620   | 41.33 | 5  |
+| 25 | Precious Cyrus-David | The Overcomers                       | Houston, TX           | 615   | 41.00 |    |
+| 26 | Hector Rivera        | God\'s Mighty Defenders              | Waxahatchie, TX       | 605   | 40.33 | 5  |
+| 27 | Josh Rose            | Blood Bought Brothers                | Mustang, OK           | 600   | 40.00 |    |
+| 28 | Elizabeth            | Eagles                               | North Little Rock, AR | 575   | 38.33 | 4  |
+| 29 | Ayden Rush           | Blood Bought Brothers                | Mustang, OK           | 570   | 38.00 | 7  |
+| 30 | Hannah Massard       | Minds of the Bible                   | Shakopee, MN          | 565   | 37.67 |    |
+| 31 | Jeremy Varghese      | God Squad                            | Chandler, AZ          | 525   | 35.00 | 4  |
+| 32 | Joshua Malayil       | God Squad                            | Chandler, AZ          | 510   | 34.00 |    |
+| 33 | Jett King            | Blood Bought Brothers                | Mustang, OK           | 445   | 29.67 |    |
+| 34 | Brooke Zermatten     | Eagles                               | North Little Rock, AR | 405   | 27.00 |    |
+| 35 | Ezekiel Hamel        | CIA Special Agents                   | Mendon, MA            | 385   | 25.67 | 1  |
+| 36 | Hans A Daniel        | ATC FLAMES                           | Norcross, GA          | 385   | 25.67 |    |
+| 37 | Olivia Akonzee       | The Overcomers                       | Houston, TX           | 380   | 25.33 | 1  |
+| 38 | Jasmine Saenz        | God\'s Mighty Defenders              | Waxahatchie, TX       | 380   | 25.33 |    |
+| 39 | Gabriella Demoff     | MJG Quizzers                         | Brighton, MI          | 355   | 23.67 | 2  |
+| 40 | Oduna Akonzee        | The Overcomers                       | Houston, TX           | 330   | 22.00 | 2  |
+| 41 | Joanna Paulraj       | CTI JOY                              | Wayne, NJ             | 320   | 21.33 |    |
+| 42 | Nathaniel Prejean    | Bible Jedi                           | Greensboro, NC        | 275   | 18.33 |    |
+| 43 | Grace Ruiz           | God\'s Mighty Defenders              | Waxahatchie, TX       | 260   | 17.33 |    |
+| 44 | Joshua Lewis         | Full Armored Disciples               | Toledo, OH            | 250   | 16.67 |    |
+| 45 | Taylor Searcy        | Lawson - Connie                      | Lawson, MO            | 230   | 15.33 |    |
+| 45 | Jenny CHRISTOPHER    | ATC FLAMES                           | Norcross, GA          | 230   | 15.33 |    |
+| 46 | Olivia Lee           | Truth Seekers                        | Versailles, KY        | 205   | 13.67 |    |
+| 47 | Matthew Hamel        | CIA Special Agents                   | Mendon, MA            | 195   | 13.00 |    |
+| 48 | Priscilla Adu-Gyamfi | The Overcomers                       | Houston, TX           | 180   | 12.00 |    |
+| 49 | Wesley Horn          | Blood Bought Brothers                | Mustang, OK           | 170   | 11.33 |    |
+| 50 | Aleena Varghese      | God Squad                            | Chandler, AZ          | 125   | 8.33  |    |
+| 51 | Benjamin Antony      | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN           | 105   | 7.00  |    |
+| 52 | Jacob Solvang        | Renton Royals                        | Renton, WA            | 100   | 6.67  | 1  |
+| 53 | Eliana Lee           | Truth Seekers                        | Versailles, KY        | 90    | 6.00  |    |
+| 54 | Emma Martello        | Bible Jedi                           | Greensboro, NC        | 80    | 5.33  |    |
+| 55 | Jack Martello        | Bible Jedi                           | Greensboro, NC        | 65    | 4.33  |    |
+| 56 | Jacob Lewis          | Full Armored Disciples               | Toledo, OH            | 55    | 3.67  |    |
+| 56 | Alicia Akinyi        | Renton Royals                        | Renton, WA            | 55    | 3.67  |    |
+| 57 | Tanner Longacre      | CIA Special Agents                   | Mendon, MA            | 50    | 3.33  |    |
+| 57 | Sarah Robertson      | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN           | 50    | 3.33  |    |
+| 58 | Josiah Self          | Truth Seekers                        | Versailles, KY        | 45    | 3.00  |    |
+| 59 | Matthew Wiley        | Full Armored Disciples               | Toledo, OH            | 40    | 2.67  |    |
+| 60 | Efrain Martinez      | CTI JOY                              | Wayne, NJ             | 25    | 1.67  |    |
+| 61 | Aliyah Gibson        | Eagles                               | North Little Rock, AR | 20    | 1.33  |    |
+| 62 | Kelechi Oriaku       | CTI JOY                              | Wayne, NJ             | 15    | 1.00  |    |
+| 63 | Dana Goyer           | Full Armored Disciples               | Toledo, OH            | 10    | .67   |    |
+| 63 | Annalise Jennings    | Renton Royals                        | Renton, WA            | 10    | .67   |    |
+| 64 | Joel CHRISTOPHER     | ATC FLAMES                           | Norcross, GA          |       | .00   |    |
+| 64 | Ian Sharps           | Eagles                               | North Little Rock, AR |       | .00   |    |
+| 64 | Ava Robertson        | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN           |       | .00   |    |
+| 64 | Malia Goda           | Renton Royals                        | Renton, WA            |       | .00   |    |
+| 65 | David Doan           | Renton Royals                        | Renton, WA            | -35   | -2.33 |    |
+
+
+## Saturday
+
+### Blue (L1)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                    | Church                | W/L | Total | Avg    |
+|---:|-------------------------|-----------------------|-----|------:|-------:|
+| 1  | Naperville              | Naperville, IL        | 7/2 | 1570  | 174.44 |
+| 2  | Contagious Havoc        | Mechanicsville, VA    | 7/2 | 1685  | 187.22 |
+| 3  | Jewels for Jesus        | Springfield, MO       | 6/3 | 1445  | 160.56 |
+| 4  | Tribulation Force       | Red Oak, TX           | 5/4 | 1135  | 126.11 |
+| 5  | MJG Quizzers            | Brighton, MI          | 4/5 | 1295  | 143.89 |
+| 6  | Truth Seekers           | Versailles, KY        | 4/5 | 1265  | 140.56 |
+| 7  | Knights 4 Christ- Faith | Monmouth Junction, NJ | 4/5 | 1180  | 131.11 |
+| 8  | Wilmington Warriors     | Wilmington, NC        | 3/6 | 1265  | 140.56 |
+| 9  | Changed Inside Out      | Bowling Green, OH     | 3/6 | 1310  | 145.56 |
+| 10 | Fluffy Panda Quizzers   | Gahanna, OH           | 2/7 | 880   | 97.78  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                    | Church                | Total | Avg    | QO |
+|---:|----------------------|-------------------------|-----------------------|------:|-------:|---:|
+| 1  | Braden Adams         | Contagious Havoc        | Mechanicsville, VA    | 1110  | 123.33 | 6  |
+| 2  | Elizabeth Jones      | Jewels for Jesus        | Springfield, MO       | 1065  | 118.33 | 4  |
+| 3  | Sheldon Powell       | Naperville              | Naperville, IL        | 885   | 98.33  | 3  |
+| 4  | Jared Demoff         | MJG Quizzers            | Brighton, MI          | 600   | 66.67  | 1  |
+| 5  | Nathaniel Jebaraj    | Knights 4 Christ- Faith | Monmouth Junction, NJ | 575   | 63.89  | 2  |
+| 6  | Wesley Self          | Truth Seekers           | Versailles, KY        | 560   | 62.22  | 2  |
+| 7  | Shaymis Powell       | Naperville              | Naperville, IL        | 505   | 56.11  | 6  |
+| 8  | Cora Self            | Truth Seekers           | Versailles, KY        | 495   | 55.00  | 1  |
+| 9  | Elyssa Fulfer        | Tribulation Force       | Red Oak, TX           | 470   | 52.22  | 2  |
+| 10 | Zachary Leake        | Wilmington Warriors     | Wilmington, NC        | 460   | 51.11  | 1  |
+| 11 | Samuel Jebaraj       | Knights 4 Christ- Faith | Monmouth Junction, NJ | 425   | 47.22  | 4  |
+| 12 | Makayla Demoff       | MJG Quizzers            | Brighton, MI          | 415   | 46.11  | 1  |
+| 13 | Brock Boehling       | Wilmington Warriors     | Wilmington, NC        | 410   | 45.56  |    |
+| 13 | Olivia Neerudu       | Changed Inside Out      | Bowling Green, OH     | 410   | 45.56  |    |
+| 14 | Noah Smith           | Changed Inside Out      | Bowling Green, OH     | 375   | 41.67  | 4  |
+| 15 | Will Rittenhouse     | Contagious Havoc        | Mechanicsville, VA    | 360   | 40.00  | 4  |
+| 16 | Preston Hoggard      | Tribulation Force       | Red Oak, TX           | 335   | 37.22  | 4  |
+| 17 | Aidan Fulfer         | Tribulation Force       | Red Oak, TX           | 335   | 37.22  |    |
+| 18 | Abel Karthik         | Fluffy Panda Quizzers   | Gahanna, OH           | 330   | 36.67  |    |
+| 19 | Abigail Slembarski   | Changed Inside Out      | Bowling Green, OH     | 310   | 34.44  |    |
+| 20 | Gabriella Demoff     | MJG Quizzers            | Brighton, MI          | 280   | 31.11  |    |
+| 21 | Caleb Karthik        | Fluffy Panda Quizzers   | Gahanna, OH           | 265   | 29.44  | 2  |
+| 22 | Sammy Mair           | Fluffy Panda Quizzers   | Gahanna, OH           | 265   | 29.44  |    |
+| 23 | Shekinah Phelps      | Jewels for Jesus        | Springfield, MO       | 250   | 27.78  | 2  |
+| 24 | Britt Adams          | Contagious Havoc        | Mechanicsville, VA    | 220   | 24.44  | 2  |
+| 25 | Hannah Facer         | Changed Inside Out      | Bowling Green, OH     | 215   | 23.89  |    |
+| 26 | Jocelyn Fredrick     | Knights 4 Christ- Faith | Monmouth Junction, NJ | 180   | 20.00  |    |
+| 26 | Shaylee Powell       | Naperville              | Naperville, IL        | 180   | 20.00  |    |
+| 27 | Kora Beth witzenman  | Wilmington Warriors     | Wilmington, NC        | 145   | 16.11  | 1  |
+| 28 | Luke shelton         | Wilmington Warriors     | Wilmington, NC        | 130   | 14.44  |    |
+| 29 | Olivia Lee           | Truth Seekers           | Versailles, KY        | 105   | 11.67  |    |
+| 30 | Eliana Lee           | Truth Seekers           | Versailles, KY        | 100   | 11.11  |    |
+| 31 | Rachel McDonald      | Wilmington Warriors     | Wilmington, NC        | 80    | 8.89   |    |
+| 32 | Abby Jones           | Jewels for Jesus        | Springfield, MO       | 70    | 7.78   |    |
+| 33 | Trinity Phelps       | Jewels for Jesus        | Springfield, MO       | 60    | 6.67   |    |
+| 34 | Anna Scott witzenman | Wilmington Warriors     | Wilmington, NC        | 40    | 4.44   |    |
+| 35 | Brenda Light         | Fluffy Panda Quizzers   | Gahanna, OH           | 20    | 2.22   |    |
+| 36 | Josiah Self          | Truth Seekers           | Versailles, KY        | 5     | .56    |    |
+| 37 | Corrie lee Boehling  | Wilmington Warriors     | Wilmington, NC        |       | .00    |    |
+| 37 | Carley McDonald      | Wilmington Warriors     | Wilmington, NC        |       | .00    |    |
+| 37 | Brookleyn Light      | Fluffy Panda Quizzers   | Gahanna, OH           |       | .00    |    |
+| 38 | Angel Walker         | Contagious Havoc        | Mechanicsville, VA    | -5    | -0.56  |    |
+
+
+### Green (L2)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                           | Church                | W/L | Total | Avg    |
+|---:|--------------------------------|-----------------------|-----|------:|-------:|
+| 1  | Bible Jedi                     | Greensboro, NC        | 8/1 | 1580  | 175.56 |
+| 2  | God\'s Mighty Warriors         | Milwaukee, WI         | 6/3 | 1430  | 158.89 |
+| 3  | Knights 4 Christ - Salvation   | Monmouth Junction, NJ | 5/4 | 1585  | 176.11 |
+| 4  | Naperville (C)                 | Naperville, IL        | 5/4 | 1390  | 154.44 |
+| 5  | Bethlehem Church               | Richmond Hill, NY     | 5/4 | 1205  | 133.89 |
+| 6  | Iron Sharp                     | Normal, IL            | 5/4 | 1145  | 127.22 |
+| 7  | Agents of the Shield           | Omaha, NE             | 4/5 | 1230  | 136.67 |
+| 8  | God\'s Mighty Defenders        | Waxahatchie, TX       | 3/6 | 1020  | 113.33 |
+| 9  | Askewville Hashtags            | Askewville, NC        | 3/6 | 1050  | 116.67 |
+| 10 | The Parable of 2 Boys & a Girl | Lakeland, FL          | 1/8 | 1165  | 129.44 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team                           | Church                | Total | Avg    | QO |
+|---:|------------------------|--------------------------------|-----------------------|------:|-------:|---:|
+| 1  | Aidan Rajesh           | Bible Jedi                     | Greensboro, NC        | 1145  | 127.22 | 6  |
+| 2  | Gabi Acevedo           | God\'s Mighty Warriors         | Milwaukee, WI         | 965   | 107.22 | 5  |
+| 3  | Remi Brigilin          | Knights 4 Christ - Salvation   | Monmouth Junction, NJ | 945   | 105.00 | 4  |
+| 4  | Grace Dempsey          | Iron Sharp                     | Normal, IL            | 775   | 86.11  | 4  |
+| 5  | MacKenzie Wright       | The Parable of 2 Boys & a Girl | Lakeland, FL          | 690   | 76.67  | 1  |
+| 6  | Micah Hill             | Askewville Hashtags            | Askewville, NC        | 615   | 68.33  | 2  |
+| 7  | Joy Escobar            | God\'s Mighty Defenders        | Waxahatchie, TX       | 570   | 63.33  |    |
+| 8  | Stephen Bough          | Naperville (C)                 | Naperville, IL        | 495   | 55.00  | 5  |
+| 9  | Reagan Stevens         | Naperville (C)                 | Naperville, IL        | 475   | 52.78  |    |
+| 10 | Iakona Fern            | Agents of the Shield           | Omaha, NE             | 455   | 50.56  | 4  |
+| 11 | Clara Dempsey          | Iron Sharp                     | Normal, IL            | 350   | 38.89  | 2  |
+| 12 | David Biruduganti      | Naperville (C)                 | Naperville, IL        | 330   | 36.67  | 1  |
+| 13 | Brianna Boodram        | Bethlehem Church               | Richmond Hill, NY     | 320   | 35.56  |    |
+| 14 | Jayden Rodriquez       | Bethlehem Church               | Richmond Hill, NY     | 270   | 30.00  | 1  |
+| 15 | Ashley Okafor          | Bethlehem Church               | Richmond Hill, NY     | 255   | 28.33  | 1  |
+| 16 | Danny Dominic          | Knights 4 Christ - Salvation   | Monmouth Junction, NJ | 250   | 27.78  |    |
+| 16 | Joel Ravela            | The Parable of 2 Boys & a Girl | Lakeland, FL          | 250   | 27.78  |    |
+| 16 | Lademi Davies          | Agents of the Shield           | Omaha, NE             | 250   | 27.78  |    |
+| 17 | Haven Hoggard          | Askewville Hashtags            | Askewville, NC        | 245   | 27.22  |    |
+| 17 | Kaitlin Slottke        | God\'s Mighty Warriors         | Milwaukee, WI         | 245   | 27.22  |    |
+| 18 | Charlotte Elliott      | Agents of the Shield           | Omaha, NE             | 240   | 26.67  |    |
+| 18 | Aaron Martin           | Agents of the Shield           | Omaha, NE             | 240   | 26.67  |    |
+| 19 | Faith Buchanan         | Bethlehem Church               | Richmond Hill, NY     | 230   | 25.56  |    |
+| 20 | Josiah Horst           | The Parable of 2 Boys & a Girl | Lakeland, FL          | 225   | 25.00  |    |
+| 21 | Trenton Morris         | Bible Jedi                     | Greensboro, NC        | 205   | 22.78  | 2  |
+| 22 | Jason Theodore         | Knights 4 Christ - Salvation   | Monmouth Junction, NJ | 200   | 22.22  | 1  |
+| 23 | Freya Brigilin         | Knights 4 Christ - Salvation   | Monmouth Junction, NJ | 190   | 21.11  |    |
+| 24 | Eliana Bazemore        | Askewville Hashtags            | Askewville, NC        | 160   | 17.78  |    |
+| 24 | Jasmine Saenz          | God\'s Mighty Defenders        | Waxahatchie, TX       | 160   | 17.78  |    |
+| 25 | Hector Rivera          | God\'s Mighty Defenders        | Waxahatchie, TX       | 150   | 16.67  | 1  |
+| 26 | Daniel Kyzer           | God\'s Mighty Warriors         | Milwaukee, WI         | 150   | 16.67  |    |
+| 27 | Grace Ruiz             | God\'s Mighty Defenders        | Waxahatchie, TX       | 140   | 15.56  |    |
+| 28 | Jon Luc Jobson- Larkin | Bethlehem Church               | Richmond Hill, NY     | 130   | 14.44  |    |
+| 29 | Nathaniel Prejean      | Bible Jedi                     | Greensboro, NC        | 125   | 13.89  |    |
+| 30 | Samuel Biruduganti     | Naperville (C)                 | Naperville, IL        | 90    | 10.00  |    |
+| 31 | Ronnie Slottke         | God\'s Mighty Warriors         | Milwaukee, WI         | 60    | 6.67   |    |
+| 32 | Emma Martello          | Bible Jedi                     | Greensboro, NC        | 55    | 6.11   |    |
+| 33 | Jack Martello          | Bible Jedi                     | Greensboro, NC        | 50    | 5.56   |    |
+| 34 | Chrissy Hetrick        | Agents of the Shield           | Omaha, NE             | 45    | 5.00   |    |
+| 35 | Lynsey Bazemore        | Askewville Hashtags            | Askewville, NC        | 30    | 3.33   |    |
+| 36 | Hannah Rumley          | Iron Sharp                     | Normal, IL            | 20    | 2.22   |    |
+| 37 | Zach Weidner           | God\'s Mighty Warriors         | Milwaukee, WI         | 10    | 1.11   |    |
+| 37 | Olivia Houk            | Iron Sharp                     | Normal, IL            | 10    | 1.11   |    |
+| 38 | Elias Jacob            | Iron Sharp                     | Normal, IL            |       | .00    |    |
+| 38 | Emma Kokora            | Bethlehem Church               | Richmond Hill, NY     |       | .00    |    |
+| 38 | Ariel Boodhram         | Bethlehem Church               | Richmond Hill, NY     |       | .00    |    |
+| 38 | James Jobson - Larkin  | Bethlehem Church               | Richmond Hill, NY     |       | .00    |    |
+| 39 | Marcos Martinez        | Iron Sharp                     | Normal, IL            | -10   | -1.11  |    |
+
+
+### Lavender (L3)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                   | Church            | W/L | Total | Avg    |
+|---:|------------------------|-------------------|-----|------:|-------:|
+| 1  | More Than Conquerors   | Tallahassee, FL   | 7/2 | 1365  | 151.67 |
+| 2  | Souled Out             | San Jose, CA      | 6/3 | 1360  | 151.11 |
+| 3  | The Chosen Ones        | Houston, TX       | 6/3 | 1430  | 158.89 |
+| 4  | Transformed            | Garland, TX       | 5/4 | 1485  | 165.00 |
+| 5  | Full Armored Disciples | Toledo, OH        | 5/4 | 1280  | 142.22 |
+| 6  | Gospel Girls           | Rogers, AR        | 5/4 | 1275  | 141.67 |
+| 7  | Gushers                | Bristow, VA       | 4/5 | 1445  | 160.56 |
+| 8  | Minds of the Bible     | Shakopee, MN      | 3/6 | 1150  | 127.78 |
+| 9  | God\'s Incredibles     | Lakeville, MN     | 2/7 | 1120  | 124.44 |
+| 10 | Quiz Kidz IX           | Scotch Plains, NJ | 2/7 | 945   | 105.00 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                   | Church            | Total | Avg   | QO |
+|---:|--------------------|------------------------|-------------------|------:|------:|---:|
+| 1  | Samuel Jebaraj     | Souled Out             | San Jose, CA      | 895   | 99.44 | 4  |
+| 2  | Sydney Shockley    | Gospel Girls           | Rogers, AR        | 875   | 97.22 | 4  |
+| 3  | Zane Brown         | Transformed            | Garland, TX       | 860   | 95.56 | 4  |
+| 4  | Ethan Stewart      | More Than Conquerors   | Tallahassee, FL   | 855   | 95.00 | 5  |
+| 5  | Jet Blackburn      | Full Armored Disciples | Toledo, OH        | 740   | 82.22 | 2  |
+| 6  | Gabby Pahl         | Minds of the Bible     | Shakopee, MN      | 560   | 62.22 | 1  |
+| 7  | Isabella Kashubin  | God\'s Incredibles     | Lakeville, MN     | 525   | 58.33 |    |
+| 8  | Michael Ukonu      | The Chosen Ones        | Houston, TX       | 510   | 56.67 |    |
+| 9  | Ellen Smith        | Gushers                | Bristow, VA       | 470   | 52.22 | 3  |
+| 10 | Brandon Ukonu      | The Chosen Ones        | Houston, TX       | 435   | 48.33 | 5  |
+| 11 | Simeon Thomas      | Quiz Kidz IX           | Scotch Plains, NJ | 420   | 46.67 |    |
+| 12 | Tinley Boysen      | Gospel Girls           | Rogers, AR        | 400   | 44.44 | 2  |
+| 13 | Hannah Massard     | Minds of the Bible     | Shakopee, MN      | 375   | 41.67 |    |
+| 14 | Isaiah Kashubin    | God\'s Incredibles     | Lakeville, MN     | 350   | 38.89 | 4  |
+| 15 | Audrey Mason       | Gushers                | Bristow, VA       | 350   | 38.89 | 3  |
+| 16 | William Adu-Gyamfi | The Chosen Ones        | Houston, TX       | 330   | 36.67 |    |
+| 17 | Laila Dasi         | Quiz Kidz IX           | Scotch Plains, NJ | 325   | 36.11 | 2  |
+| 18 | Michael Ikechukwu  | Transformed            | Garland, TX       | 315   | 35.00 | 3  |
+| 19 | Fionette Fefe King | Gushers                | Bristow, VA       | 285   | 31.67 |    |
+| 20 | Elijah Stewart     | More Than Conquerors   | Tallahassee, FL   | 275   | 30.56 | 1  |
+| 21 | Michael Newland    | Gushers                | Bristow, VA       | 240   | 26.67 |    |
+| 22 | Jack Douglass      | Full Armored Disciples | Toledo, OH        | 235   | 26.11 | 2  |
+| 23 | Faithful Iwuamadi  | Transformed            | Garland, TX       | 230   | 25.56 | 1  |
+| 24 | Jacob Kashuba      | God\'s Incredibles     | Lakeville, MN     | 220   | 24.44 |    |
+| 25 | Lauren Pahl        | Minds of the Bible     | Shakopee, MN      | 215   | 23.89 | 1  |
+| 26 | Jebi Sukumar       | Souled Out             | San Jose, CA      | 200   | 22.22 | 2  |
+| 27 | Victoria Hernandez | Quiz Kidz IX           | Scotch Plains, NJ | 200   | 22.22 |    |
+| 28 | Keren Godson       | Souled Out             | San Jose, CA      | 190   | 21.11 |    |
+| 29 | Iyanu Akanbi       | The Chosen Ones        | Houston, TX       | 155   | 17.22 |    |
+| 29 | Emma Stewart       | More Than Conquerors   | Tallahassee, FL   | 155   | 17.22 |    |
+| 29 | Jacob Lewis        | Full Armored Disciples | Toledo, OH        | 155   | 17.22 |    |
+| 30 | Kathline Newland   | Gushers                | Bristow, VA       | 100   | 11.11 |    |
+| 31 | Joshua Lewis       | Full Armored Disciples | Toledo, OH        | 90    | 10.00 |    |
+| 32 | Chi Chi Otah       | Transformed            | Garland, TX       | 80    | 8.89  |    |
+| 32 | Collin Nester      | More Than Conquerors   | Tallahassee, FL   | 80    | 8.89  |    |
+| 33 | Jeremiah Godson    | Souled Out             | San Jose, CA      | 75    | 8.33  |    |
+| 34 | Matthew Wiley      | Full Armored Disciples | Toledo, OH        | 60    | 6.67  |    |
+| 35 | Jason Fry          | God\'s Incredibles     | Lakeville, MN     | 15    | 1.67  |    |
+| 36 | Brandon Schommer   | God\'s Incredibles     | Lakeville, MN     | 10    | 1.11  |    |
+| 37 | Dana Goyer         | Full Armored Disciples | Toledo, OH        |       | .00   |    |
+
+
+### Orange (L4)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                        | Church           | W/L | Total | Avg    |
+|---:|-----------------------------|------------------|-----|------:|-------:|
+| 1  | 360 Quizzers                | Springfield, MO  | 7/2 | 1565  | 173.89 |
+| 2  | Heart of a Lion             | Angleton, TX     | 7/2 | 1570  | 174.44 |
+| 3  | CTI JOY                     | Wayne, NJ        | 6/3 | 1180  | 131.11 |
+| 4  | Cedar Park Eagles           | Bothell, WA      | 6/3 | 1700  | 188.89 |
+| 5  | Naperville (D)              | Naperville, IL   | 5/4 | 1435  | 159.44 |
+| 6  | S.P.Y. Kids                 | Leesburg, VA     | 4/5 | 1240  | 137.78 |
+| 7  | Mindcraft                   | Fayetteville, AR | 3/6 | 1340  | 148.89 |
+| 8  | God Squad                   | Chandler, AZ     | 3/6 | 1165  | 129.44 |
+| 9  | HRQ-Holy Righteous Quizzers | Brookfield, WI   | 3/6 | 865   | 96.11  |
+| 10 | Sparta                      | Sparta, WI       | 1/8 | 830   | 92.22  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                        | Church           | Total | Avg    | QO |
+|---:|-------------------|-----------------------------|------------------|------:|-------:|---:|
+| 1  | Hannah Alapati    | Heart of a Lion             | Angleton, TX     | 1110  | 123.33 | 6  |
+| 2  | Cameron Ramsey    | 360 Quizzers                | Springfield, MO  | 1085  | 120.56 | 6  |
+| 3  | Ryan Yumang       | Mindcraft                   | Fayetteville, AR | 1060  | 117.78 | 7  |
+| 4  | Shekinah Isaiah   | Cedar Park Eagles           | Bothell, WA      | 870   | 96.67  | 3  |
+| 5  | Justiss Silas     | Naperville (D)              | Naperville, IL   | 705   | 78.33  | 8  |
+| 6  | Shawn Timothy     | Naperville (D)              | Naperville, IL   | 600   | 66.67  | 2  |
+| 7  | Chineme Oriaku    | CTI JOY                     | Wayne, NJ        | 520   | 57.78  |    |
+| 8  | Miles Kastner     | HRQ-Holy Righteous Quizzers | Brookfield, WI   | 505   | 56.11  |    |
+| 9  | Christian Alapati | Heart of a Lion             | Angleton, TX     | 460   | 51.11  | 5  |
+| 10 | Samuel Otchere    | S.P.Y. Kids                 | Leesburg, VA     | 440   | 48.89  |    |
+| 11 | Phillip Bozzay    | S.P.Y. Kids                 | Leesburg, VA     | 400   | 44.44  | 1  |
+| 12 | Cole Abbott       | Sparta                      | Sparta, WI       | 375   | 41.67  | 2  |
+| 13 | Joshua Malayil    | God Squad                   | Chandler, AZ     | 375   | 41.67  |    |
+| 14 | Jeremy Varghese   | God Squad                   | Chandler, AZ     | 355   | 39.44  | 1  |
+| 15 | Caleb Cook        | CTI JOY                     | Wayne, NJ        | 340   | 37.78  | 4  |
+| 16 | Josi Haugo        | Cedar Park Eagles           | Bothell, WA      | 325   | 36.11  | 2  |
+| 17 | Sancia Gladwin    | Cedar Park Eagles           | Bothell, WA      | 325   | 36.11  |    |
+| 18 | Joanna Paulraj    | CTI JOY                     | Wayne, NJ        | 305   | 33.89  |    |
+| 19 | Conner Haddaway   | S.P.Y. Kids                 | Leesburg, VA     | 280   | 31.11  | 2  |
+| 20 | Timothy Mathew    | God Squad                   | Chandler, AZ     | 270   | 30.00  |    |
+| 21 | Emma White        | Mindcraft                   | Fayetteville, AR | 240   | 26.67  |    |
+| 22 | Alyssa Ramsey     | 360 Quizzers                | Springfield, MO  | 200   | 22.22  | 1  |
+| 22 | Corbin Frydenlund | Sparta                      | Sparta, WI       | 200   | 22.22  | 1  |
+| 23 | Bryce Helgerson   | Sparta                      | Sparta, WI       | 200   | 22.22  |    |
+| 24 | Bella Reynolds    | Cedar Park Eagles           | Bothell, WA      | 180   | 20.00  |    |
+| 25 | Todimu Afolayan   | HRQ-Holy Righteous Quizzers | Brookfield, WI   | 165   | 18.33  | 1  |
+| 26 | Aleena Varghese   | God Squad                   | Chandler, AZ     | 165   | 18.33  |    |
+| 27 | Kaitlyn Ramsey    | 360 Quizzers                | Springfield, MO  | 145   | 16.11  | 1  |
+| 28 | Catie Wolfe       | 360 Quizzers                | Springfield, MO  | 135   | 15.00  |    |
+| 29 | McKinley Stevens  | Naperville (D)              | Naperville, IL   | 130   | 14.44  |    |
+| 30 | Isaiah Delaney    | HRQ-Holy Righteous Quizzers | Brookfield, WI   | 95    | 10.56  |    |
+| 31 | Elizabeth Murray  | HRQ-Holy Righteous Quizzers | Brookfield, WI   | 90    | 10.00  |    |
+| 32 | Gracelyn Daniel   | S.P.Y. Kids                 | Leesburg, VA     | 75    | 8.33   | 1  |
+| 33 | Kolton Chasteen   | Sparta                      | Sparta, WI       | 55    | 6.11   |    |
+| 34 | Hannah Judd       | S.P.Y. Kids                 | Leesburg, VA     | 45    | 5.00   |    |
+| 35 | Jazlin Redding    | Mindcraft                   | Fayetteville, AR | 40    | 4.44   |    |
+| 36 | Hannah Murray     | HRQ-Holy Righteous Quizzers | Brookfield, WI   | 10    | 1.11   |    |
+| 36 | Kelechi Oriaku    | CTI JOY                     | Wayne, NJ        | 10    | 1.11   |    |
+| 37 | Efrain Martinez   | CTI JOY                     | Wayne, NJ        | 5     | .56    |    |
+| 38 | Leah Hodge        | S.P.Y. Kids                 | Leesburg, VA     |       | .00    |    |
+| 38 | James Bozzay      | S.P.Y. Kids                 | Leesburg, VA     |       | .00    |    |
+| 38 | Gabriel Otchere   | S.P.Y. Kids                 | Leesburg, VA     |       | .00    |    |
+| 38 | McKenna Black     | 360 Quizzers                | Springfield, MO  |       | .00    |    |
+
+
+### Pink (L5)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team               | Church           | W/L | Total | Avg    |
+|---:|--------------------|------------------|-----|------:|-------:|
+| 1  | Kung Fu Quizzers   | Benton, AR       | 8/1 | 1670  | 185.56 |
+| 2  | Lawson - Connie    | Lawson, MO       | 6/3 | 1590  | 176.67 |
+| 3  | Mighty Minions     | Cedar Hill, TX   | 5/4 | 1405  | 156.11 |
+| 4  | Marshmallow Cats   | Chesterfield, MO | 5/4 | 1215  | 135.00 |
+| 5  | The Journey        | Charlotte, NC    | 4/5 | 1335  | 148.33 |
+| 6  | The Overcomers     | Houston, TX      | 4/5 | 1185  | 131.67 |
+| 7  | The Dream Team     | Phoenix, AZ      | 4/5 | 1125  | 125.00 |
+| 8  | Glow Kids          | San Antonio, TX  | 4/5 | 1080  | 120.00 |
+| 9  | Lightning Quizzers | Springfield, MO  | 3/6 | 1135  | 126.11 |
+| 10 | God\'s Girls       | Oswego, KS       | 2/7 | 1145  | 127.22 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                | Team               | Church           | Total | Avg    | QO |
+|---:|------------------------|--------------------|------------------|------:|-------:|---:|
+| 1  | Bobbie Barnes          | Kung Fu Quizzers   | Benton, AR       | 1130  | 125.56 | 7  |
+| 2  | Nick Cook              | Lawson - Connie    | Lawson, MO       | 825   | 91.67  | 3  |
+| 3  | Jehosh Jebaraj         | The Journey        | Charlotte, NC    | 815   | 90.56  | 3  |
+| 4  | Hannah Plake           | Lightning Quizzers | Springfield, MO  | 770   | 85.56  | 3  |
+| 5  | Noah Claunch           | Mighty Minions     | Cedar Hill, TX   | 710   | 78.89  | 8  |
+| 6  | Grace Searcy           | Lawson - Connie    | Lawson, MO       | 655   | 72.78  | 6  |
+| 7  | Aradhana SatheeshKumar | The Dream Team     | Phoenix, AZ      | 575   | 63.89  | 1  |
+| 8  | Jadyn Laila Thomas     | Glow Kids          | San Antonio, TX  | 535   | 59.44  | 1  |
+| 9  | Jerusha Jebaraj        | The Journey        | Charlotte, NC    | 520   | 57.78  | 3  |
+| 10 | Brittyn Glover         | Kung Fu Quizzers   | Benton, AR       | 465   | 51.67  | 5  |
+| 11 | Cecillia Newby         | God\'s Girls       | Oswego, KS       | 465   | 51.67  |    |
+| 12 | Adeline Keith          | Mighty Minions     | Cedar Hill, TX   | 425   | 47.22  |    |
+| 13 | Abhishek SatheeshKumar | The Dream Team     | Phoenix, AZ      | 400   | 44.44  | 5  |
+| 14 | Carmen Eisenbrandt     | God\'s Girls       | Oswego, KS       | 395   | 43.89  |    |
+| 15 | Precious Cyrus-David   | The Overcomers     | Houston, TX      | 390   | 43.33  |    |
+| 16 | Abigail Pedapudi       | Marshmallow Cats   | Chesterfield, MO | 385   | 42.78  |    |
+| 17 | Liana Rachel Thomas    | Glow Kids          | San Antonio, TX  | 360   | 40.00  |    |
+| 18 | Joshua Elliott         | Marshmallow Cats   | Chesterfield, MO | 345   | 38.33  | 3  |
+| 19 | Anyiah Odera           | The Overcomers     | Houston, TX      | 330   | 36.67  |    |
+| 20 | Joseph Glaser          | Marshmallow Cats   | Chesterfield, MO | 305   | 33.89  |    |
+| 21 | Oduna Akonzee          | The Overcomers     | Houston, TX      | 260   | 28.89  | 1  |
+| 22 | Elli Woodward          | Lightning Quizzers | Springfield, MO  | 215   | 23.89  |    |
+| 23 | Joseph Barajas         | Mighty Minions     | Cedar Hill, TX   | 200   | 22.22  |    |
+| 24 | Ben Elliott            | Marshmallow Cats   | Chesterfield, MO | 180   | 20.00  |    |
+| 24 | Priscilla Adu-Gyamfi   | The Overcomers     | Houston, TX      | 180   | 20.00  |    |
+| 25 | Caris Marie Thomas     | Glow Kids          | San Antonio, TX  | 165   | 18.33  | 1  |
+| 26 | Delaney Reynolds       | God\'s Girls       | Oswego, KS       | 165   | 18.33  |    |
+| 27 | Tyler Trexler          | The Dream Team     | Phoenix, AZ      | 150   | 16.67  |    |
+| 28 | Grace Noel             | God\'s Girls       | Oswego, KS       | 120   | 13.33  |    |
+| 29 | Taylor Searcy          | Lawson - Connie    | Lawson, MO       | 110   | 12.22  |    |
+| 30 | Madison Claunch        | Mighty Minions     | Cedar Hill, TX   | 70    | 7.78   |    |
+| 31 | Anna Le                | Lightning Quizzers | Springfield, MO  | 65    | 7.22   |    |
+| 32 | Bethany Plake          | Lightning Quizzers | Springfield, MO  | 45    | 5.00   |    |
+| 33 | Andrew Le              | Lightning Quizzers | Springfield, MO  | 40    | 4.44   |    |
+| 33 | Caden Sanders          | Kung Fu Quizzers   | Benton, AR       | 40    | 4.44   |    |
+| 34 | Olivia Akonzee         | The Overcomers     | Houston, TX      | 30    | 3.33   |    |
+| 35 | Mabry Haley            | Glow Kids          | San Antonio, TX  | 20    | 2.22   |    |
+| 36 | Noah Sanders           | Kung Fu Quizzers   | Benton, AR       | 15    | 1.67   |    |
+| 37 | Lauren Green           | Kung Fu Quizzers   | Benton, AR       | 10    | 1.11   |    |
+| 37 | Olivia Moore           | Kung Fu Quizzers   | Benton, AR       | 10    | 1.11   |    |
+| 38 | Stephen Prakash        | The Journey        | Charlotte, NC    |       | .00    |    |
+| 38 | Andee Ernest           | Kung Fu Quizzers   | Benton, AR       |       | .00    |    |
+| 38 | Kacey Mayfield         | God\'s Girls       | Oswego, KS       |       | .00    |    |
+| 38 | Jace White             | Mighty Minions     | Cedar Hill, TX   |       | .00    |    |
+| 38 | Isaac Davenport        | Mighty Minions     | Cedar Hill, TX   |       | .00    |    |
+| 38 | Elijah Lee             | Mighty Minions     | Cedar Hill, TX   |       | .00    |    |
+
+
+### Silver (L6)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                     | Church         | W/L | Total | Avg    |
+|---:|--------------------------|----------------|-----|------:|-------:|
+| 1  | Kinetic Konnection       | Bismarck, ND   | 8/1 | 1725  | 191.67 |
+| 2  | ATC FLAMES               | Norcross, GA   | 8/1 | 1540  | 171.11 |
+| 3  | Minecraft Bible Builders | Fortville, IN  | 7/2 | 1445  | 160.56 |
+| 4  | FBI                      | Tucson, AZ     | 5/4 | 1155  | 128.33 |
+| 5  | Renton Royals            | Renton, WA     | 5/4 | 1370  | 152.22 |
+| 6  | Racine Encouragers       | Racine, WI     | 4/5 | 1120  | 124.44 |
+| 7  | Catching Fire            | Montgomery, AL | 3/6 | 1060  | 117.78 |
+| 8  | Lawson - Chad            | Lawson, MO     | 2/7 | 1065  | 118.33 |
+| 9  | 4 girls \'n the Houde    | Billings, MT   | 2/7 | 805   | 89.44  |
+| 10 | M&M\'s of Christ         | Tucson, AZ     | 1/8 | 975   | 108.33 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                     | Church         | Total | Avg    | QO |
+|---:|-------------------|--------------------------|----------------|------:|-------:|---:|
+| 1  | Hannah G Daniel   | ATC FLAMES               | Norcross, GA   | 1210  | 134.44 | 8  |
+| 2  | Jaden Garland     | Renton Royals            | Renton, WA     | 930   | 103.33 | 5  |
+| 3  | Hans Holzhausen   | Minecraft Bible Builders | Fortville, IN  | 770   | 85.56  | 2  |
+| 4  | Ethan Sipes       | Kinetic Konnection       | Bismarck, ND   | 605   | 67.22  |    |
+| 5  | McKenna Walker    | Racine Encouragers       | Racine, WI     | 580   | 64.44  |    |
+| 6  | Taylen Manns      | Lawson - Chad            | Lawson, MO     | 550   | 61.11  | 5  |
+| 7  | Eric Bender       | Kinetic Konnection       | Bismarck, ND   | 545   | 60.56  | 1  |
+| 8  | Seth Archer       | Lawson - Chad            | Lawson, MO     | 485   | 53.89  | 1  |
+| 9  | Kevin Sowers      | Catching Fire            | Montgomery, AL | 460   | 51.11  | 1  |
+| 10 | Micah Houde       | 4 girls \'n the Houde    | Billings, MT   | 455   | 50.56  | 1  |
+| 11 | Max Ortega        | FBI                      | Tucson, AZ     | 430   | 47.78  | 1  |
+| 12 | Elijah Bohlen     | Kinetic Konnection       | Bismarck, ND   | 415   | 46.11  | 5  |
+| 13 | Ian Chilson       | Renton Royals            | Renton, WA     | 405   | 45.00  | 3  |
+| 14 | Anthony Diaz      | FBI                      | Tucson, AZ     | 400   | 44.44  | 1  |
+| 15 | Mark Orth         | Minecraft Bible Builders | Fortville, IN  | 385   | 42.78  | 4  |
+| 16 | Michele Lobato    | M&M\'s of Christ         | Tucson, AZ     | 315   | 35.00  |    |
+| 17 | Madeline Berkey   | M&M\'s of Christ         | Tucson, AZ     | 305   | 33.89  |    |
+| 18 | Peyton Shuffitt   | Catching Fire            | Montgomery, AL | 290   | 32.22  | 1  |
+| 19 | Hannah Royer      | M&M\'s of Christ         | Tucson, AZ     | 280   | 31.11  | 2  |
+| 20 | Ariana Klein      | Racine Encouragers       | Racine, WI     | 260   | 28.89  |    |
+| 21 | Logan Orth        | Minecraft Bible Builders | Fortville, IN  | 245   | 27.22  |    |
+| 22 | Cristina Gonzalez | Catching Fire            | Montgomery, AL | 220   | 24.44  |    |
+| 23 | Nevaeh Walker     | 4 girls \'n the Houde    | Billings, MT   | 205   | 22.78  |    |
+| 24 | Jenny CHRISTOPHER | ATC FLAMES               | Norcross, GA   | 190   | 21.11  |    |
+| 25 | Serenity Orozco   | FBI                      | Tucson, AZ     | 165   | 18.33  | 1  |
+| 26 | Hannah Bohlen     | Kinetic Konnection       | Bismarck, ND   | 160   | 17.78  |    |
+| 27 | Aaliyah Landers   | 4 girls \'n the Houde    | Billings, MT   | 145   | 16.11  |    |
+| 28 | Hans A Daniel     | ATC FLAMES               | Norcross, GA   | 140   | 15.56  |    |
+| 29 | Matthew Walker    | Racine Encouragers       | Racine, WI     | 125   | 13.89  |    |
+| 30 | John Cooley       | FBI                      | Tucson, AZ     | 90    | 10.00  |    |
+| 31 | Allie Haynes      | Catching Fire            | Montgomery, AL | 80    | 8.89   |    |
+| 32 | Ayden Sorensen    | FBI                      | Tucson, AZ     | 70    | 7.78   |    |
+| 33 | Marianna Aguero   | Racine Encouragers       | Racine, WI     | 55    | 6.11   |    |
+| 34 | Myah Berkey       | M&M\'s of Christ         | Tucson, AZ     | 45    | 5.00   |    |
+| 35 | Caitlyn Jackson   | Racine Encouragers       | Racine, WI     | 40    | 4.44   |    |
+| 36 | Miranda Moncayo   | Racine Encouragers       | Racine, WI     | 35    | 3.89   |    |
+| 37 | Jadyn Archer      | Lawson - Chad            | Lawson, MO     | 30    | 3.33   |    |
+| 37 | Gabriella Lobato  | M&M\'s of Christ         | Tucson, AZ     | 30    | 3.33   |    |
+| 37 | Darla Holzhausen  | Minecraft Bible Builders | Fortville, IN  | 30    | 3.33   |    |
+| 38 | Nicholas Tait     | Racine Encouragers       | Racine, WI     | 25    | 2.78   |    |
+| 38 | Jacob Solvang     | Renton Royals            | Renton, WA     | 25    | 2.78   |    |
+| 39 | Lily Robinson     | 4 girls \'n the Houde    | Billings, MT   | 20    | 2.22   |    |
+| 40 | Joy Holzhausen    | Minecraft Bible Builders | Fortville, IN  | 10    | 1.11   |    |
+| 40 | Keira Orth        | Minecraft Bible Builders | Fortville, IN  | 10    | 1.11   |    |
+| 40 | Adeline Powell    | Catching Fire            | Montgomery, AL | 10    | 1.11   |    |
+| 40 | Alicia Akinyi     | Renton Royals            | Renton, WA     | 10    | 1.11   |    |
+| 41 | Malia Goda        | Renton Royals            | Renton, WA     |       | .00    |    |
+| 41 | Brody Acra        | Minecraft Bible Builders | Fortville, IN  |       | .00    |    |
+| 41 | Annalise Jennings | Renton Royals            | Renton, WA     |       | .00    |    |
+| 41 | Julia Loven       | Kinetic Konnection       | Bismarck, ND   |       | .00    |    |
+| 41 | David Doan        | Renton Royals            | Renton, WA     |       | .00    |    |
+| 41 | Kaia Orth         | Minecraft Bible Builders | Fortville, IN  |       | .00    |    |
+| 41 | Ana Gonzalez      | Catching Fire            | Montgomery, AL |       | .00    |    |
+| 41 | Joel CHRISTOPHER  | ATC FLAMES               | Norcross, GA   |       | .00    |    |
+| 42 | Brooke Bentz      | 4 girls \'n the Houde    | Billings, MT   | -20   | -2.22  |    |
+
+
+### Tan (L7)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                                 | Church             | W/L | Total | Avg    |
+|---:|--------------------------------------|--------------------|-----|------:|-------:|
+| 1  | Highpoint Quizzers                   | Port St. Lucie, FL | 6/3 | 1485  | 165.00 |
+| 2  | Westminster Warriors                 | Westminster, CA    | 6/3 | 1340  | 148.89 |
+| 3  | Undignified                          | Dumas, TX          | 6/3 | 1260  | 140.00 |
+| 4  | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN        | 5/4 | 1280  | 142.22 |
+| 5  | The Awakening Force                  | Novi, MI           | 5/4 | 1275  | 141.67 |
+| 6  | Parkway Christian Center             | Grants Pass, OR    | 5/4 | 1235  | 137.22 |
+| 7  | Triple Threat                        | Fruitland, FL      | 4/5 | 1340  | 148.89 |
+| 8  | Dancing Disciples                    | Fort Wayne, IN     | 4/5 | 1215  | 135.00 |
+| 9  | Blood Bought Brothers                | Mustang, OK        | 2/7 | 855   | 95.00  |
+| 10 | Shreveport Bible Investigators       | Shreveport, LA     | 2/7 | 810   | 90.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                                 | Church             | Total | Avg    | QO |
+|---:|---------------------|--------------------------------------|--------------------|------:|-------:|---:|
+| 1  | PJ Ball             | Highpoint Quizzers                   | Port St. Lucie, FL | 970   | 107.78 | 4  |
+| 2  | David Schoening     | Westminster Warriors                 | Westminster, CA    | 755   | 83.89  | 3  |
+| 3  | Cavan McIntyre      | The Awakening Force                  | Novi, MI           | 705   | 78.33  | 3  |
+| 4  | Samuel Deppe        | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN        | 695   | 77.22  | 2  |
+| 5  | Isaac Erickson      | Shreveport Bible Investigators       | Shreveport, LA     | 640   | 71.11  | 3  |
+| 6  | Esther Zavala       | Undignified                          | Dumas, TX          | 615   | 68.33  | 1  |
+| 7  | Isaac Wolf          | Dancing Disciples                    | Fort Wayne, IN     | 580   | 64.44  | 3  |
+| 8  | Dominic LoGiudice   | Triple Threat                        | Fruitland, FL      | 560   | 62.22  |    |
+| 9  | Izabella Hendy      | Parkway Christian Center             | Grants Pass, OR    | 520   | 57.78  | 2  |
+| 10 | Scotlynn Reinhold   | Triple Threat                        | Fruitland, FL      | 475   | 52.78  | 1  |
+| 11 | Marjorie Ehrman     | Dancing Disciples                    | Fort Wayne, IN     | 455   | 50.56  | 4  |
+| 12 | Evangeline Antony   | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN        | 445   | 49.44  | 2  |
+| 13 | Abigail Yatooma     | The Awakening Force                  | Novi, MI           | 430   | 47.78  |    |
+| 14 | Ayden Rush          | Blood Bought Brothers                | Mustang, OK        | 420   | 46.67  | 4  |
+| 15 | Sarai Zavala        | Undignified                          | Dumas, TX          | 315   | 35.00  |    |
+| 16 | Will Thompson       | Triple Threat                        | Fruitland, FL      | 305   | 33.89  | 1  |
+| 17 | Eden Castro         | Highpoint Quizzers                   | Port St. Lucie, FL | 285   | 31.67  | 1  |
+| 18 | Sarah Wiltrout      | Parkway Christian Center             | Grants Pass, OR    | 280   | 31.11  | 1  |
+| 19 | Emersyn VanderVoort | Westminster Warriors                 | Westminster, CA    | 265   | 29.44  |    |
+| 20 | Nathan Wiltrout     | Parkway Christian Center             | Grants Pass, OR    | 250   | 27.78  |    |
+| 21 | Diamond Zavala      | Undignified                          | Dumas, TX          | 220   | 24.44  | 1  |
+| 22 | Neyssia Feria       | Westminster Warriors                 | Westminster, CA    | 215   | 23.89  | 1  |
+| 23 | Zeke DeGeyter       | Parkway Christian Center             | Grants Pass, OR    | 185   | 20.56  | 1  |
+| 24 | Josh Rose           | Blood Bought Brothers                | Mustang, OK        | 175   | 19.44  |    |
+| 25 | Wesley Horn         | Blood Bought Brothers                | Mustang, OK        | 150   | 16.67  |    |
+| 26 | David Freitas       | Highpoint Quizzers                   | Port St. Lucie, FL | 135   | 15.00  | 1  |
+| 27 | Wubitu Ehrman       | Dancing Disciples                    | Fort Wayne, IN     | 130   | 14.44  |    |
+| 28 | Benjamin Antony     | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN        | 115   | 12.78  |    |
+| 28 | Jett King           | Blood Bought Brothers                | Mustang, OK        | 115   | 12.78  |    |
+| 29 | Jonathan Schoening  | Westminster Warriors                 | Westminster, CA    | 105   | 11.67  |    |
+| 30 | Alexis Wilson       | Highpoint Quizzers                   | Port St. Lucie, FL | 100   | 11.11  |    |
+| 31 | Hayley Vecchio      | Undignified                          | Dumas, TX          | 90    | 10.00  |    |
+| 32 | Ethan Swaggerty     | The Awakening Force                  | Novi, MI           | 80    | 8.89   | 1  |
+| 33 | Caroline Tew        | Shreveport Bible Investigators       | Shreveport, LA     | 80    | 8.89   |    |
+| 34 | Abby Shinn          | Dancing Disciples                    | Fort Wayne, IN     | 50    | 5.56   |    |
+| 35 | Braden Tew          | Shreveport Bible Investigators       | Shreveport, LA     | 45    | 5.00   |    |
+| 36 | Luke Swaggerty      | The Awakening Force                  | Novi, MI           | 40    | 4.44   |    |
+| 37 | Ethan Paredes       | Shreveport Bible Investigators       | Shreveport, LA     | 35    | 3.89   |    |
+| 38 | M\'Kayla McDaniel   | Undignified                          | Dumas, TX          | 25    | 2.78   |    |
+| 38 | Sarah Robertson     | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN        | 25    | 2.78   |    |
+| 39 | Chi-Chi Okezie      | The Awakening Force                  | Novi, MI           | 15    | 1.67   |    |
+| 40 | London Hamilton     | Shreveport Bible Investigators       | Shreveport, LA     | 10    | 1.11   |    |
+| 41 | Payton McIntyre     | The Awakening Force                  | Novi, MI           | 5     | .56    |    |
+| 42 | Aaron Barlow        | Parkway Christian Center             | Grants Pass, OR    |       | .00    |    |
+| 42 | Emma Lovejoy        | Highpoint Quizzers                   | Port St. Lucie, FL |       | .00    |    |
+| 42 | Julian Castillo     | Undignified                          | Dumas, TX          |       | .00    |    |
+| 42 | Isabelle Erickson   | Shreveport Bible Investigators       | Shreveport, LA     |       | .00    |    |
+| 42 | Owen Fleck          | Dancing Disciples                    | Fort Wayne, IN     |       | .00    |    |
+| 42 | Kyle Bryant         | Shreveport Bible Investigators       | Shreveport, LA     |       | .00    |    |
+| 42 | Hannah Fry          | Westminster Warriors                 | Westminster, CA    |       | .00    |    |
+| 42 | Carter Ehrman       | Dancing Disciples                    | Fort Wayne, IN     |       | .00    |    |
+| 42 | Ava Robertson       | Word Wise Quiz Kids - Memphis 1st A1 | Cordova, TN        |       | .00    |    |
+| 42 | Joy Wolf            | Dancing Disciples                    | Fort Wayne, IN     |       | .00    |    |
+| 42 | Arielle Erickson    | Shreveport Bible Investigators       | Shreveport, LA     |       | .00    |    |
+| 43 | Ramon Castillo      | Undignified                          | Dumas, TX          | -5    | -0.56  |    |
+| 43 | Jacob Coffey        | Highpoint Quizzers                   | Port St. Lucie, FL | -5    | -0.56  |    |
+
+
+### Yellow (L8)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| #  | Team                      | Church                | W/L | Total | Avg    |
+|---:|---------------------------|-----------------------|-----|------:|-------:|
+| 1  | New Creatures             | Beulah, ND            | 8/1 | 1825  | 202.78 |
+| 2  | Heroes of Faith           | Orlando, FL           | 7/2 | 1730  | 192.22 |
+| 3  | Eagles                    | North Little Rock, AR | 6/3 | 1645  | 182.78 |
+| 4  | Griffin First Gospel Gang | Griffin, GA           | 5/4 | 1340  | 148.89 |
+| 5  | Mount Hope Burlington     | Burlington, MA        | 5/4 | 1395  | 155.00 |
+| 6  | Champion Quizzers         | Las Vegas, NV         | 4/5 | 1100  | 122.22 |
+| 7  | Webster                   | Webster, NY           | 3/6 | 1010  | 112.22 |
+| 8  | Blazing Buzzer Breakers   | Apple Valley, MN      | 3/6 | 995   | 110.56 |
+| 9  | CIA Special Agents        | Mendon, MA            | 3/6 | 825   | 91.67  |
+| 10 | God\'s Property           | Riverside, CA         | 1/8 | 465   | 51.67  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer          | Team                      | Church                | Total | Avg   | QO |
+|---:|------------------|---------------------------|-----------------------|------:|------:|---:|
+| 1  | Trevin Sago      | New Creatures             | Beulah, ND            | 830   | 92.22 | 3  |
+| 2  | Jacob Blackburn  | Eagles                    | North Little Rock, AR | 770   | 85.56 | 2  |
+| 3  | Colson Sago      | New Creatures             | Beulah, ND            | 715   | 79.44 | 4  |
+| 4  | Colton Doling    | Heroes of Faith           | Orlando, FL           | 685   | 76.11 | 4  |
+| 5  | Daniel Tadigiri  | Mount Hope Burlington     | Burlington, MA        | 610   | 67.78 | 2  |
+| 6  | Nick Odle        | Webster                   | Webster, NY           | 590   | 65.56 |    |
+| 7  | Elijah Hicks     | Champion Quizzers         | Las Vegas, NV         | 585   | 65.00 |    |
+| 8  | Hayden Monty     | CIA Special Agents        | Mendon, MA            | 580   | 64.44 | 2  |
+| 9  | Casey McDermitt  | Griffin First Gospel Gang | Griffin, GA           | 560   | 62.22 | 1  |
+| 10 | Jiana Speir      | Griffin First Gospel Gang | Griffin, GA           | 525   | 58.33 | 1  |
+| 11 | Spencer Morrison | Blazing Buzzer Breakers   | Apple Valley, MN      | 515   | 57.22 | 1  |
+| 12 | Elizabeth        | Eagles                    | North Little Rock, AR | 480   | 53.33 | 5  |
+| 13 | Hailey Spence    | Heroes of Faith           | Orlando, FL           | 440   | 48.89 |    |
+| 14 | Jesse King       | Mount Hope Burlington     | Burlington, MA        | 430   | 47.78 | 5  |
+| 15 | Ariel Tucker     | Heroes of Faith           | Orlando, FL           | 400   | 44.44 |    |
+| 16 | Brooke Zermatten | Eagles                    | North Little Rock, AR | 395   | 43.89 | 2  |
+| 17 | Travis Leavitt   | Champion Quizzers         | Las Vegas, NV         | 365   | 40.56 | 1  |
+| 18 | Grace Bassey     | God\'s Property           | Riverside, CA         | 300   | 33.33 | 1  |
+| 19 | Aubryn Sago      | New Creatures             | Beulah, ND            | 280   | 31.11 | 1  |
+| 20 | Ezekiel Hamel    | CIA Special Agents        | Mendon, MA            | 260   | 28.89 |    |
+| 21 | Sawyer Grant     | Griffin First Gospel Gang | Griffin, GA           | 255   | 28.33 |    |
+| 22 | Addison Odle     | Webster                   | Webster, NY           | 225   | 25.00 | 1  |
+| 23 | Alayna Boy       | Heroes of Faith           | Orlando, FL           | 205   | 22.78 | 1  |
+| 24 | Luke Odle        | Webster                   | Webster, NY           | 200   | 22.22 | 2  |
+| 25 | Ian Poch         | Blazing Buzzer Breakers   | Apple Valley, MN      | 200   | 22.22 |    |
+| 26 | Michelle Muddasu | Mount Hope Burlington     | Burlington, MA        | 185   | 20.56 |    |
+| 27 | Cienna Field     | Blazing Buzzer Breakers   | Apple Valley, MN      | 175   | 19.44 | 1  |
+| 28 | Elizabeth Bassey | God\'s Property           | Riverside, CA         | 165   | 18.33 |    |
+| 29 | Tru Young        | Champion Quizzers         | Las Vegas, NV         | 145   | 16.11 |    |
+| 30 | Joel Indipiginja | Mount Hope Burlington     | Burlington, MA        | 140   | 15.56 |    |
+| 31 | Brielle Field    | Blazing Buzzer Breakers   | Apple Valley, MN      | 105   | 11.67 | 1  |
+| 32 | Madison Weir     | Mount Hope Burlington     | Burlington, MA        | 30    | 3.33  |    |
+| 33 | Tanner Longacre  | CIA Special Agents        | Mendon, MA            | 15    | 1.67  |    |
+| 34 | KyLee Hicks      | Champion Quizzers         | Las Vegas, NV         | 5     | .56   |    |
+| 35 | Amelia Stieb     | Champion Quizzers         | Las Vegas, NV         |       | .00   |    |
+| 35 | Ian Sharps       | Eagles                    | North Little Rock, AR |       | .00   |    |
+| 35 | Aliyah Gibson    | Eagles                    | North Little Rock, AR |       | .00   |    |
+| 35 | Lizzie Biek      | Champion Quizzers         | Las Vegas, NV         |       | .00   |    |
+| 36 | Matthew Hamel    | CIA Special Agents        | Mendon, MA            | -30   | -3.33 |    |
+

--- a/_pages/jbq/2017/index.md
+++ b/_pages/jbq/2017/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2017 JBQ Season"
+permalink: /jbq/2017/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+<a href="{% link _pages/jbq/2017/nationals.md %}" class="button is-primary">National Finals</a>
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2017/nationals.md
+++ b/_pages/jbq/2017/nationals.md
@@ -1,0 +1,1077 @@
+---
+layout: page
+title: "2017 National Festival: Cedar Hill, TX"
+permalink: /jbq/2017/nationals/
+date: "2019-12-06"
+toc_title: Results
+menubar_toc: true
+---
+
+## Friday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                   | W/L    | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | Naperville-IL (Naperville (D))                  | 11 / 4 | 2970  | 198   | 19 | 82% |
+| 2.0  | Bowling Green-OH (Jeune et Vivant)              | 11 / 4 | 2830  | 188.7 | 15 | 81% |
+| 3.0  | Omaha-NE (I.C.E.)                               | 11 / 4 | 2565  | 171   | 7  | 74% |
+| 4.0  | Chandler-AZ (God Squad)                         | 11 / 4 | 2555  | 170.3 | 5  | 82% |
+| 5.1  | Monmouth Junction-NJ (Knights 4 Christ - Faith) | 10 / 5 | 2660  | 177.3 | 9  | 80% |
+| 6.0  | Springfield-MO (Shock Diamonds)                 | 10 / 5 | 2495  | 166.3 | 9  | 78% |
+| 7.1  | Cedar Hill-TX (Triple Threat)                   | 9 / 6  | 2470  | 164.7 | 15 | 79% |
+| 8.0  | Mechanicsville-VA (Contagious Kindness)         | 9 / 6  | 2445  | 163   | 11 | 82% |
+| 9.1  | Beulah-ND (New Creatures)                       | 8 / 7  | 2450  | 163.3 | 6  | 93% |
+| 10.0 | Lakeland-FL (Victory Kids)                      | 8 / 7  | 2205  | 147   | 9  | 87% |
+| 11.0 | Concord-NC (S.W.A.T.)                           | 6 / 9  | 1890  | 126   | 6  | 77% |
+| 12.0 | Oswego-KS (God\'s Girls)                        | 5 / 10 | 1925  | 128.3 | 2  | 78% |
+| 13.0 | Mendon-MA (CIA Special Agents)                  | 3 / 12 | 1665  | 111   | 1  | 70% |
+| 14.0 | Racine-WI (Racine B.F.F.)                       | 3 / 12 | 1510  | 100.7 | 3  | 85% |
+| 15.0 | Bellevue-WA (Bright Arrows)                     | 3 / 12 | 1330  | 88.7  | 5  | 74% |
+| 16.0 | Benton-AR (Kung Fu Quizzers)                    | 2 / 13 | 1305  | 87    | 3  | 64% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                                   | Total | Avg   | QO | Q%   |
+|---------:|---------------------|-------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Reagan Stevens      | Naperville-IL (Naperville (D))                  | 1790  | 119.3 | 10 | 87%  |
+| 2        | Hannah Plake        | Springfield-MO (Shock Diamonds)                 | 1720  | 114.7 | 7  | 90%  |
+| 3        | Joel Ravela         | Lakeland-FL (Victory Kids)                      | 1600  | 106.7 | 7  | 86%  |
+| 4        | Nathaniel Jebaraj   | Monmouth Junction-NJ (Knights 4 Christ - Faith) | 1220  | 81.3  | 4  | 76%  |
+| 5        | Angel Walker        | Mechanicsville-VA (Contagious Kindness)         | 1210  | 80.7  | 5  | 85%  |
+| 6        | Trevin Sago         | Beulah-ND (New Creatures)                       | 1180  | 78.7  | 3  | 95%  |
+| 7        | Hayden Monty        | Mendon-MA (CIA Special Agents)                  | 1155  | 77    | 1  | 83%  |
+| 8        | Olivia Neerudu      | Bowling Green-OH (Jeune et Vivant)              | 1145  | 76.3  | 1  | 82%  |
+| 9        | Lademi Davies       | Omaha-NE (I.C.E.)                               | 1010  | 67.3  | 7  | 83%  |
+| 10       | Noah Claunch        | Cedar Hill-TX (Triple Threat)                   | 960   | 64    | 6  | 88%  |
+| 11       | Samuel Jebaraj      | Monmouth Junction-NJ (Knights 4 Christ - Faith) | 950   | 63.3  | 4  | 87%  |
+| 12       | Lester Threatt      | Concord-NC (S.W.A.T.)                           | 950   | 63.3  | 3  | 83%  |
+| 13       | Timothy Mathew      | Chandler-AZ (God Squad)                         | 915   | 61    |    | 79%  |
+| 14       | Kona Fern           | Omaha-NE (I.C.E.)                               | 870   | 58    |    | 75%  |
+| 15       | Abigail Slembarski  | Bowling Green-OH (Jeune et Vivant)              | 845   | 56.3  | 3  | 81%  |
+| 16       | Noah Smith          | Bowling Green-OH (Jeune et Vivant)              | 840   | 56    | 11 | 81%  |
+| 17       | Joseph Barajas      | Cedar Hill-TX (Triple Threat)                   | 790   | 52.7  | 8  | 75%  |
+| 18       | Savannah Harper     | Mechanicsville-VA (Contagious Kindness)         | 785   | 52.3  | 5  | 81%  |
+| 19       | Joshua Malayail     | Chandler-AZ (God Squad)                         | 770   | 51.3  | 1  | 70%  |
+| 20       | McKinley Stevens    | Naperville-IL (Naperville (D))                  | 765   | 51    | 9  | 78%  |
+| 21       | Carmen Eisenbrandt  | Oswego-KS (God\'s Girls)                        | 750   | 50    |    | 73%  |
+| 22       | Adeline Keith       | Cedar Hill-TX (Triple Threat)                   | 720   | 48    | 1  | 75%  |
+| 23       | Colson Sago         | Beulah-ND (New Creatures)                       | 690   | 46    |    | 92%  |
+| 24       | Angelina Arasavelli | Bellevue-WA (Bright Arrows)                     | 640   | 42.7  |    | 74%  |
+| 25       | Tyler Kelly         | Benton-AR (Kung Fu Quizzers)                    | 635   | 42.3  | 2  | 61%  |
+| 26       | Samuel Abothu       | Bellevue-WA (Bright Arrows)                     | 585   | 39    | 5  | 79%  |
+| 27       | Cecillia Newby      | Oswego-KS (God\'s Girls)                        | 530   | 35.3  |    | 91%  |
+| 28       | Elli Woodward       | Springfield-MO (Shock Diamonds)                 | 520   | 34.7  | 2  | 73%  |
+| 29       | Aleena Daniel       | Chandler-AZ (God Squad)                         | 500   | 33.3  | 3  | 89%  |
+| 30       | Jocelyn Fredrick    | Monmouth Junction-NJ (Knights 4 Christ - Faith) | 490   | 32.7  | 1  | 77%  |
+| 31       | Brendan Van Offeren | Racine-WI (Racine B.F.F.)                       | 475   | 31.7  | 2  | 76%  |
+| **\*31** | Grace Noel          | Oswego-KS (God\'s Girls)                        | 475   | 31.7  | 2  | 75%  |
+| 32       | Zoe Lipor           | Racine-WI (Racine B.F.F.)                       | 420   | 28    |    | 92%  |
+| **\*32** | Pierce Stevens      | Naperville-IL (Naperville (D))                  | 420   | 28    |    | 81%  |
+| 33       | Marianna Aguero     | Racine-WI (Racine B.F.F.)                       | 415   | 27.7  | 1  | 92%  |
+| 34       | Gabe Hudson         | Concord-NC (S.W.A.T.)                           | 400   | 26.7  | 3  | 67%  |
+| 35       | Nathan Joiner       | Lakeland-FL (Victory Kids)                      | 390   | 26    | 2  | 86%  |
+| 36       | Honey Schwickerath  | Mechanicsville-VA (Contagious Kindness)         | 375   | 25    | 1  | 77%  |
+| 37       | Kristyn Bauer       | Beulah-ND (New Creatures)                       | 325   | 21.7  | 2  | 87%  |
+| 38       | Jordan Torres       | Concord-NC (S.W.A.T.)                           | 275   | 18.3  |    | 86%  |
+| 39       | Charlotte Elliott   | Omaha-NE (I.C.E.)                               | 265   | 17.7  |    | 67%  |
+| 40       | Aubryn Sago         | Beulah-ND (New Creatures)                       | 255   | 17    | 1  | 96%  |
+| 41       | Ezekiel Hamel       | Mendon-MA (CIA Special Agents)                  | 245   | 16.3  |    | 64%  |
+| **\*41** | Aaron Martin        | Omaha-NE (I.C.E.)                               | 245   | 16.3  |    | 63%  |
+| 42       | Bethany Plake       | Springfield-MO (Shock Diamonds)                 | 235   | 15.7  |    | 65%  |
+| 43       | Noah Sanders        | Benton-AR (Kung Fu Quizzers)                    | 220   | 14.7  |    | 67%  |
+| 44       | Olivia Moore        | Benton-AR (Kung Fu Quizzers)                    | 205   | 13.7  |    | 91%  |
+| 45       | Anita Mathew        | Chandler-AZ (God Squad)                         | 185   | 12.3  | 1  | 95%  |
+| 46       | Shreya Ganeshan     | Chandler-AZ (God Squad)                         | 185   | 12.3  |    | 95%  |
+| **\*46** | Rylan Hance         | Lakeland-FL (Victory Kids)                      | 185   | 12.3  |    | 89%  |
+| 47       | Caden Sanders       | Benton-AR (Kung Fu Quizzers)                    | 180   | 12    | 1  | 57%  |
+| 48       | Nolan King          | Omaha-NE (I.C.E.)                               | 175   | 11.7  |    | 71%  |
+| 49       | Charlotte Smith     | Concord-NC (S.W.A.T.)                           | 150   | 10    |    | 100% |
+| **\*49** | Matthew Hamel       | Mendon-MA (CIA Special Agents)                  | 150   | 10    |    | 57%  |
+| 50       | Delaney Reynolds    | Oswego-KS (God\'s Girls)                        | 120   | 8     |    | 100% |
+| **\*50** | Nicholas Tait       | Racine-WI (Racine B.F.F.)                       | 120   | 8     |    | 82%  |
+| **\*50** | Braidan Morais      | Mendon-MA (CIA Special Agents)                  | 120   | 8     |    | 67%  |
+| 51       | Roby Matta          | Bellevue-WA (Bright Arrows)                     | 105   | 7     |    | 62%  |
+| 52       | Seth Hudson         | Concord-NC (S.W.A.T.)                           | 100   | 6.7   |    | 75%  |
+| 53       | Amanda Moncayo      | Racine-WI (Racine B.F.F.)                       | 80    | 5.3   |    | 100% |
+| 54       | Berkley Adams       | Mechanicsville-VA (Contagious Kindness)         | 75    | 5     |    | 71%  |
+| 55       | Kacey Mayfield      | Oswego-KS (God\'s Girls)                        | 50    | 3.3   |    | 100% |
+| 56       | Andee Earnest       | Benton-AR (Kung Fu Quizzers)                    | 40    | 2.7   |    | 100% |
+| 57       | Hayden Wright       | Lakeland-FL (Victory Kids)                      | 30    | 2     |    | 100% |
+| 58       | Riley Huskey        | Benton-AR (Kung Fu Quizzers)                    | 20    | 1.3   |    | 100% |
+| **\*58** | Lydia Hill          | Concord-NC (S.W.A.T.)                           | 20    | 1.3   |    | 99%  |
+| **\*58** | Anna Le             | Springfield-MO (Shock Diamonds)                 | 20    | 1.3   |    | 62%  |
+| 59       | Andrew Greenwell    | Benton-AR (Kung Fu Quizzers)                    | 5     | .3    |    | 50%  |
+| 60       | Hannah Noel         | Oswego-KS (God\'s Girls)                        | 0     |       |    |      |
+| **\*60** | Jace Hance          | Lakeland-FL (Victory Kids)                      | 0     |       |    |      |
+| **\*60** | Michaekela Irving   | Benton-AR (Kung Fu Quizzers)                    | 0     |       |    |      |
+| 61       | Tanner Longacre     | Mendon-MA (CIA Special Agents)                  | -5    | -.3   |    |      |
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                         | W/L    | Total | Avg   | QO | Q%  |
+|-----:|---------------------------------------|--------|------:|------:|---:|----:|
+| 1.1  | Garland-TX (Guardians of Gospel)      | 12 / 3 | 2670  | 178   | 13 | 73% |
+| 2.0  | Naperville-IL (Naperville (C))        | 12 / 3 | 3015  | 201   | 23 | 89% |
+| 3.0  | San Jose-CA (Warriors of the faith)   | 11 / 4 | 2770  | 184.7 | 16 | 89% |
+| 4.1  | Wayne-NJ (CTI - JOY)                  | 10 / 5 | 2415  | 161   | 12 | 77% |
+| 5.0  | Springfield-MO (Fried Pickles)        | 10 / 5 | 2285  | 152.3 | 13 | 77% |
+| 6.1  | Tallahassee-FL (More Than Conquerors) | 9 / 6  | 2505  | 167   | 12 | 84% |
+| 7.0  | Bristow-VA (Gushers)                  | 9 / 6  | 2535  | 169   | 11 | 77% |
+| 8.1  | Great Bend-KS (Bible Warriors)        | 8 / 7  | 2240  | 149.3 | 2  | 83% |
+| 9.0  | Lawson-MO (Lawson-Connie )            | 8 / 7  | 2360  | 157.3 | 8  | 87% |
+| 10.1 | Racine-WI (Racine E.P.I.C.)           | 7 / 8  | 2190  | 146   | 10 | 78% |
+| 11.0 | Rogers-AR (Rogers First A/G)          | 7 / 8  | 2150  | 143.3 | 4  | 91% |
+| 12.1 | Williston-ND (Adam\'s Ribs)           | 5 / 10 | 1790  | 119.3 | 5  | 73% |
+| 13.0 | Kinston-NC (Kinston - Tanglewood)     | 5 / 10 | 1835  | 122.3 | 6  | 77% |
+| 14.0 | Dumas-TX (Undignified)                | 3 / 12 | 1665  | 111   | 3  | 69% |
+| 15.0 | Cumming-GA (Righteous Warriors)       | 2 / 13 | 1650  | 110   | 5  | 65% |
+| 16.0 | Louisville-KY (Redeemed)              | 2 / 13 | 1315  | 87.7  | 4  | 86% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                         | Total | Avg   | QO | Q%   |
+|---------:|--------------------|---------------------------------------|------:|------:|---:|-----:|
+| 1        | Shawn Timothy      | Naperville-IL (Naperville (C))        | 2045  | 136.3 | 13 | 93%  |
+| 2        | Samuel E. Jebaraj  | San Jose-CA (Warriors of the faith)   | 1975  | 131.7 | 14 | 88%  |
+| 3        | Grace Searcy       | Lawson-MO (Lawson-Connie )            | 1420  | 94.7  | 5  | 85%  |
+| 4        | Elijah Stewart     | Tallahassee-FL (More Than Conquerors) | 1375  | 91.7  | 11 | 82%  |
+| 5        | Chineme Oriaku     | Wayne-NJ (CTI - JOY)                  | 1270  | 84.7  | 6  | 80%  |
+| 6        | Julia Barnes       | Louisville-KY (Redeemed)              | 1185  | 79    | 4  | 88%  |
+| 7        | McKenna Walker     | Racine-WI (Racine E.P.I.C.)           | 1180  | 78.7  | 3  | 84%  |
+| 8        | Kaitlyn Ramsey     | Springfield-MO (Fried Pickles)        | 1100  | 73.3  | 6  | 70%  |
+| 9        | Kathline Newland   | Bristow-VA (Gushers)                  | 1055  | 70.3  | 4  | 71%  |
+| 10       | Esther Zavala      | Dumas-TX (Undignified)                | 1030  | 68.7  | 2  | 71%  |
+| 11       | Katy Nix           | Williston-ND (Adam\'s Ribs)           | 1010  | 67.3  | 1  | 93%  |
+| 12       | Sarah Clements     | Kinston-NC (Kinston - Tanglewood)     | 1005  | 67    | 2  | 82%  |
+| 13       | Hannah Cheney      | Rogers-AR (Rogers First A/G)          | 965   | 64.3  | 3  | 90%  |
+| 14       | Ellen Smith        | Bristow-VA (Gushers)                  | 915   | 61    | 6  | 80%  |
+| 15       | Jensen Suresh      | Naperville-IL (Naperville (C))        | 860   | 57.3  | 10 | 83%  |
+| 16       | Matthew Walker     | Racine-WI (Racine E.P.I.C.)           | 845   | 56.3  | 7  | 73%  |
+| 17       | Nathan Koch        | Garland-TX (Guardians of Gospel)      | 840   | 56    | 6  | 68%  |
+| 18       | Pravarsh Kalapala  | Cumming-GA (Righteous Warriors)       | 835   | 55.7  | 3  | 64%  |
+| 19       | Zachary Bernardini | Rogers-AR (Rogers First A/G)          | 800   | 53.3  | 1  | 93%  |
+| 20       | Emma Stewart       | Tallahassee-FL (More Than Conquerors) | 765   | 51    |    | 92%  |
+| 21       | Morgan MacKinney   | Great Bend-KS (Bible Warriors)        | 735   | 49    |    | 96%  |
+| 22       | Waylon Moore       | Kinston-NC (Kinston - Tanglewood)     | 705   | 47    | 4  | 70%  |
+| 23       | Addy Dougherty     | Great Bend-KS (Bible Warriors)        | 680   | 45.3  | 1  | 73%  |
+| 24       | Makenna Koch       | Garland-TX (Guardians of Gospel)      | 635   | 42.3  |    | 75%  |
+| 25       | Rylie Pugh         | Garland-TX (Guardians of Gospel)      | 620   | 41.3  | 7  | 76%  |
+| 26       | Alyssa Ramsey      | Springfield-MO (Fried Pickles)        | 615   | 41    | 3  | 77%  |
+| 27       | Kelechi Oriaku     | Wayne-NJ (CTI - JOY)                  | 600   | 40    | 5  | 75%  |
+| 28       | Catie Wolfe        | Springfield-MO (Fried Pickles)        | 565   | 37.7  | 4  | 84%  |
+| 29       | Joanna Paulraj     | Wayne-NJ (CTI - JOY)                  | 545   | 36.3  | 1  | 75%  |
+| 30       | Joanne Ramesh      | Garland-TX (Guardians of Gospel)      | 425   | 28.3  |    | 95%  |
+| 31       | Kendra Hall        | Williston-ND (Adam\'s Ribs)           | 420   | 28    | 4  | 79%  |
+| 32       | Joshua Panuganti   | Cumming-GA (Righteous Warriors)       | 405   | 27    | 2  | 67%  |
+| 33       | Caydence Calvert   | Lawson-MO (Lawson-Connie )            | 400   | 26.7  | 2  | 91%  |
+| 34       | Kayleigh Henley    | Bristow-VA (Gushers)                  | 385   | 25.7  | 1  | 75%  |
+| 35       | Hayley Vecchio     | Dumas-TX (Undignified)                | 375   | 25    | 1  | 68%  |
+| 36       | Ella Krier         | Great Bend-KS (Bible Warriors)        | 340   | 22.7  |    | 100% |
+| 37       | Jeremiah Godson    | San Jose-CA (Warriors of the faith)   | 335   | 22.3  | 2  | 84%  |
+| 38       | Steven Dasari      | Cumming-GA (Righteous Warriors)       | 335   | 22.3  |    | 59%  |
+| 39       | Taylor Searcy      | Lawson-MO (Lawson-Connie )            | 330   | 22    | 1  | 85%  |
+| 40       | Tehillah Jebaraj   | San Jose-CA (Warriors of the faith)   | 310   | 20.7  |    | 94%  |
+| 41       | Charlie Zimmerman  | Tallahassee-FL (More Than Conquerors) | 305   | 20.3  | 1  | 79%  |
+| 42       | Cole MacKinney     | Great Bend-KS (Bible Warriors)        | 270   | 18    | 1  | 76%  |
+| 43       | Diamond Zavala     | Dumas-TX (Undignified)                | 245   | 16.3  |    | 80%  |
+| 44       | Makayla Burton     | Great Bend-KS (Bible Warriors)        | 215   | 14.3  |    | 88%  |
+| 45       | Hannah O\'Dell     | Lawson-MO (Lawson-Connie )            | 210   | 14    |    | 90%  |
+| 46       | Landon Manweiler   | Rogers-AR (Rogers First A/G)          | 195   | 13    |    | 95%  |
+| 47       | Tielyr Boysen      | Rogers-AR (Rogers First A/G)          | 190   | 12.7  |    | 84%  |
+| 48       | Audrey Mason       | Bristow-VA (Gushers)                  | 160   | 10.7  |    | 100% |
+| 49       | Andrew Lopez       | Garland-TX (Guardians of Gospel)      | 150   | 10    |    | 61%  |
+| **\*49** | Dallas Pitman      | Williston-ND (Adam\'s Ribs)           | 150   | 10    |    | 44%  |
+| 50       | Glennis Ho         | San Jose-CA (Warriors of the faith)   | 140   | 9.3   |    | 100% |
+| 51       | Rachael Noble      | Kinston-NC (Kinston - Tanglewood)     | 125   | 8.3   |    | 93%  |
+| 52       | Kara Barnes        | Louisville-KY (Redeemed)              | 120   | 8     |    | 77%  |
+| **\*52** | Zachary Hartley    | Williston-ND (Adam\'s Ribs)           | 120   | 8     |    | 55%  |
+| 53       | Jayden Suresh      | Naperville-IL (Naperville (C))        | 110   | 7.3   |    | 100% |
+| 54       | Amy Draxton        | Williston-ND (Adam\'s Ribs)           | 90    | 6     |    | 83%  |
+| 55       | Angela Peddapalli  | Cumming-GA (Righteous Warriors)       | 75    | 5     |    | 89%  |
+| 56       | Allison Weiler     | Racine-WI (Racine E.P.I.C.)           | 70    | 4.7   |    | 80%  |
+| 57       | Kaylin Steinmetz   | Tallahassee-FL (More Than Conquerors) | 60    | 4     |    | 100% |
+| **\*57** | Razalyn Kramer     | Racine-WI (Racine E.P.I.C.)           | 60    | 4     |    | 100% |
+| 58       | Miranda Moncayo    | Racine-WI (Racine E.P.I.C.)           | 40    | 2.7   |    | 75%  |
+| 59       | Michael Newland    | Bristow-VA (Gushers)                  | 20    | 1.3   |    | 50%  |
+| 60       | Julian Castillo    | Dumas-TX (Undignified)                | 15    | 1     |    | 39%  |
+| 61       | Miraclin Jebastian | San Jose-CA (Warriors of the faith)   | 10    | .7    |    | 99%  |
+| **\*61** | Amanda Barnes      | Louisville-KY (Redeemed)              | 10    | .7    |    | 99%  |
+| 62       | McKenna Black      | Springfield-MO (Fried Pickles)        | 5     | .3    |    | 99%  |
+| 63       | Trinidy Calvary    | Racine-WI (Racine E.P.I.C.)           | 0     |       |    |      |
+| **\*63** | Reese Pugh         | Garland-TX (Guardians of Gospel)      | 0     |       |    |      |
+| **\*63** | M\'Kayla McDaniel  | Dumas-TX (Undignified)                | 0     |       |    |      |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                      | W/L    | Total | Avg   | QO | Q%  |
+|-----:|----------------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | Angleton-TX (Heart of a Lion)                      | 14 / 1 | 2960  | 197.3 | 23 | 89% |
+| 2.0  | Naperville-IL (Naperville (M))                     | 13 / 2 | 2875  | 191.7 | 25 | 80% |
+| 3.0  | Monmouth Junction-NJ (Knights 4 Christ -Salvation) | 12 / 3 | 2980  | 198.7 | 14 | 84% |
+| 4.0  | Shakopee-MN (Minds of the Bible)                   | 11 / 4 | 2720  | 181.3 | 15 | 84% |
+| 5.1  | Akron-OH (Girls on a Mission)                      | 10 / 5 | 2890  | 192.7 | 13 | 88% |
+| 6.0  | Waxahachie-TX (Kids For Christ)                    | 10 / 5 | 2540  | 169.3 | 13 | 75% |
+| 7.1  | Greensboro-NC (Calvary Blue)                       | 9 / 6  | 2275  | 151.7 | 10 | 87% |
+| 8.0  | New Whiteland-IN (Pardon the Interruption)         | 9 / 6  | 2405  | 160.3 | 7  | 73% |
+| 9.0  | Norcross -GA (ATC FLAMES )                         | 7 / 8  | 2365  | 157.7 | 13 | 79% |
+| 10.1 | Rochester-NY (Faith Temple)                        | 6 / 9  | 1760  | 117.3 | 6  | 67% |
+| 11.0 | Billings -MT (New Life Billings)                   | 6 / 9  | 2065  | 137.7 | 7  | 79% |
+| 12.0 | Urbandale-IA (Fireball Ninjas)                     | 5 / 10 | 1670  | 111.3 | 5  | 72% |
+| 13.0 | Lee\'s Summit-MO (Bible Ninjas)                    | 4 / 11 | 1470  | 98    | 5  | 66% |
+| 14.0 | Cordova-TN (Word Wise Quiz Kids)                   | 3 / 12 | 1780  | 118.7 | 3  | 84% |
+| 15.0 | Riverside-CA (God\'s Property)                     | 1 / 14 | 1095  | 73    | 1  | 84% |
+| 16.0 | Overland Park-KS (KC Quizzers)                     | 0 / 15 | 1170  | 78    | 1  | 67% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                    | Team / Church                                      | Total | Avg   | QO | Q%   |
+|---------:|----------------------------|----------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Hannah Vanaja Alapati      | Angleton-TX (Heart of a Lion)                      | 2130  | 142   | 14 | 93%  |
+| 2        | Shaymis Powell             | Naperville-IL (Naperville (M))                     | 1870  | 124.7 | 13 | 83%  |
+| 3        | Elylah Stager              | Akron-OH (Girls on a Mission)                      | 1740  | 116   | 7  | 87%  |
+| 4        | Remi Briglin               | Monmouth Junction-NJ (Knights 4 Christ -Salvation) | 1415  | 94.3  | 4  | 82%  |
+| 5        | Joy Escobar                | Waxahachie-TX (Kids For Christ)                    | 1385  | 92.3  | 5  | 77%  |
+| 6        | Hannah Gabriela Daniel     | Norcross -GA (ATC FLAMES )                         | 1375  | 91.7  | 6  | 77%  |
+| 7        | Gabby Pahl                 | Shakopee-MN (Minds of the Bible)                   | 1315  | 87.7  | 6  | 92%  |
+| 8        | Micah Houde                | Billings -MT (New Life Billings)                   | 1260  | 84    | 4  | 78%  |
+| 9        | Emma Martello              | Greensboro-NC (Calvary Blue)                       | 1240  | 82.7  | 6  | 84%  |
+| 10       | Samuel Deppe               | Cordova-TN (Word Wise Quiz Kids)                   | 1145  | 76.3  | 3  | 85%  |
+| 11       | Larissa Cox                | New Whiteland-IN (Pardon the Interruption)         | 1080  | 72    | 6  | 82%  |
+| 12       | Josh Monickaraj            | Rochester-NY (Faith Temple)                        | 1040  | 69.3  | 3  | 69%  |
+| 13       | Jack Martello              | Greensboro-NC (Calvary Blue)                       | 1035  | 69    | 4  | 90%  |
+| 14       | Jason Theodore             | Monmouth Junction-NJ (Knights 4 Christ -Salvation) | 1030  | 68.7  | 7  | 87%  |
+| 15       | Shaylee Powell             | Naperville-IL (Naperville (M))                     | 895   | 59.7  | 12 | 80%  |
+| 16       | Christian Chowdary Alapati | Angleton-TX (Heart of a Lion)                      | 830   | 55.3  | 9  | 85%  |
+| 17       | Andrian Kolliegbo          | New Whiteland-IN (Pardon the Interruption)         | 830   | 55.3  | 1  | 82%  |
+| 18       | Jenny Christopher          | Norcross -GA (ATC FLAMES )                         | 805   | 53.7  | 7  | 83%  |
+| 19       | Chloe Eder                 | Akron-OH (Girls on a Mission)                      | 770   | 51.3  | 4  | 89%  |
+| 20       | Alana Hight                | Urbandale-IA (Fireball Ninjas)                     | 765   | 51    | 2  | 80%  |
+| 21       | Lauren Pahl                | Shakopee-MN (Minds of the Bible)                   | 745   | 49.7  | 9  | 78%  |
+| 22       | Josiah Brookbank           | Lee\'s Summit-MO (Bible Ninjas)                    | 735   | 49    | 3  | 64%  |
+| 23       | Truett Van Slyke           | Overland Park-KS (KC Quizzers)                     | 725   | 48.3  |    | 73%  |
+| 24       | Addie Putman               | Shakopee-MN (Minds of the Bible)                   | 660   | 44    |    | 83%  |
+| 25       | Grace Bassey               | Riverside-CA (God\'s Property)                     | 615   | 41    | 1  | 78%  |
+| 26       | Ismael Rodriguez           | Waxahachie-TX (Kids For Christ)                    | 595   | 39.7  | 1  | 75%  |
+| 27       | Hector Rivera              | Waxahachie-TX (Kids For Christ)                    | 550   | 36.7  | 7  | 74%  |
+| 28       | Freya Briglin              | Monmouth Junction-NJ (Knights 4 Christ -Salvation) | 535   | 35.7  | 3  | 83%  |
+| 29       | Jase Cooper                | Billings -MT (New Life Billings)                   | 505   | 33.7  | 3  | 84%  |
+| 30       | Elizabeth Bassey           | Riverside-CA (God\'s Property)                     | 485   | 32.3  |    | 94%  |
+| 31       | Jayde Todd                 | Urbandale-IA (Fireball Ninjas)                     | 420   | 28    | 1  | 55%  |
+| 32       | Ben Butler                 | Rochester-NY (Faith Temple)                        | 410   | 27.3  | 3  | 60%  |
+| 33       | Denice Mackey              | Akron-OH (Girls on a Mission)                      | 380   | 25.3  | 2  | 87%  |
+| 34       | Mackenzie Hight            | Urbandale-IA (Fireball Ninjas)                     | 365   | 24.3  | 2  | 84%  |
+| 35       | Peter Van Slyke            | Overland Park-KS (KC Quizzers)                     | 365   | 24.3  | 1  | 62%  |
+| 36       | Casen Gray                 | Lee\'s Summit-MO (Bible Ninjas)                    | 355   | 23.7  | 2  | 64%  |
+| 37       | Benjamin Antony            | Cordova-TN (Word Wise Quiz Kids)                   | 330   | 22    |    | 83%  |
+| 38       | George Hoelzel             | Lee\'s Summit-MO (Bible Ninjas)                    | 285   | 19    |    | 95%  |
+| 39       | Sarah Robertson            | Cordova-TN (Word Wise Quiz Kids)                   | 240   | 16    |    | 83%  |
+| **\*39** | Lucas Brunson              | New Whiteland-IN (Pardon the Interruption)         | 240   | 16    |    | 78%  |
+| 40       | Graham Little              | New Whiteland-IN (Pardon the Interruption)         | 210   | 14    |    | 56%  |
+| 41       | Chelsea Maynard            | Rochester-NY (Faith Temple)                        | 180   | 12    |    | 67%  |
+| 42       | Mason Ostermiller          | Billings -MT (New Life Billings)                   | 150   | 10    |    | 94%  |
+| **\*42** | Kaiden Taylor              | Billings -MT (New Life Billings)                   | 150   | 10    |    | 58%  |
+| 43       | Hans Asher Daniel          | Norcross -GA (ATC FLAMES )                         | 135   | 9     |    | 83%  |
+| 44       | Hector Siaca               | Rochester-NY (Faith Temple)                        | 130   | 8.7   |    | 80%  |
+| 45       | Taya Todd                  | Urbandale-IA (Fireball Ninjas)                     | 120   | 8     |    | 87%  |
+| 46       | Abdiel Parra               | Naperville-IL (Naperville (M))                     | 110   | 7.3   |    | 65%  |
+| 47       | Gabe Diebold               | Lee\'s Summit-MO (Bible Ninjas)                    | 95    | 6.3   |    | 54%  |
+| 48       | Justice Sanchez            | Overland Park-KS (KC Quizzers)                     | 80    | 5.3   |    | 65%  |
+| 49       | Ava Robertson              | Cordova-TN (Word Wise Quiz Kids)                   | 65    | 4.3   |    | 87%  |
+| 50       | Joel Christopher           | Norcross -GA (ATC FLAMES )                         | 55    | 3.7   |    | 70%  |
+| 51       | Daniel Sprague             | New Whiteland-IN (Pardon the Interruption)         | 40    | 2.7   |    | 100% |
+| 52       | Grace Ruiz                 | Waxahachie-TX (Kids For Christ)                    | 10    | .7    |    | 50%  |
+| 53       | William Okyere             | New Whiteland-IN (Pardon the Interruption)         | 5     | .3    |    | 44%  |
+| 54       | Alethia Martin             | Waxahachie-TX (Kids For Christ)                    | 0     |       |    |      |
+| **\*54** | Brianna Madonia            | Greensboro-NC (Calvary Blue)                       | 0     |       |    |      |
+| **\*54** | Bella Sharbono-hafner      | Billings -MT (New Life Billings)                   | 0     |       |    |      |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                   | W/L    | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | Houston-TX (The Chosen Ones)                    | 12 / 3 | 3070  | 204.7 | 19 | 85% |
+| 2.0  | Naperville-IL (Naperville (S))                  | 12 / 3 | 2765  | 184.3 | 19 | 81% |
+| 3.0  | Lawson-MO (Lawson-Wendy)                        | 12 / 3 | 2650  | 176.7 | 13 | 84% |
+| 4.0  | Marietta-GA (Royal Diadem)                      | 10 / 5 | 2540  | 169.3 | 14 | 83% |
+| 5.0  | Shelby Township-MI (Jedi Knights)               | 10 / 5 | 2520  | 168   | 11 | 80% |
+| 6.0  | Bothell-WA (Cedar Park Eagles)                  | 10 / 5 | 2495  | 166.3 | 7  | 72% |
+| 7.0  | Ravenna-OH (God\'s Golden Girls)                | 10 / 5 | 2345  | 156.3 | 13 | 82% |
+| 8.0  | Richmond Hill -NY (Bethlehem Church)            | 8 / 7  | 2480  | 165.3 | 12 | 74% |
+| 9.0  | Lakeville-MN (Under Armour of God)              | 8 / 7  | 2350  | 156.7 | 10 | 82% |
+| 10.0 | Brewton-AL (Connected God Squad)                | 8 / 7  | 2275  | 151.7 | 7  | 83% |
+| 11.0 | Fordyce-AR (Fordyce Bible Bugs)                 | 6 / 9  | 1730  | 115.3 | 7  | 71% |
+| 12.0 | Fruitland Park-FL (Kingdom Quizzers)            | 5 / 10 | 2205  | 147   | 8  | 78% |
+| 13.0 | Mustang-OK (United for Christ)                  | 4 / 11 | 1695  | 113   | 3  | 83% |
+| 14.0 | Webster-NY (Webster)                            | 3 / 12 | 1670  | 111.3 | 4  | 66% |
+| 15.0 | Collierville-TN (Collierville Freedom Fighters) | 1 / 14 | 1335  | 89    |    | 89% |
+| 16.0 | Emporia-KS (God\'s Masterpiece)                 | 1 / 14 | 1070  | 71.3  | 2  | 76% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                 | Team / Church                                   | Total | Avg   | QO | Q%   |
+|---------:|-------------------------|-------------------------------------------------|------:|------:|---:|-----:|
+| 1        | David Biruduganti       | Naperville-IL (Naperville (S))                  | 1765  | 117.7 | 9  | 84%  |
+| 2        | Meleah Sawastuk         | Ravenna-OH (God\'s Golden Girls)                | 1650  | 110   | 8  | 86%  |
+| 3        | Seth Archer             | Lawson-MO (Lawson-Wendy)                        | 1580  | 105.3 | 7  | 77%  |
+| 4        | Shekinah Isaiah         | Bothell-WA (Cedar Park Eagles)                  | 1550  | 103.3 | 4  | 88%  |
+| 5        | Shreya Joy              | Marietta-GA (Royal Diadem)                      | 1490  | 99.3  | 7  | 88%  |
+| 6        | Faith Buchanan          | Richmond Hill -NY (Bethlehem Church)            | 1445  | 96.3  | 8  | 69%  |
+| 7        | Michael Ukonu           | Houston-TX (The Chosen Ones)                    | 1335  | 89    | 6  | 82%  |
+| 8        | Garrett Crescenti       | Shelby Township-MI (Jedi Knights)               | 1315  | 87.7  | 4  | 84%  |
+| 9        | Isabella Kashubin       | Lakeville-MN (Under Armour of God)              | 1265  | 84.3  | 3  | 80%  |
+| 10       | Brayden Shepherd        | Fruitland Park-FL (Kingdom Quizzers)            | 1220  | 81.3  | 4  | 75%  |
+| 11       | James Coleman           | Brewton-AL (Connected God Squad)                | 1135  | 75.7  | 3  | 85%  |
+| 12       | Brandon Ukonu           | Houston-TX (The Chosen Ones)                    | 940   | 62.7  | 8  | 83%  |
+| 13       | Eli Turner              | Fordyce-AR (Fordyce Bible Bugs)                 | 890   | 59.3  | 2  | 73%  |
+| 14       | Steve Joy               | Marietta-GA (Royal Diadem)                      | 885   | 59    | 7  | 77%  |
+| 15       | Joel Paul               | Collierville-TN (Collierville Freedom Fighters) | 880   | 58.7  |    | 93%  |
+| 16       | Braylon Hood-Colbert    | Mustang-OK (United for Christ)                  | 830   | 55.3  | 1  | 80%  |
+| 17       | Iynu Akanbi             | Houston-TX (The Chosen Ones)                    | 795   | 53    | 5  | 92%  |
+| 18       | Samuel Biruduganti      | Naperville-IL (Naperville (S))                  | 760   | 50.7  | 10 | 75%  |
+| 19       | Noah Small              | Emporia-KS (God\'s Masterpiece)                 | 735   | 49    | 2  | 75%  |
+| 20       | Austanne Barney         | Shelby Township-MI (Jedi Knights)               | 705   | 47    | 7  | 79%  |
+| 21       | Ansley Hornaday         | Fordyce-AR (Fordyce Bible Bugs)                 | 705   | 47    | 5  | 66%  |
+| 22       | Jocelyn Calvert         | Lawson-MO (Lawson-Wendy)                        | 685   | 45.7  | 6  | 93%  |
+| 23       | Gavin Galloway          | Brewton-AL (Connected God Squad)                | 655   | 43.7  | 4  | 84%  |
+| 24       | Nick Odle               | Webster-NY (Webster)                            | 635   | 42.3  |    | 62%  |
+| 25       | Isaiah Kashubin         | Lakeville-MN (Under Armour of God)              | 630   | 42    | 7  | 80%  |
+| 26       | Emily Sawastuk          | Ravenna-OH (God\'s Golden Girls)                | 575   | 38.3  | 5  | 78%  |
+| 27       | Will Thompson           | Fruitland Park-FL (Kingdom Quizzers)            | 510   | 34    | 1  | 87%  |
+| 28       | Micah Trippe            | Brewton-AL (Connected God Squad)                | 480   | 32    |    | 81%  |
+| **\*28** | Wesley Horn             | Mustang-OK (United for Christ)                  | 480   | 32    |    | 78%  |
+| 29       | Gianna LoGiudice        | Fruitland Park-FL (Kingdom Quizzers)            | 475   | 31.7  | 3  | 78%  |
+| 30       | Ella Buzzell            | Webster-NY (Webster)                            | 430   | 28.7  | 1  | 65%  |
+| 31       | Luke Odle               | Webster-NY (Webster)                            | 395   | 26.3  | 2  | 68%  |
+| 32       | Samantha Anselmo        | Richmond Hill -NY (Bethlehem Church)            | 375   | 25    | 2  | 88%  |
+| 33       | Sancia Gladwin          | Bothell-WA (Cedar Park Eagles)                  | 355   | 23.7  |    | 66%  |
+| 34       | Samuel DeSilva          | Richmond Hill -NY (Bethlehem Church)            | 350   | 23.3  | 2  | 82%  |
+| 35       | Abby Tveit              | Bothell-WA (Cedar Park Eagles)                  | 330   | 22    | 2  | 64%  |
+| 36       | Adalia Abinteh          | Collierville-TN (Collierville Freedom Fighters) | 325   | 21.7  |    | 92%  |
+| 37       | Lucy Morency            | Shelby Township-MI (Jedi Knights)               | 320   | 21.3  |    | 100% |
+| **\*37** | Kailyn Heath            | Lakeville-MN (Under Armour of God)              | 320   | 21.3  |    | 80%  |
+| 38       | Jadyn Archer            | Lawson-MO (Lawson-Wendy)                        | 275   | 18.3  |    | 91%  |
+| 39       | Cole Campbell           | Mustang-OK (United for Christ)                  | 245   | 16.3  | 2  | 89%  |
+| 40       | Shekinah Biruduganti    | Naperville-IL (Naperville (S))                  | 245   | 16.3  |    | 91%  |
+| 41       | Josiah Brown            | Bothell-WA (Cedar Park Eagles)                  | 235   | 15.7  | 1  | 69%  |
+| 42       | Jade Smith              | Emporia-KS (God\'s Masterpiece)                 | 230   | 15.3  |    | 77%  |
+| 43       | Tabitha Barney          | Shelby Township-MI (Jedi Knights)               | 180   | 12    |    | 67%  |
+| 44       | Eylene Kingsly          | Marietta-GA (Royal Diadem)                      | 160   | 10.7  |    | 94%  |
+| 45       | Emma Kokora             | Richmond Hill -NY (Bethlehem Church)            | 145   | 9.7   |    | 65%  |
+| 46       | Addison Odle            | Webster-NY (Webster)                            | 140   | 9.3   | 1  | 92%  |
+| 47       | Eric Romanets           | Lakeville-MN (Under Armour of God)              | 140   | 9.3   |    | 100% |
+| 48       | Blaize Vaughn           | Lawson-MO (Lawson-Wendy)                        | 115   | 7.7   |    | 74%  |
+| 49       | Portia Wolfe            | Emporia-KS (God\'s Masterpiece)                 | 105   | 7     |    | 80%  |
+| 50       | Rachel Hodges           | Fordyce-AR (Fordyce Bible Bugs)                 | 95    | 6.3   |    | 91%  |
+| **\*50** | Mayah Johnson           | Richmond Hill -NY (Bethlehem Church)            | 95    | 6.3   |    | 80%  |
+| 51       | Adyson Campbell         | Mustang-OK (United for Christ)                  | 90    | 6     |    | 100% |
+| 52       | Meso Ogwo               | Collierville-TN (Collierville Freedom Fighters) | 85    | 5.7   |    | 83%  |
+| 53       | Annelise Nowak          | Ravenna-OH (God\'s Golden Girls)                | 70    | 4.7   |    | 78%  |
+| **\*53** | Emily Buzzell           | Webster-NY (Webster)                            | 70    | 4.7   |    | 58%  |
+| 54       | Jocelyn Nowak           | Ravenna-OH (God\'s Golden Girls)                | 50    | 3.3   |    | 100% |
+| **\*54** | Zoey Fischer            | Mustang-OK (United for Christ)                  | 50    | 3.3   |    | 100% |
+| 55       | Muna Ogwo               | Collierville-TN (Collierville Freedom Fighters) | 45    | 3     |    | 62%  |
+| 56       | Jon Luc Jobson - Larkin | Richmond Hill -NY (Bethlehem Church)            | 40    | 2.7   |    | 50%  |
+| 57       | Dylan Smith             | Richmond Hill -NY (Bethlehem Church)            | 30    | 2     |    | 67%  |
+| **\*57** | Lucky Baldwin           | Bothell-WA (Cedar Park Eagles)                  | 30    | 2     |    | 50%  |
+| 58       | Adalyn Hornaday         | Fordyce-AR (Fordyce Bible Bugs)                 | 20    | 1.3   |    | 100% |
+| **\*58** | Elizabeth Knudson       | Fordyce-AR (Fordyce Bible Bugs)                 | 20    | 1.3   |    | 100% |
+| 59       | Evelyn Kingsly          | Marietta-GA (Royal Diadem)                      | 15    | 1     |    | 75%  |
+| 60       | Kyla Trippe             | Brewton-AL (Connected God Squad)                | 5     | .3    |    | 50%  |
+| 61       | David Barney            | Shelby Township-MI (Jedi Knights)               | 0     |       |    |      |
+| **\*61** | Rahul Padmanabhan       | Shelby Township-MI (Jedi Knights)               | 0     |       |    |      |
+| **\*61** | Samuel Padmanabhan      | Shelby Township-MI (Jedi Knights)               | 0     |       |    |      |
+| **\*61** | Dharshini Jayakrishnan  | Marietta-GA (Royal Diadem)                      | 0     |       |    |      |
+| **\*61** | Payton Gillund          | Emporia-KS (God\'s Masterpiece)                 | 0     |       |    |      |
+| **\*61** | Tripp Stormont          | Emporia-KS (God\'s Masterpiece)                 | 0     |       |    |      |
+| **\*61** | Fred Jackson            | Emporia-KS (God\'s Masterpiece)                 | 0     |       |    |      |
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                         | W/L    | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | Springfield-MO (Double Edged Swords)                  | 14 / 1 | 3185  | 212.3 | 20 | 84% |
+| 2.0  | Houston-TX (The Overcomers)                           | 13 / 2 | 2710  | 180.7 | 11 | 82% |
+| 3.0  | Mechanicsville-VA (Contagious Valor)                  | 11 / 4 | 2620  | 174.7 | 7  | 86% |
+| 4.0  | Gahanna-OH (Fluffy Panda Quizzers)                    | 10 / 5 | 3005  | 200.3 | 16 | 83% |
+| 5.0  | Sparta-WI (Blazing Boys of the Bible)                 | 10 / 5 | 2380  | 158.7 | 11 | 76% |
+| 6.0  | Greensboro-NC (POW - Patriots of the Word)            | 10 / 5 | 2250  | 150   | 12 | 77% |
+| 7.0  | Tucson-AZ (#JesusJitters)                             | 9 / 6  | 2435  | 162.3 | 7  | 79% |
+| 8.0  | Fortville-IN (Transformed Twins and Faithful Friends) | 8 / 7  | 2195  | 146.3 | 12 | 76% |
+| 9.1  | Red Oak-TX (Tribulation Force)                        | 7 / 8  | 2090  | 139.3 | 13 | 75% |
+| 10.0 | Bismarck-ND (Sinai Samurai)                           | 7 / 8  | 2085  | 139   | 4  | 75% |
+| 11.0 | Swedesboro-NJ (Palm Sunday)                           | 6 / 9  | 2045  | 136.3 | 6  | 75% |
+| 12.1 | Cumming -GA (Rockstars for Jesus)                     | 4 / 11 | 1665  | 111   | 3  | 64% |
+| 13.0 | Kenmore-WA (Thunder Hawks)                            | 4 / 11 | 1570  | 104.7 | 2  | 66% |
+| 14.1 | Montgomery-AL (3-D)                                   | 3 / 12 | 1675  | 111.7 | 5  | 73% |
+| 15.0 | Kearney-NE (Laughing Leviathans)                      | 3 / 12 | 1625  | 108.3 | 5  | 79% |
+| 16.0 | Shreveport-LA (Shining Stars)                         | 1 / 14 | 475   | 31.7  | 1  | 47% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                                         | Total | Avg   | QO | Q%   |
+|---------:|----------------------|-------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Abigail Jones        | Springfield-MO (Double Edged Swords)                  | 1730  | 115.3 | 6  | 87%  |
+| 2        | Aidan Rajesh         | Greensboro-NC (POW - Patriots of the Word)            | 1600  | 106.7 | 9  | 76%  |
+| 3        | Abel Karthik         | Gahanna-OH (Fluffy Panda Quizzers)                    | 1465  | 97.7  | 6  | 86%  |
+| 4        | Madeline Berkey      | Tucson-AZ (#JesusJitters)                             | 1405  | 93.7  | 7  | 81%  |
+| 5        | Cole Abbott          | Sparta-WI (Blazing Boys of the Bible)                 | 1330  | 88.7  | 7  | 69%  |
+| 6        | Shekinah Phelps      | Springfield-MO (Double Edged Swords)                  | 1215  | 81    | 14 | 86%  |
+| 7        | Mark Orth            | Fortville-IN (Transformed Twins and Faithful Friends) | 1065  | 71    | 9  | 74%  |
+| 8        | Toby Hill            | Swedesboro-NJ (Palm Sunday)                           | 1060  | 70.7  | 2  | 84%  |
+| 9        | Britt Adams          | Mechanicsville-VA (Contagious Valor)                  | 980   | 65.3  | 1  | 84%  |
+| 10       | Logan Orth           | Fortville-IN (Transformed Twins and Faithful Friends) | 950   | 63.3  | 3  | 74%  |
+| 11       | Precious Cyrus-David | Houston-TX (The Overcomers)                           | 915   | 61    |    | 81%  |
+| 12       | Sammy Mair           | Gahanna-OH (Fluffy Panda Quizzers)                    | 860   | 57.3  | 7  | 82%  |
+| 13       | Elyssa Fulfer        | Red Oak-TX (Tribulation Force)                        | 860   | 57.3  | 3  | 72%  |
+| 14       | Priscilla Adu-Gyamfi | Houston-TX (The Overcomers)                           | 845   | 56.3  | 10 | 96%  |
+| 15       | Elijah Bohlen        | Bismarck-ND (Sinai Samurai)                           | 825   | 55    |    | 70%  |
+| 16       | Christopher Johnson  | Kearney-NE (Laughing Leviathans)                      | 785   | 52.3  | 3  | 64%  |
+| 17       | Bryce Helgerson      | Sparta-WI (Blazing Boys of the Bible)                 | 750   | 50    | 4  | 89%  |
+| 18       | Michelle Lobato      | Tucson-AZ (#JesusJitters)                             | 710   | 47.3  |    | 82%  |
+| 19       | Ezra King            | Red Oak-TX (Tribulation Force)                        | 700   | 46.7  | 9  | 81%  |
+| 20       | Ethan Sipes          | Bismarck-ND (Sinai Samurai)                           | 690   | 46    | 1  | 76%  |
+| 21       | Caleb Karthik        | Gahanna-OH (Fluffy Panda Quizzers)                    | 680   | 45.3  | 3  | 83%  |
+| 22       | Peyton Shuffitt      | Montgomery-AL (3-D)                                   | 670   | 44.7  | 2  | 65%  |
+| 23       | Christian Steele     | Mechanicsville-VA (Contagious Valor)                  | 610   | 40.7  | 5  | 86%  |
+| 24       | Anyiah Odera         | Houston-TX (The Overcomers)                           | 610   | 40.7  | 1  | 76%  |
+| 25       | Elizabeth Godavarthi | Kenmore-WA (Thunder Hawks)                            | 570   | 38    |    | 71%  |
+| 26       | Johans Zakkam        | Cumming -GA (Rockstars for Jesus)                     | 540   | 36    |    | 62%  |
+| 27       | Aidan Fulfer         | Red Oak-TX (Tribulation Force)                        | 530   | 35.3  | 1  | 70%  |
+| 28       | Cristina Gonzalez    | Montgomery-AL (3-D)                                   | 525   | 35    | 3  | 83%  |
+| 29       | Brooks Adams         | Mechanicsville-VA (Contagious Valor)                  | 520   | 34.7  | 1  | 96%  |
+| 30       | Joseph Zborek        | Mechanicsville-VA (Contagious Valor)                  | 510   | 34    |    | 79%  |
+| 31       | Trenton Morris       | Greensboro-NC (POW - Patriots of the Word)            | 495   | 33    | 3  | 76%  |
+| 32       | Aryan Bunga          | Cumming -GA (Rockstars for Jesus)                     | 470   | 31.3  | 2  | 65%  |
+| 33       | Kevin Sowers         | Montgomery-AL (3-D)                                   | 470   | 31.3  |    | 74%  |
+| 34       | Jonah Gallo          | Kenmore-WA (Thunder Hawks)                            | 465   | 31    | 1  | 61%  |
+| 35       | Makya Gans           | Kearney-NE (Laughing Leviathans)                      | 425   | 28.3  | 2  | 93%  |
+| 36       | Joel Samuel          | Swedesboro-NJ (Palm Sunday)                           | 415   | 27.7  | 4  | 68%  |
+| 37       | Hannah Bohlen        | Bismarck-ND (Sinai Samurai)                           | 400   | 26.7  | 2  | 76%  |
+| 38       | Vandana Peddapalli   | Cumming -GA (Rockstars for Jesus)                     | 365   | 24.3  | 1  | 68%  |
+| 39       | William Adu-Gyamfi   | Houston-TX (The Overcomers)                           | 350   | 23.3  |    | 62%  |
+| 40       | Katelyn Buse         | Kearney-NE (Laughing Leviathans)                      | 290   | 19.3  |    | 94%  |
+| **\*40** | Trisha Gundugollu    | Cumming -GA (Rockstars for Jesus)                     | 290   | 19.3  |    | 60%  |
+| **\*40** | Aiden Callahan       | Swedesboro-NJ (Palm Sunday)                           | 290   | 19.3  |    | 59%  |
+| 41       | Jessica Samuel       | Swedesboro-NJ (Palm Sunday)                           | 280   | 18.7  |    | 94%  |
+| **\*41** | Matthew Vemuri       | Kenmore-WA (Thunder Hawks)                            | 280   | 18.7  |    | 74%  |
+| 42       | Patrick Thomas       | Shreveport-LA (Shining Stars)                         | 265   | 17.7  |    | 45%  |
+| 43       | Elijah Gallo         | Kenmore-WA (Thunder Hawks)                            | 255   | 17    | 1  | 62%  |
+| 44       | Jason Stoughter      | Shreveport-LA (Shining Stars)                         | 180   | 12    | 1  | 53%  |
+| 45       | Keira Orth           | Fortville-IN (Transformed Twins and Faithful Friends) | 180   | 12    |    | 90%  |
+| 46       | Julia Loven          | Bismarck-ND (Sinai Samurai)                           | 170   | 11.3  | 1  | 89%  |
+| 47       | Serenity Orozco      | Tucson-AZ (#JesusJitters)                             | 160   | 10.7  |    | 89%  |
+| 48       | Sawyer Curtis        | Sparta-WI (Blazing Boys of the Bible)                 | 155   | 10.3  |    | 94%  |
+| **\*48** | James McGovern       | Greensboro-NC (POW - Patriots of the Word)            | 155   | 10.3  |    | 85%  |
+| 49       | Andrew Le            | Springfield-MO (Double Edged Swords)                  | 145   | 9.7   |    | 84%  |
+| **\*49** | Corbin Frydenlund    | Sparta-WI (Blazing Boys of the Bible)                 | 145   | 9.7   |    | 64%  |
+| 50       | Annika Posvar        | Kearney-NE (Laughing Leviathans)                      | 125   | 8.3   |    | 93%  |
+| 51       | Eliana Phelps        | Springfield-MO (Double Edged Swords)                  | 85    | 5.7   |    | 62%  |
+| 52       | Myah Berkey          | Tucson-AZ (#JesusJitters)                             | 80    | 5.3   |    | 60%  |
+| 53       | Gabriella Lobato     | Tucson-AZ (#JesusJitters)                             | 40    | 2.7   |    | 100% |
+| **\*53** | Mason Berkey         | Tucson-AZ (#JesusJitters)                             | 40    | 2.7   |    | 54%  |
+| 54       | Norman Thomas        | Shreveport-LA (Shining Stars)                         | 30    | 2     |    | 41%  |
+| 55       | Sarah Jones          | Springfield-MO (Double Edged Swords)                  | 10    | .7    |    | 99%  |
+| **\*55** | Trey Oliver          | Montgomery-AL (3-D)                                   | 10    | .7    |    | 50%  |
+| 56       | Katelynn Do          | Montgomery-AL (3-D)                                   | 5     | .3    |    | 99%  |
+| 57       | Gracie DeSanto       | Swedesboro-NJ (Palm Sunday)                           | 0     |       |    |      |
+| **\*57** | Isaac Helgerson      | Sparta-WI (Blazing Boys of the Bible)                 | 0     |       |    |      |
+| **\*57** | Bryson Thomas        | Shreveport-LA (Shining Stars)                         | 0     |       |    |      |
+| **\*57** | Adeline Powell       | Montgomery-AL (3-D)                                   | 0     |       |    |      |
+| **\*57** | Annabelle Morris     | Greensboro-NC (POW - Patriots of the Word)            | 0     |       |    |      |
+| **\*57** | Brookleyn Light      | Gahanna-OH (Fluffy Panda Quizzers)                    | 0     |       |    |      |
+| **\*57** | Darla Holzhausen     | Fortville-IN (Transformed Twins and Faithful Friends) | 0     |       |    |      |
+| 58       | Sofia Gonzalez       | Montgomery-AL (3-D)                                   | -5    | -.3   |    |      |
+
+## Saturday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                        | W/L   | Total | Avg   | QO | Q%  |
+|-----:|--------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Garland-TX (Guardians of Gospel)     | 6 / 3 | 1570  | 174.4 | 10 | 72% |
+| 2.0  | Naperville-IL (Naperville (M))       | 6 / 3 | 1515  | 168.3 | 10 | 77% |
+| 3.0  | Houston-TX (The Chosen Ones)         | 6 / 3 | 1485  | 165   | 8  | 85% |
+| 4.1  | Houston-TX (The Overcomers)          | 5 / 4 | 1395  | 155   | 4  | 80% |
+| 5.0  | Bowling Green-OH (Jeune et Vivant)   | 5 / 4 | 1345  | 149.4 | 3  | 74% |
+| 6.0  | Springfield-MO (Double Edged Swords) | 4 / 5 | 1370  | 152.2 | 5  | 81% |
+| 7.0  | Naperville-IL (Naperville (C))       | 4 / 5 | 1185  | 131.7 | 7  | 77% |
+| 8.0  | Naperville-IL (Naperville (D))       | 4 / 5 | 1085  | 120.5 | 4  | 68% |
+| 9.0  | Angleton-TX (Heart of a Lion)        | 3 / 6 | 1335  | 148.3 | 10 | 85% |
+| 10.0 | Naperville-IL (Naperville (S))       | 2 / 7 | 1170  | 130   | 4  | 82% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #  | Quizzer                    | Team / Church                        | Total | Avg   | QO | Q%   |
+|---:|----------------------------|--------------------------------------|------:|------:|---:|-----:|
+| 1  | Shaymis Powell             | Naperville-IL (Naperville (M))       | 1085  | 120.6 | 7  | 81%  |
+| 2  | Hannah Vanaja Alapati      | Angleton-TX (Heart of a Lion)        | 865   | 96.1  | 4  | 86%  |
+| 3  | David Biruduganti          | Naperville-IL (Naperville (S))       | 795   | 88.3  | 1  | 90%  |
+| 4  | Olivia Neerudu             | Bowling Green-OH (Jeune et Vivant)   | 740   | 82.2  |    | 91%  |
+| 5  | Shawn Timothy              | Naperville-IL (Naperville (C))       | 720   | 80    | 3  | 77%  |
+| 6  | Nathan Koch                | Garland-TX (Guardians of Gospel)     | 685   | 76.1  | 4  | 74%  |
+| 7  | Abigail Jones              | Springfield-MO (Double Edged Swords) | 665   | 73.9  |    | 91%  |
+| 8  | Reagan Stevens             | Naperville-IL (Naperville (D))       | 655   | 72.8  | 2  | 71%  |
+| 9  | Shekinah Phelps            | Springfield-MO (Double Edged Swords) | 590   | 65.6  | 5  | 74%  |
+| 10 | Brandon Ukonu              | Houston-TX (The Chosen Ones)         | 530   | 58.9  | 4  | 82%  |
+| 11 | Iynu Akanbi                | Houston-TX (The Chosen Ones)         | 515   | 57.2  | 3  | 97%  |
+| 12 | Precious Cyrus-David       | Houston-TX (The Overcomers)          | 480   | 53.3  |    | 82%  |
+| 13 | Christian Chowdary Alapati | Angleton-TX (Heart of a Lion)        | 470   | 52.2  | 6  | 84%  |
+| 14 | Priscilla Adu-Gyamfi       | Houston-TX (The Overcomers)          | 470   | 52.2  | 4  | 88%  |
+| 15 | Jensen Suresh              | Naperville-IL (Naperville (C))       | 440   | 48.9  | 4  | 77%  |
+| 16 | Michael Ukonu              | Houston-TX (The Chosen Ones)         | 440   | 48.9  | 1  | 75%  |
+| 17 | Shaylee Powell             | Naperville-IL (Naperville (M))       | 400   | 44.4  | 3  | 74%  |
+| 18 | Anyiah Odera               | Houston-TX (The Overcomers)          | 400   | 44.4  |    | 74%  |
+| 19 | Samuel Biruduganti         | Naperville-IL (Naperville (S))       | 355   | 39.4  | 3  | 74%  |
+| 20 | McKinley Stevens           | Naperville-IL (Naperville (D))       | 340   | 37.8  | 2  | 66%  |
+| 21 | Joanne Ramesh              | Garland-TX (Guardians of Gospel)     | 330   | 36.7  |    | 93%  |
+| 22 | Abigail Slembarski         | Bowling Green-OH (Jeune et Vivant)   | 315   | 35    |    | 76%  |
+| 23 | Noah Smith                 | Bowling Green-OH (Jeune et Vivant)   | 290   | 32.2  | 3  | 63%  |
+| 24 | Andrew Lopez               | Garland-TX (Guardians of Gospel)     | 205   | 22.8  | 3  | 71%  |
+| 25 | Rylie Pugh                 | Garland-TX (Guardians of Gospel)     | 190   | 21.1  | 3  | 60%  |
+| 26 | Makenna Koch               | Garland-TX (Guardians of Gospel)     | 155   | 17.2  |    | 71%  |
+| 27 | Andrew Le                  | Springfield-MO (Double Edged Swords) | 120   | 13.3  |    | 100% |
+| 28 | Pierce Stevens             | Naperville-IL (Naperville (D))       | 90    | 10    |    | 61%  |
+| 29 | William Adu-Gyamfi         | Houston-TX (The Overcomers)          | 50    | 5.6   |    | 50%  |
+| 30 | Abdiel Parra               | Naperville-IL (Naperville (M))       | 30    | 3.3   |    | 67%  |
+| 31 | Jayden Suresh              | Naperville-IL (Naperville (C))       | 25    | 2.8   |    | 75%  |
+| 32 | Shekinah Biruduganti       | Naperville-IL (Naperville (S))       | 20    | 2.2   |    | 100% |
+| 33 | Reese Pugh                 | Garland-TX (Guardians of Gospel)     | 10    | 1.1   |    | 99%  |
+| 34 | Sarah Jones                | Springfield-MO (Double Edged Swords) | 0     |       |    |      |
+| 35 | Eliana Phelps              | Springfield-MO (Double Edged Swords) | -5    | -.6   |    |      |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                      | W/L   | Total | Avg   | QO | Q%  |
+|-----:|----------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.1  | Monmouth Junction-NJ (Knights 4 Christ -Salvation) | 7 / 2 | 1675  | 186.1 | 5  | 89% |
+| 2.0  | San Jose-CA (Warriors of the faith)                | 7 / 2 | 1600  | 177.8 | 7  | 90% |
+| 3.0  | Gahanna-OH (Fluffy Panda Quizzers)                 | 6 / 3 | 1335  | 148.3 | 5  | 69% |
+| 4.0  | Bothell-WA (Cedar Park Eagles)                     | 5 / 4 | 1485  | 165   | 5  | 79% |
+| 5.0  | Chandler-AZ (God Squad)                            | 5 / 4 | 1355  | 150.5 | 1  | 76% |
+| 6.0  | Shakopee-MN (Minds of the Bible)                   | 5 / 4 | 1330  | 147.8 | 5  | 85% |
+| 7.0  | Omaha-NE (I.C.E.)                                  | 4 / 5 | 1130  | 125.5 | 1  | 71% |
+| 8.0  | Mechanicsville-VA (Contagious Valor)               | 2 / 7 | 1155  | 128.3 | 3  | 73% |
+| 9.0  | Lawson-MO (Lawson-Wendy)                           | 2 / 7 | 1135  | 126.1 | 3  | 78% |
+| 10.0 | Wayne-NJ (CTI - JOY)                               | 2 / 7 | 905   | 100.5 | 3  | 68% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                                      | Total | Avg   | QO | Q%   |
+|---------:|--------------------|----------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Samuel E. Jebaraj  | San Jose-CA (Warriors of the faith)                | 1120  | 124.4 | 7  | 87%  |
+| 2        | Shekinah Isaiah    | Bothell-WA (Cedar Park Eagles)                     | 950   | 105.6 | 3  | 89%  |
+| 3        | Remi Briglin       | Monmouth Junction-NJ (Knights 4 Christ -Salvation) | 895   | 99.4  | 3  | 91%  |
+| 4        | Abel Karthik       | Gahanna-OH (Fluffy Panda Quizzers)                 | 805   | 89.4  | 2  | 78%  |
+| 5        | Seth Archer        | Lawson-MO (Lawson-Wendy)                           | 775   | 86.1  | 2  | 76%  |
+| 6        | Gabby Pahl         | Shakopee-MN (Minds of the Bible)                   | 610   | 67.8  |    | 89%  |
+| **\*6**  | Timothy Mathew     | Chandler-AZ (God Squad)                            | 610   | 67.8  |    | 83%  |
+| 7        | Joseph Zborek      | Mechanicsville-VA (Contagious Valor)               | 505   | 56.1  | 1  | 78%  |
+| 8        | Jason Theodore     | Monmouth Junction-NJ (Knights 4 Christ -Salvation) | 455   | 50.6  | 2  | 83%  |
+| 9        | Lauren Pahl        | Shakopee-MN (Minds of the Bible)                   | 445   | 49.4  | 5  | 80%  |
+| 10       | Joshua Malayail    | Chandler-AZ (God Squad)                            | 440   | 48.9  | 1  | 74%  |
+| 11       | Chineme Oriaku     | Wayne-NJ (CTI - JOY)                               | 430   | 47.8  | 1  | 68%  |
+| 12       | Caleb Karthik      | Gahanna-OH (Fluffy Panda Quizzers)                 | 380   | 42.2  | 3  | 72%  |
+| 13       | Jocelyn Calvert    | Lawson-MO (Lawson-Wendy)                           | 335   | 37.2  | 1  | 87%  |
+| 14       | Lademi Davies      | Omaha-NE (I.C.E.)                                  | 325   | 36.1  | 1  | 71%  |
+| 15       | Freya Briglin      | Monmouth Junction-NJ (Knights 4 Christ -Salvation) | 325   | 36.1  |    | 92%  |
+| 16       | Christian Steele   | Mechanicsville-VA (Contagious Valor)               | 320   | 35.6  | 2  | 78%  |
+| 17       | Kelechi Oriaku     | Wayne-NJ (CTI - JOY)                               | 305   | 33.9  | 2  | 67%  |
+| 18       | Addie Putman       | Shakopee-MN (Minds of the Bible)                   | 275   | 30.6  |    | 92%  |
+| 19       | Aaron Martin       | Omaha-NE (I.C.E.)                                  | 270   | 30    |    | 82%  |
+| 20       | Britt Adams        | Mechanicsville-VA (Contagious Valor)               | 260   | 28.9  |    | 59%  |
+| 21       | Tehillah Jebaraj   | San Jose-CA (Warriors of the faith)                | 230   | 25.6  |    | 100% |
+| 22       | Kona Fern          | Omaha-NE (I.C.E.)                                  | 220   | 24.4  |    | 59%  |
+| 23       | Abby Tveit         | Bothell-WA (Cedar Park Eagles)                     | 195   | 21.7  | 1  | 66%  |
+| 24       | Sancia Gladwin     | Bothell-WA (Cedar Park Eagles)                     | 180   | 20    |    | 83%  |
+| 25       | Aleena Daniel      | Chandler-AZ (God Squad)                            | 175   | 19.4  |    | 68%  |
+| 26       | Joanna Paulraj     | Wayne-NJ (CTI - JOY)                               | 170   | 18.9  |    | 71%  |
+| 27       | Charlotte Elliott  | Omaha-NE (I.C.E.)                                  | 165   | 18.3  |    | 73%  |
+| 28       | Nolan King         | Omaha-NE (I.C.E.)                                  | 155   | 17.2  |    | 73%  |
+| 29       | Sammy Mair         | Gahanna-OH (Fluffy Panda Quizzers)                 | 150   | 16.7  |    | 53%  |
+| 30       | Jeremiah Godson    | San Jose-CA (Warriors of the faith)                | 130   | 14.4  |    | 82%  |
+| 31       | Glennis Ho         | San Jose-CA (Warriors of the faith)                | 120   | 13.3  |    | 100% |
+| 32       | Josiah Brown       | Bothell-WA (Cedar Park Eagles)                     | 110   | 12.2  | 1  | 75%  |
+| 33       | Brooks Adams       | Mechanicsville-VA (Contagious Valor)               | 70    | 7.8   |    | 71%  |
+| 34       | Shreya Ganeshan    | Chandler-AZ (God Squad)                            | 65    | 7.2   |    | 87%  |
+| **\*34** | Anita Mathew       | Chandler-AZ (God Squad)                            | 65    | 7.2   |    | 73%  |
+| 35       | Lucky Baldwin      | Bothell-WA (Cedar Park Eagles)                     | 50    | 5.6   |    | 75%  |
+| 36       | Jadyn Archer       | Lawson-MO (Lawson-Wendy)                           | 20    | 2.2   |    | 99%  |
+| 37       | Blaize Vaughn      | Lawson-MO (Lawson-Wendy)                           | 5     | .6    |    | 37%  |
+| 38       | Miraclin Jebastian | San Jose-CA (Warriors of the faith)                | 0     |       |    |      |
+| **\*38** | Brookleyn Light    | Gahanna-OH (Fluffy Panda Quizzers)                 | 0     |       |    |      |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                   | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Springfield-MO (Shock Diamonds)                 | 7 / 2 | 1510  | 167.8 | 6  | 82% |
+| 2.0  | Sparta-WI (Blazing Boys of the Bible)           | 5 / 4 | 1495  | 166.1 | 6  | 75% |
+| 3.0  | Waxahachie-TX (Kids For Christ)                 | 5 / 4 | 1310  | 145.5 | 3  | 80% |
+| 4.0  | Greensboro-NC (POW - Patriots of the Word)      | 5 / 4 | 1305  | 145   | 7  | 76% |
+| 5.0  | Springfield-MO (Fried Pickles)                  | 5 / 4 | 1280  | 142.2 | 6  | 73% |
+| 6.0  | Monmouth Junction-NJ (Knights 4 Christ - Faith) | 4 / 5 | 1365  | 151.6 | 3  | 74% |
+| 7.0  | Marietta-GA (Royal Diadem)                      | 4 / 5 | 1275  | 141.7 | 5  | 84% |
+| 8.0  | Tallahassee-FL (More Than Conquerors)           | 4 / 5 | 1265  | 140.5 | 2  | 78% |
+| 9.0  | Akron-OH (Girls on a Mission)                   | 4 / 5 | 1210  | 134.4 | 3  | 76% |
+| 10.0 | Shelby Township-MI (Jedi Knights)               | 2 / 7 | 1000  | 111.1 | 3  | 72% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                                   | Total | Avg   | QO | Q%   |
+|---------:|------------------------|-------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Hannah Plake           | Springfield-MO (Shock Diamonds)                 | 1005  | 111.7 | 3  | 88%  |
+| 2        | Cole Abbott            | Sparta-WI (Blazing Boys of the Bible)           | 920   | 102.2 | 4  | 75%  |
+| 3        | Aidan Rajesh           | Greensboro-NC (POW - Patriots of the Word)      | 860   | 95.6  | 4  | 75%  |
+| 4        | Joy Escobar            | Waxahachie-TX (Kids For Christ)                 | 750   | 83.3  | 1  | 81%  |
+| 5        | Shreya Joy             | Marietta-GA (Royal Diadem)                      | 725   | 80.6  | 2  | 88%  |
+| 6        | Nathaniel Jebaraj      | Monmouth Junction-NJ (Knights 4 Christ - Faith) | 695   | 77.2  | 1  | 76%  |
+| 7        | Kaitlyn Ramsey         | Springfield-MO (Fried Pickles)                  | 660   | 73.3  | 2  | 68%  |
+| 8        | Elylah Stager          | Akron-OH (Girls on a Mission)                   | 620   | 68.9  | 2  | 73%  |
+| 9        | Elijah Stewart         | Tallahassee-FL (More Than Conquerors)           | 520   | 57.8  | 2  | 71%  |
+| 10       | Emma Stewart           | Tallahassee-FL (More Than Conquerors)           | 520   | 57.8  |    | 100% |
+| 11       | Steve Joy              | Marietta-GA (Royal Diadem)                      | 510   | 56.7  | 3  | 80%  |
+| 12       | Garrett Crescenti      | Shelby Township-MI (Jedi Knights)               | 415   | 46.1  |    | 68%  |
+| 13       | Austanne Barney        | Shelby Township-MI (Jedi Knights)               | 395   | 43.9  | 3  | 74%  |
+| 14       | Hector Rivera          | Waxahachie-TX (Kids For Christ)                 | 380   | 42.2  | 2  | 83%  |
+| 15       | Elli Woodward          | Springfield-MO (Shock Diamonds)                 | 375   | 41.7  | 3  | 79%  |
+| 16       | Alyssa Ramsey          | Springfield-MO (Fried Pickles)                  | 365   | 40.6  | 4  | 70%  |
+| 17       | Jocelyn Fredrick       | Monmouth Junction-NJ (Knights 4 Christ - Faith) | 335   | 37.2  | 2  | 80%  |
+| 18       | Bryce Helgerson        | Sparta-WI (Blazing Boys of the Bible)           | 335   | 37.2  | 1  | 75%  |
+| 19       | Samuel Jebaraj         | Monmouth Junction-NJ (Knights 4 Christ - Faith) | 335   | 37.2  |    | 66%  |
+| 20       | Chloe Eder             | Akron-OH (Girls on a Mission)                   | 330   | 36.7  |    | 76%  |
+| 21       | Trenton Morris         | Greensboro-NC (POW - Patriots of the Word)      | 325   | 36.1  | 2  | 73%  |
+| 22       | Denice Mackey          | Akron-OH (Girls on a Mission)                   | 260   | 28.9  | 1  | 78%  |
+| 23       | Catie Wolfe            | Springfield-MO (Fried Pickles)                  | 255   | 28.3  |    | 88%  |
+| 24       | Charlie Zimmerman      | Tallahassee-FL (More Than Conquerors)           | 195   | 21.7  |    | 73%  |
+| 25       | Ismael Rodriguez       | Waxahachie-TX (Kids For Christ)                 | 180   | 20    |    | 68%  |
+| 26       | Corbin Frydenlund      | Sparta-WI (Blazing Boys of the Bible)           | 160   | 17.8  | 1  | 69%  |
+| 27       | Lucy Morency           | Shelby Township-MI (Jedi Knights)               | 130   | 14.4  |    | 100% |
+| 28       | James McGovern         | Greensboro-NC (POW - Patriots of the Word)      | 120   | 13.3  | 1  | 100% |
+| 29       | Bethany Plake          | Springfield-MO (Shock Diamonds)                 | 120   | 13.3  |    | 73%  |
+| 30       | Sawyer Curtis          | Sparta-WI (Blazing Boys of the Bible)           | 75    | 8.3   |    | 89%  |
+| 31       | Tabitha Barney         | Shelby Township-MI (Jedi Knights)               | 60    | 6.7   |    | 67%  |
+| 32       | Eylene Kingsly         | Marietta-GA (Royal Diadem)                      | 40    | 4.4   |    | 100% |
+| 33       | Kaylin Steinmetz       | Tallahassee-FL (More Than Conquerors)           | 30    | 3.3   |    | 100% |
+| 34       | Anna Le                | Springfield-MO (Shock Diamonds)                 | 15    | 1.7   |    | 50%  |
+| 35       | Isaac Helgerson        | Sparta-WI (Blazing Boys of the Bible)           | 10    | 1.1   |    | 99%  |
+| 36       | Alethia Martin         | Waxahachie-TX (Kids For Christ)                 | 0     |       |    |      |
+| **\*36** | Grace Ruiz             | Waxahachie-TX (Kids For Christ)                 | 0     |       |    |      |
+| **\*36** | McKenna Black          | Springfield-MO (Fried Pickles)                  | 0     |       |    |      |
+| **\*36** | David Barney           | Shelby Township-MI (Jedi Knights)               | 0     |       |    |      |
+| **\*36** | Rahul Padmanabhan      | Shelby Township-MI (Jedi Knights)               | 0     |       |    |      |
+| **\*36** | Samuel Padmanabhan     | Shelby Township-MI (Jedi Knights)               | 0     |       |    |      |
+| **\*36** | Evelyn Kingsly         | Marietta-GA (Royal Diadem)                      | 0     |       |    |      |
+| **\*36** | Dharshini Jayakrishnan | Marietta-GA (Royal Diadem)                      | 0     |       |    |      |
+| **\*36** | Annabelle Morris       | Greensboro-NC (POW - Patriots of the Word)      | 0     |       |    |      |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                         | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Cedar Hill-TX (Triple Threat)                         | 8 / 1 | 1675  | 186.1 | 6  | 82% |
+| 2.0  | Ravenna-OH (God\'s Golden Girls)                      | 6 / 3 | 1445  | 160.5 | 8  | 84% |
+| 3.0  | Fortville-IN (Transformed Twins and Faithful Friends) | 6 / 3 | 1400  | 155.5 | 8  | 74% |
+| 4.0  | Bristow-VA (Gushers)                                  | 6 / 3 | 1395  | 155   | 2  | 73% |
+| 5.0  | Richmond Hill -NY (Bethlehem Church)                  | 5 / 4 | 1300  | 144.4 | 4  | 71% |
+| 6.1  | New Whiteland-IN (Pardon the Interruption)            | 4 / 5 | 1225  | 136.1 | 3  | 78% |
+| 7.0  | Great Bend-KS (Bible Warriors)                        | 4 / 5 | 1245  | 138.3 | 3  | 79% |
+| 8.1  | Mechanicsville-VA (Contagious Kindness)               | 3 / 6 | 1240  | 137.8 | 4  | 76% |
+| 9.0  | Tucson-AZ (#JesusJitters)                             | 3 / 6 | 1275  | 141.7 | 3  | 80% |
+| 10.0 | Greensboro-NC (Calvary Blue)                          | 0 / 9 | 895   | 99.4  | 4  | 81% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                 | Team / Church                                         | Total | Avg   | QO | Q%   |
+|---------:|-------------------------|-------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Meleah Sawastuk         | Ravenna-OH (God\'s Golden Girls)                      | 920   | 102.2 | 4  | 86%  |
+| 2        | Faith Buchanan          | Richmond Hill -NY (Bethlehem Church)                  | 825   | 91.7  | 3  | 71%  |
+| 3        | Noah Claunch            | Cedar Hill-TX (Triple Threat)                         | 680   | 75.6  | 3  | 82%  |
+| 4        | Logan Orth              | Fortville-IN (Transformed Twins and Faithful Friends) | 640   | 71.1  | 4  | 73%  |
+| **\*4**  | Mark Orth               | Fortville-IN (Transformed Twins and Faithful Friends) | 640   | 71.1  | 4  | 73%  |
+| 5        | Angel Walker            | Mechanicsville-VA (Contagious Kindness)               | 605   | 67.2  | 2  | 87%  |
+| 6        | Adeline Keith           | Cedar Hill-TX (Triple Threat)                         | 585   | 65    | 1  | 97%  |
+| 7        | Emma Martello           | Greensboro-NC (Calvary Blue)                          | 565   | 62.8  | 3  | 78%  |
+| 8        | Ellen Smith             | Bristow-VA (Gushers)                                  | 560   | 62.2  | 1  | 73%  |
+| 9        | Madeline Berkey         | Tucson-AZ (#JesusJitters)                             | 550   | 61.1  | 2  | 76%  |
+| 10       | Larissa Cox             | New Whiteland-IN (Pardon the Interruption)            | 540   | 60    | 2  | 90%  |
+| 11       | Michelle Lobato         | Tucson-AZ (#JesusJitters)                             | 445   | 49.4  | 1  | 83%  |
+| 12       | Morgan MacKinney        | Great Bend-KS (Bible Warriors)                        | 435   | 48.3  |    | 84%  |
+| 13       | Joseph Barajas          | Cedar Hill-TX (Triple Threat)                         | 410   | 45.6  | 2  | 75%  |
+| 14       | Emily Sawastuk          | Ravenna-OH (God\'s Golden Girls)                      | 405   | 45    | 4  | 79%  |
+| 15       | Kathline Newland        | Bristow-VA (Gushers)                                  | 360   | 40    |    | 68%  |
+| 16       | Savannah Harper         | Mechanicsville-VA (Contagious Kindness)               | 350   | 38.9  | 1  | 64%  |
+| 17       | Cole MacKinney          | Great Bend-KS (Bible Warriors)                        | 335   | 37.2  | 2  | 87%  |
+| 18       | Jack Martello           | Greensboro-NC (Calvary Blue)                          | 330   | 36.7  | 1  | 86%  |
+| 19       | Addy Dougherty          | Great Bend-KS (Bible Warriors)                        | 260   | 28.9  |    | 64%  |
+| 20       | Honey Schwickerath      | Mechanicsville-VA (Contagious Kindness)               | 240   | 26.7  | 1  | 80%  |
+| 21       | Kayleigh Henley         | Bristow-VA (Gushers)                                  | 220   | 24.4  | 1  | 69%  |
+| 22       | Lucas Brunson           | New Whiteland-IN (Pardon the Interruption)            | 210   | 23.3  | 1  | 85%  |
+| 23       | Michael Newland         | Bristow-VA (Gushers)                                  | 190   | 21.1  |    | 91%  |
+| 24       | Andrian Kolliegbo       | New Whiteland-IN (Pardon the Interruption)            | 180   | 20    |    | 62%  |
+| 25       | Mayah Johnson           | Richmond Hill -NY (Bethlehem Church)                  | 155   | 17.2  |    | 90%  |
+| 26       | Serenity Orozco         | Tucson-AZ (#JesusJitters)                             | 130   | 14.4  |    | 100% |
+| 27       | Samuel DeSilva          | Richmond Hill -NY (Bethlehem Church)                  | 125   | 13.9  | 1  | 74%  |
+| 28       | Ella Krier              | Great Bend-KS (Bible Warriors)                        | 120   | 13.3  |    | 78%  |
+| **\*28** | William Okyere          | New Whiteland-IN (Pardon the Interruption)            | 120   | 13.3  |    | 71%  |
+| 29       | Graham Little           | New Whiteland-IN (Pardon the Interruption)            | 115   | 12.8  |    | 68%  |
+| 30       | Makayla Burton          | Great Bend-KS (Bible Warriors)                        | 95    | 10.6  | 1  | 77%  |
+| 31       | Keira Orth              | Fortville-IN (Transformed Twins and Faithful Friends) | 85    | 9.4   |    | 83%  |
+| 32       | Myah Berkey             | Tucson-AZ (#JesusJitters)                             | 80    | 8.9   |    | 75%  |
+| 33       | Mason Berkey            | Tucson-AZ (#JesusJitters)                             | 75    | 8.3   |    | 75%  |
+| 34       | Samantha Anselmo        | Richmond Hill -NY (Bethlehem Church)                  | 70    | 7.8   |    | 69%  |
+| 35       | Audrey Mason            | Bristow-VA (Gushers)                                  | 65    | 7.2   |    | 87%  |
+| **\*35** | Emma Kokora             | Richmond Hill -NY (Bethlehem Church)                  | 65    | 7.2   |    | 54%  |
+| 36       | Jocelyn Nowak           | Ravenna-OH (God\'s Golden Girls)                      | 60    | 6.7   |    | 100% |
+| **\*36** | Annelise Nowak          | Ravenna-OH (God\'s Golden Girls)                      | 60    | 6.7   |    | 100% |
+| **\*36** | Daniel Sprague          | New Whiteland-IN (Pardon the Interruption)            | 60    | 6.7   |    | 100% |
+| **\*36** | Jon Luc Jobson - Larkin | Richmond Hill -NY (Bethlehem Church)                  | 60    | 6.7   |    | 71%  |
+| 37       | Berkley Adams           | Mechanicsville-VA (Contagious Kindness)               | 45    | 5     |    | 83%  |
+| 38       | Darla Holzhausen        | Fortville-IN (Transformed Twins and Faithful Friends) | 35    | 3.9   |    | 75%  |
+| 39       | Dylan Smith             | Richmond Hill -NY (Bethlehem Church)                  | 0     |       |    |      |
+| **\*39** | Brianna Madonia         | Greensboro-NC (Calvary Blue)                          | 0     |       |    |      |
+| 40       | Gabriella Lobato        | Tucson-AZ (#JesusJitters)                             | -5    | -.6   |    |      |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                      | W/L   | Total | Avg   | QO | Q%  |
+|-----:|------------------------------------|-------|------:|------:|---:|----:|
+| 1.1  | Lakeville-MN (Under Armour of God) | 7 / 2 | 1495  | 166.1 | 4  | 84% |
+| 2.0  | Beulah-ND (New Creatures)          | 7 / 2 | 1465  | 162.8 | 3  | 90% |
+| 3.0  | Norcross -GA (ATC FLAMES )         | 5 / 4 | 1505  | 167.2 | 6  | 84% |
+| 4.0  | Red Oak-TX (Tribulation Force)     | 5 / 4 | 1450  | 161.1 | 6  | 76% |
+| 5.0  | Brewton-AL (Connected God Squad)   | 5 / 4 | 1360  | 151.1 | 3  | 79% |
+| 6.0  | Bismarck-ND (Sinai Samurai)        | 5 / 4 | 1330  | 147.8 | 2  | 70% |
+| 7.0  | Rochester-NY (Faith Temple)        | 4 / 5 | 1025  | 113.9 | 2  | 69% |
+| 8.0  | Lakeland-FL (Victory Kids)         | 3 / 6 | 1215  | 135   | 4  | 88% |
+| 9.0  | Lawson-MO (Lawson-Connie )         | 2 / 7 | 1150  | 127.8 | 4  | 75% |
+| 10.0 | Racine-WI (Racine E.P.I.C.)        | 2 / 7 | 950   | 105.5 | 3  | 67% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                      | Total | Avg   | QO | Q%   |
+|---------:|------------------------|------------------------------------|------:|------:|---:|-----:|
+| 1        | Hannah Gabriela Daniel | Norcross -GA (ATC FLAMES )         | 905   | 100.6 | 3  | 80%  |
+| 2        | James Coleman          | Brewton-AL (Connected God Squad)   | 850   | 94.4  | 2  | 89%  |
+| 3        | Grace Searcy           | Lawson-MO (Lawson-Connie )         | 835   | 92.8  | 4  | 81%  |
+| 4        | Joel Ravela            | Lakeland-FL (Victory Kids)         | 805   | 89.4  | 3  | 88%  |
+| 5        | Isabella Kashubin      | Lakeville-MN (Under Armour of God) | 775   | 86.1  | 2  | 83%  |
+| 6        | Elyssa Fulfer          | Red Oak-TX (Tribulation Force)     | 700   | 77.8  | 2  | 77%  |
+| 7        | Trevin Sago            | Beulah-ND (New Creatures)          | 690   | 76.7  | 1  | 90%  |
+| 8        | Josh Monickaraj        | Rochester-NY (Faith Temple)        | 675   | 75    | 1  | 70%  |
+| 9        | Ethan Sipes            | Bismarck-ND (Sinai Samurai)        | 655   | 72.8  |    | 71%  |
+| 10       | McKenna Walker         | Racine-WI (Racine E.P.I.C.)        | 510   | 56.7  |    | 65%  |
+| 11       | Ezra King              | Red Oak-TX (Tribulation Force)     | 420   | 46.7  | 4  | 79%  |
+| 12       | Jenny Christopher      | Norcross -GA (ATC FLAMES )         | 370   | 41.1  | 3  | 83%  |
+| 13       | Kristyn Bauer          | Beulah-ND (New Creatures)          | 370   | 41.1  | 2  | 90%  |
+| 14       | Isaiah Kashubin        | Lakeville-MN (Under Armour of God) | 350   | 38.9  | 2  | 79%  |
+| 15       | Elijah Bohlen          | Bismarck-ND (Sinai Samurai)        | 350   | 38.9  | 1  | 60%  |
+| 16       | Aidan Fulfer           | Red Oak-TX (Tribulation Force)     | 330   | 36.7  |    | 68%  |
+| 17       | Matthew Walker         | Racine-WI (Racine E.P.I.C.)        | 320   | 35.6  | 3  | 62%  |
+| 18       | Colson Sago            | Beulah-ND (New Creatures)          | 285   | 31.7  |    | 91%  |
+| 19       | Micah Trippe           | Brewton-AL (Connected God Squad)   | 280   | 31.1  |    | 74%  |
+| 20       | Hannah Bohlen          | Bismarck-ND (Sinai Samurai)        | 255   | 28.3  | 1  | 76%  |
+| 21       | Gavin Galloway         | Brewton-AL (Connected God Squad)   | 230   | 25.6  | 1  | 70%  |
+| 22       | Kailyn Heath           | Lakeville-MN (Under Armour of God) | 225   | 25    |    | 87%  |
+| 23       | Hans Asher Daniel      | Norcross -GA (ATC FLAMES )         | 220   | 24.4  |    | 92%  |
+| 24       | Rylan Hance            | Lakeland-FL (Victory Kids)         | 195   | 21.7  |    | 94%  |
+| 25       | Chelsea Maynard        | Rochester-NY (Faith Temple)        | 175   | 19.4  | 1  | 67%  |
+| 26       | Eric Romanets          | Lakeville-MN (Under Armour of God) | 150   | 16.7  |    | 100% |
+| 27       | Nathan Joiner          | Lakeland-FL (Victory Kids)         | 145   | 16.1  | 1  | 79%  |
+| 28       | Taylor Searcy          | Lawson-MO (Lawson-Connie )         | 145   | 16.1  |    | 62%  |
+| 29       | Aubryn Sago            | Beulah-ND (New Creatures)          | 120   | 13.3  |    | 87%  |
+| 30       | Caydence Calvert       | Lawson-MO (Lawson-Connie )         | 115   | 12.8  |    | 78%  |
+| 31       | Ben Butler             | Rochester-NY (Faith Temple)        | 90    | 10    |    | 71%  |
+| **\*31** | Hector Siaca           | Rochester-NY (Faith Temple)        | 90    | 10    |    | 71%  |
+| 32       | Hayden Wright          | Lakeland-FL (Victory Kids)         | 70    | 7.8   |    | 100% |
+| **\*32** | Julia Loven            | Bismarck-ND (Sinai Samurai)        | 70    | 7.8   |    | 100% |
+| 33       | Allison Weiler         | Racine-WI (Racine E.P.I.C.)        | 60    | 6.7   |    | 100% |
+| **\*33** | Hannah O\'Dell         | Lawson-MO (Lawson-Connie )         | 60    | 6.7   |    | 100% |
+| 34       | Razalyn Kramer         | Racine-WI (Racine E.P.I.C.)        | 30    | 3.3   |    | 100% |
+| 35       | Trinidy Calvary        | Racine-WI (Racine E.P.I.C.)        | 15    | 1.7   |    | 100% |
+| **\*35** | Miranda Moncayo        | Racine-WI (Racine E.P.I.C.)        | 15    | 1.7   |    | 66%  |
+| 36       | Joel Christopher       | Norcross -GA (ATC FLAMES )         | 10    | 1.1   |    | 99%  |
+| 37       | Jace Hance             | Lakeland-FL (Victory Kids)         | 0     |       |    |      |
+| **\*37** | Kyla Trippe            | Brewton-AL (Connected God Squad)   | 0     |       |    |      |
+
+
+### Silver
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                        | W/L   | Total | Avg   | QO | Q%  |
+|-----:|--------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Oswego-KS (God\'s Girls)             | 6 / 3 | 1535  | 170.5 | 4  | 79% |
+| 2.0  | Williston-ND (Adam\'s Ribs)          | 6 / 3 | 1450  | 161.1 | 2  | 77% |
+| 3.0  | Swedesboro-NJ (Palm Sunday)          | 6 / 3 | 1440  | 160   | 5  | 75% |
+| 4.0  | Fordyce-AR (Fordyce Bible Bugs)      | 6 / 3 | 1385  | 153.9 | 4  | 78% |
+| 5.0  | Concord-NC (S.W.A.T.)                | 5 / 4 | 1410  | 156.6 | 6  | 78% |
+| 6.0  | Fruitland Park-FL (Kingdom Quizzers) | 5 / 4 | 1355  | 150.5 | 5  | 78% |
+| 7.0  | Rogers-AR (Rogers First A/G)         | 5 / 4 | 1345  | 149.4 | 4  | 88% |
+| 8.1  | Billings -MT (New Life Billings)     | 3 / 6 | 1000  | 111.1 | 4  | 76% |
+| 9.0  | Cumming -GA (Rockstars for Jesus)    | 3 / 6 | 1190  | 132.2 | 5  | 71% |
+| 10.0 | Urbandale-IA (Fireball Ninjas)       | 0 / 9 | 665   | 73.9  |    | 64% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer               | Team / Church                        | Total | Avg  | QO | Q%   |
+|---------:|-----------------------|--------------------------------------|------:|-----:|---:|-----:|
+| 1        | Toby Hill             | Swedesboro-NJ (Palm Sunday)          | 895   | 99.4 | 3  | 93%  |
+| 2        | Lester Threatt        | Concord-NC (S.W.A.T.)                | 810   | 90   | 2  | 87%  |
+| 3        | Hannah Cheney         | Rogers-AR (Rogers First A/G)         | 700   | 77.8 | 4  | 87%  |
+| 4        | Katy Nix              | Williston-ND (Adam\'s Ribs)          | 670   | 74.4 | 1  | 92%  |
+| 5        | Ansley Hornaday       | Fordyce-AR (Fordyce Bible Bugs)      | 650   | 72.2 | 4  | 73%  |
+| 6        | Eli Turner            | Fordyce-AR (Fordyce Bible Bugs)      | 650   | 72.2 |    | 80%  |
+| 7        | Carmen Eisenbrandt    | Oswego-KS (God\'s Girls)             | 580   | 64.4 | 1  | 82%  |
+| 8        | Brayden Shepherd      | Fruitland Park-FL (Kingdom Quizzers) | 530   | 58.9 | 1  | 67%  |
+| 9        | Cecillia Newby        | Oswego-KS (God\'s Girls)             | 525   | 58.3 | 1  | 83%  |
+| 10       | Will Thompson         | Fruitland Park-FL (Kingdom Quizzers) | 470   | 52.2 | 1  | 100% |
+| 11       | Dallas Pitman         | Williston-ND (Adam\'s Ribs)          | 450   | 50   |    | 75%  |
+| 12       | Micah Houde           | Billings -MT (New Life Billings)     | 440   | 48.9 | 2  | 64%  |
+| 13       | Zachary Bernardini    | Rogers-AR (Rogers First A/G)         | 400   | 44.4 |    | 91%  |
+| 14       | Aryan Bunga           | Cumming -GA (Rockstars for Jesus)    | 395   | 43.9 | 3  | 73%  |
+| 15       | Gianna LoGiudice      | Fruitland Park-FL (Kingdom Quizzers) | 355   | 39.4 | 3  | 78%  |
+| 16       | Jase Cooper           | Billings -MT (New Life Billings)     | 335   | 37.2 | 2  | 91%  |
+| 17       | Gabe Hudson           | Concord-NC (S.W.A.T.)                | 330   | 36.7 | 4  | 70%  |
+| 18       | Grace Noel            | Oswego-KS (God\'s Girls)             | 325   | 36.1 | 2  | 74%  |
+| 19       | Jayde Todd            | Urbandale-IA (Fireball Ninjas)       | 310   | 34.4 |    | 52%  |
+| 20       | Trisha Gundugollu     | Cumming -GA (Rockstars for Jesus)    | 285   | 31.7 |    | 71%  |
+| 21       | Vandana Peddapalli    | Cumming -GA (Rockstars for Jesus)    | 260   | 28.9 | 1  | 70%  |
+| 22       | Johans Zakkam         | Cumming -GA (Rockstars for Jesus)    | 250   | 27.8 | 1  | 65%  |
+| 23       | Jessica Samuel        | Swedesboro-NJ (Palm Sunday)          | 235   | 26.1 | 1  | 83%  |
+| 24       | Joel Samuel           | Swedesboro-NJ (Palm Sunday)          | 170   | 18.9 | 1  | 58%  |
+| 25       | Kendra Hall           | Williston-ND (Adam\'s Ribs)          | 160   | 17.8 | 1  | 61%  |
+| 26       | Mackenzie Hight       | Urbandale-IA (Fireball Ninjas)       | 160   | 17.8 |    | 89%  |
+| 27       | Charlotte Smith       | Concord-NC (S.W.A.T.)                | 150   | 16.7 |    | 100% |
+| 28       | Aiden Callahan        | Swedesboro-NJ (Palm Sunday)          | 140   | 15.6 |    | 62%  |
+| 29       | Zachary Hartley       | Williston-ND (Adam\'s Ribs)          | 135   | 15   |    | 76%  |
+| 30       | Tielyr Boysen         | Rogers-AR (Rogers First A/G)         | 125   | 13.9 |    | 92%  |
+| **\*30** | Landon Manweiler      | Rogers-AR (Rogers First A/G)         | 125   | 13.9 |    | 82%  |
+| 31       | Kaiden Taylor         | Billings -MT (New Life Billings)     | 120   | 13.3 |    | 67%  |
+| 32       | Mason Ostermiller     | Billings -MT (New Life Billings)     | 105   | 11.7 |    | 80%  |
+| 33       | Taya Todd             | Urbandale-IA (Fireball Ninjas)       | 100   | 11.1 |    | 85%  |
+| **\*33** | Jordan Torres         | Concord-NC (S.W.A.T.)                | 100   | 11.1 |    | 69%  |
+| 34       | Alana Hight           | Urbandale-IA (Fireball Ninjas)       | 95    | 10.6 |    | 53%  |
+| 35       | Delaney Reynolds      | Oswego-KS (God\'s Girls)             | 80    | 8.9  |    | 100% |
+| 36       | Rachel Hodges         | Fordyce-AR (Fordyce Bible Bugs)      | 60    | 6.7  |    | 100% |
+| 37       | Amy Draxton           | Williston-ND (Adam\'s Ribs)          | 35    | 3.9  |    | 80%  |
+| 38       | Elizabeth Knudson     | Fordyce-AR (Fordyce Bible Bugs)      | 20    | 2.2  |    | 100% |
+| **\*38** | Kacey Mayfield        | Oswego-KS (God\'s Girls)             | 20    | 2.2  |    | 99%  |
+| **\*38** | Lydia Hill            | Concord-NC (S.W.A.T.)                | 20    | 2.2  |    | 99%  |
+| 39       | Adalyn Hornaday       | Fordyce-AR (Fordyce Bible Bugs)      | 10    | 1.1  |    | 99%  |
+| 40       | Hannah Noel           | Oswego-KS (God\'s Girls)             | 5     | .6   |    | 50%  |
+| 41       | Gracie DeSanto        | Swedesboro-NJ (Palm Sunday)          | 0     |      |    |      |
+| **\*41** | Seth Hudson           | Concord-NC (S.W.A.T.)                | 0     |      |    |      |
+| **\*41** | Bella Sharbono-hafner | Billings -MT (New Life Billings)     | 0     |      |    |      |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                     | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-----------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Webster-NY (Webster)              | 6 / 3 | 1525  | 169.4 | 7  | 77% |
+| 2.0  | Mendon-MA (CIA Special Agents)    | 6 / 3 | 1415  | 157.2 | 4  | 79% |
+| 3.0  | Mustang-OK (United for Christ)    | 6 / 3 | 1270  | 141.1 | 1  | 82% |
+| 4.0  | Kinston-NC (Kinston - Tanglewood) | 5 / 4 | 1425  | 158.3 | 5  | 80% |
+| 5.0  | Racine-WI (Racine B.F.F.)         | 5 / 4 | 1335  | 148.3 | 2  | 88% |
+| 6.0  | Montgomery-AL (3-D)               | 5 / 4 | 1310  | 145.5 | 4  | 77% |
+| 7.0  | Kenmore-WA (Thunder Hawks)        | 5 / 4 | 1275  | 141.7 | 3  | 65% |
+| 8.0  | Cordova-TN (Word Wise Quiz Kids)  | 3 / 6 | 900   | 100   | 2  | 79% |
+| 9.0  | Dumas-TX (Undignified)            | 2 / 7 | 1070  | 118.9 | 5  | 64% |
+| 10.0 | Lee\'s Summit-MO (Bible Ninjas)   | 2 / 7 | 1070  | 118.9 | 3  | 72% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                     | Total | Avg   | QO | Q%   |
+|---------:|----------------------|-----------------------------------|------:|------:|---:|-----:|
+| 1        | Nick Odle            | Webster-NY (Webster)              | 940   | 104.4 | 3  | 91%  |
+| 2        | Sarah Clements       | Kinston-NC (Kinston - Tanglewood) | 760   | 84.4  | 3  | 87%  |
+| 3        | Esther Zavala        | Dumas-TX (Undignified)            | 705   | 78.3  | 4  | 68%  |
+| 4        | Hayden Monty         | Mendon-MA (CIA Special Agents)    | 685   | 76.1  |    | 85%  |
+| 5        | Josiah Brookbank     | Lee\'s Summit-MO (Bible Ninjas)   | 630   | 70    | 1  | 70%  |
+| 6        | Samuel Deppe         | Cordova-TN (Word Wise Quiz Kids)  | 595   | 66.1  | 2  | 76%  |
+| 7        | Elizabeth Godavarthi | Kenmore-WA (Thunder Hawks)        | 545   | 60.6  | 1  | 72%  |
+| 8        | Waylon Moore         | Kinston-NC (Kinston - Tanglewood) | 535   | 59.4  | 2  | 72%  |
+| 9        | Braylon Hood-Colbert | Mustang-OK (United for Christ)    | 520   | 57.8  |    | 79%  |
+| 10       | Peyton Shuffitt      | Montgomery-AL (3-D)               | 500   | 55.6  |    | 76%  |
+| 11       | Marianna Aguero      | Racine-WI (Racine B.F.F.)         | 450   | 50    | 1  | 84%  |
+| **\*11** | Kevin Sowers         | Montgomery-AL (3-D)               | 450   | 50    | 1  | 72%  |
+| 12       | Jonah Gallo          | Kenmore-WA (Thunder Hawks)        | 440   | 48.9  |    | 63%  |
+| 13       | Wesley Horn          | Mustang-OK (United for Christ)    | 375   | 41.7  |    | 79%  |
+| 14       | Zoe Lipor            | Racine-WI (Racine B.F.F.)         | 360   | 40    | 1  | 95%  |
+| 15       | Matthew Hamel        | Mendon-MA (CIA Special Agents)    | 345   | 38.3  | 2  | 73%  |
+| 16       | Cristina Gonzalez    | Montgomery-AL (3-D)               | 330   | 36.7  | 3  | 81%  |
+| 17       | Ezekiel Hamel        | Mendon-MA (CIA Special Agents)    | 305   | 33.9  | 2  | 77%  |
+| 18       | Luke Odle            | Webster-NY (Webster)              | 265   | 29.4  | 4  | 69%  |
+| 19       | Casen Gray           | Lee\'s Summit-MO (Bible Ninjas)   | 245   | 27.2  | 2  | 71%  |
+| 20       | Nicholas Tait        | Racine-WI (Racine B.F.F.)         | 240   | 26.7  |    | 100% |
+| 21       | Cole Campbell        | Mustang-OK (United for Christ)    | 220   | 24.4  | 1  | 80%  |
+| 22       | Diamond Zavala       | Dumas-TX (Undignified)            | 195   | 21.7  | 1  | 60%  |
+| 23       | Elijah Gallo         | Kenmore-WA (Thunder Hawks)        | 175   | 19.4  | 2  | 60%  |
+| 24       | Addison Odle         | Webster-NY (Webster)              | 175   | 19.4  |    | 89%  |
+| **\*24** | Brendan Van Offeren  | Racine-WI (Racine B.F.F.)         | 175   | 19.4  |    | 76%  |
+| **\*24** | Hayley Vecchio       | Dumas-TX (Undignified)            | 175   | 19.4  |    | 63%  |
+| 25       | George Hoelzel       | Lee\'s Summit-MO (Bible Ninjas)   | 160   | 17.8  |    | 87%  |
+| 26       | Benjamin Antony      | Cordova-TN (Word Wise Quiz Kids)  | 140   | 15.6  |    | 92%  |
+| 27       | Rachael Noble        | Kinston-NC (Kinston - Tanglewood) | 130   | 14.4  |    | 100% |
+| 28       | Matthew Vemuri       | Kenmore-WA (Thunder Hawks)        | 120   | 13.3  |    | 67%  |
+| 29       | Amanda Moncayo       | Racine-WI (Racine B.F.F.)         | 110   | 12.2  |    | 100% |
+| 30       | Adyson Campbell      | Mustang-OK (United for Christ)    | 105   | 11.7  |    | 92%  |
+| **\*30** | Sarah Robertson      | Cordova-TN (Word Wise Quiz Kids)  | 105   | 11.7  |    | 77%  |
+| 31       | Emily Buzzell        | Webster-NY (Webster)              | 85    | 9.4   |    | 69%  |
+| 32       | Braidan Morais       | Mendon-MA (CIA Special Agents)    | 70    | 7.8   |    | 89%  |
+| 33       | Ava Robertson        | Cordova-TN (Word Wise Quiz Kids)  | 60    | 6.7   |    | 78%  |
+| **\*33** | Ella Buzzell         | Webster-NY (Webster)              | 60    | 6.7   |    | 50%  |
+| 34       | Zoey Fischer         | Mustang-OK (United for Christ)    | 50    | 5.6   |    | 100% |
+| 35       | Gabe Diebold         | Lee\'s Summit-MO (Bible Ninjas)   | 35    | 3.9   |    | 60%  |
+| 36       | Sofia Gonzalez       | Montgomery-AL (3-D)               | 30    | 3.3   |    | 100% |
+| 37       | Tanner Longacre      | Mendon-MA (CIA Special Agents)    | 10    | 1.1   |    | 99%  |
+| 38       | Katelynn Do          | Montgomery-AL (3-D)               | 5     | .6    |    | 50%  |
+| 39       | Adeline Powell       | Montgomery-AL (3-D)               | 0     |       |    |      |
+| **\*39** | Trey Oliver          | Montgomery-AL (3-D)               | 0     |       |    |      |
+| **\*39** | M\'Kayla McDaniel    | Dumas-TX (Undignified)            | 0     |       |    |      |
+| 40       | Julian Castillo      | Dumas-TX (Undignified)            | -5    | -.6   |    |      |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                   | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Cumming-GA (Righteous Warriors)                 | 7 / 2 | 1845  | 205   | 9  | 81% |
+| 2.0  | Kearney-NE (Laughing Leviathans)                | 6 / 3 | 1485  | 165   | 8  | 80% |
+| 3.0  | Bellevue-WA (Bright Arrows)                     | 6 / 3 | 1415  | 157.2 | 4  | 80% |
+| 4.0  | Overland Park-KS (KC Quizzers)                  | 6 / 3 | 1395  | 155   | 9  | 71% |
+| 5.1  | Louisville-KY (Redeemed)                        | 5 / 4 | 1405  | 156.1 | 8  | 92% |
+| 6.0  | Emporia-KS (God\'s Masterpiece)                 | 5 / 4 | 1240  | 137.8 | 4  | 76% |
+| 7.0  | Collierville-TN (Collierville Freedom Fighters) | 4 / 5 | 1335  | 148.3 | 3  | 90% |
+| 8.0  | Benton-AR (Kung Fu Quizzers)                    | 3 / 6 | 900   | 100   | 5  | 65% |
+| 9.0  | Riverside-CA (God\'s Property)                  | 2 / 7 | 1080  | 120   | 6  | 89% |
+| 10.0 | Shreveport-LA (Shining Stars)                   | 1 / 8 | 625   | 69.4  | 2  | 56% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                                   | Total | Avg   | QO | Q%   |
+|---------:|---------------------|-------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Julia Barnes        | Louisville-KY (Redeemed)                        | 1235  | 137.2 | 8  | 96%  |
+| 2        | Truett Van Slyke    | Overland Park-KS (KC Quizzers)                  | 1050  | 116.7 | 6  | 77%  |
+| 3        | Angelina Arasavelli | Bellevue-WA (Bright Arrows)                     | 880   | 97.8  | 3  | 89%  |
+| 4        | Pravarsh Kalapala   | Cumming-GA (Righteous Warriors)                 | 865   | 96.1  | 4  | 84%  |
+| 5        | Christopher Johnson | Kearney-NE (Laughing Leviathans)                | 820   | 91.1  | 3  | 72%  |
+| 6        | Noah Small          | Emporia-KS (God\'s Masterpiece)                 | 795   | 88.3  | 3  | 75%  |
+| 7        | Joel Paul           | Collierville-TN (Collierville Freedom Fighters) | 790   | 87.8  | 1  | 87%  |
+| 8        | Grace Bassey        | Riverside-CA (God\'s Property)                  | 715   | 79.4  | 5  | 88%  |
+| 9        | Joshua Panuganti    | Cumming-GA (Righteous Warriors)                 | 585   | 65    | 4  | 85%  |
+| 10       | Makya Gans          | Kearney-NE (Laughing Leviathans)                | 520   | 57.8  | 5  | 89%  |
+| 11       | Tyler Kelly         | Benton-AR (Kung Fu Quizzers)                    | 445   | 49.4  | 2  | 63%  |
+| 12       | Patrick Thomas      | Shreveport-LA (Shining Stars)                   | 380   | 42.2  | 1  | 57%  |
+| 13       | Elizabeth Bassey    | Riverside-CA (God\'s Property)                  | 365   | 40.6  | 1  | 89%  |
+| 14       | Adalia Abinteh      | Collierville-TN (Collierville Freedom Fighters) | 350   | 38.9  | 2  | 91%  |
+| 15       | Samuel Abothu       | Bellevue-WA (Bright Arrows)                     | 340   | 37.8  | 1  | 74%  |
+| 16       | Caden Sanders       | Benton-AR (Kung Fu Quizzers)                    | 325   | 36.1  | 3  | 67%  |
+| 17       | Steven Dasari       | Cumming-GA (Righteous Warriors)                 | 320   | 35.6  | 1  | 66%  |
+| 18       | Peter Van Slyke     | Overland Park-KS (KC Quizzers)                  | 300   | 33.3  | 3  | 72%  |
+| 19       | Portia Wolfe        | Emporia-KS (God\'s Masterpiece)                 | 265   | 29.4  |    | 76%  |
+| 20       | Roby Matta          | Bellevue-WA (Bright Arrows)                     | 195   | 21.7  |    | 75%  |
+| 21       | Jade Smith          | Emporia-KS (God\'s Masterpiece)                 | 185   | 20.6  | 1  | 80%  |
+| 22       | Jason Stoughter     | Shreveport-LA (Shining Stars)                   | 175   | 19.4  | 1  | 60%  |
+| 23       | Kara Barnes         | Louisville-KY (Redeemed)                        | 175   | 19.4  |    | 84%  |
+| 24       | Muna Ogwo           | Collierville-TN (Collierville Freedom Fighters) | 115   | 12.8  |    | 92%  |
+| **\*24** | Annika Posvar       | Kearney-NE (Laughing Leviathans)                | 115   | 12.8  |    | 81%  |
+| 25       | Olivia Moore        | Benton-AR (Kung Fu Quizzers)                    | 90    | 10    |    | 78%  |
+| 26       | Angela Peddapalli   | Cumming-GA (Righteous Warriors)                 | 80    | 8.9   |    | 100% |
+| **\*26** | Meso Ogwo           | Collierville-TN (Collierville Freedom Fighters) | 80    | 8.9   |    | 100% |
+| 27       | Norman Thomas       | Shreveport-LA (Shining Stars)                   | 70    | 7.8   |    | 50%  |
+| 28       | Justice Sanchez     | Overland Park-KS (KC Quizzers)                  | 45    | 5     |    | 48%  |
+| 29       | Katelyn Buse        | Kearney-NE (Laughing Leviathans)                | 30    | 3.3   |    | 66%  |
+| 30       | Michaekela Irving   | Benton-AR (Kung Fu Quizzers)                    | 20    | 2.2   |    | 99%  |
+| 31       | Andee Earnest       | Benton-AR (Kung Fu Quizzers)                    | 10    | 1.1   |    | 99%  |
+| 32       | Riley Huskey        | Benton-AR (Kung Fu Quizzers)                    | 5     | .6    |    | 50%  |
+| **\*32** | Noah Sanders        | Benton-AR (Kung Fu Quizzers)                    | 5     | .6    |    | 37%  |
+| 33       | Bryson Thomas       | Shreveport-LA (Shining Stars)                   | 0     |       |    |      |
+| **\*33** | Tripp Stormont      | Emporia-KS (God\'s Masterpiece)                 | 0     |       |    |      |
+| **\*33** | Fred Jackson        | Emporia-KS (God\'s Masterpiece)                 | 0     |       |    |      |
+| **\*33** | Andrew Greenwell    | Benton-AR (Kung Fu Quizzers)                    | 0     |       |    |      |
+| 34       | Amanda Barnes       | Louisville-KY (Redeemed)                        | -5    | -.6   |    |      |
+| **\*34** | Payton Gillund      | Emporia-KS (God\'s Masterpiece)                 | -5    | -.6   |    |      |

--- a/_pages/jbq/2018/index.md
+++ b/_pages/jbq/2018/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2018 JBQ Season"
+permalink: /jbq/2018/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+<a href="{% link _pages/jbq/2018/nationals.md %}" class="button is-primary">National Finals</a>
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2018/nationals.md
+++ b/_pages/jbq/2018/nationals.md
@@ -1,0 +1,1148 @@
+---
+layout: page
+title: "2018 National Festival: Orlando, FL"
+permalink: /jbq/2018/nationals/
+date: "2018-06-09"
+toc_title: Results
+menubar_toc: true
+---
+
+## Friday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                   | W/L    | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | The Overcomers (Houston-TX)                     | 15 / 0 | 3425  | 228.3 | 19 | 89% |
+| 2.0  | Naperville (D) (Naperville-IL)                  | 11 / 4 | 3005  | 200.3 | 20 | 89% |
+| 3.0  | More Than Conquerors (Tallahassee-FL)           | 11 / 4 | 2755  | 183.7 | 16 | 82% |
+| 4.0  | Minds of the Bible (Apple Valley-MN)            | 11 / 4 | 2550  | 170   | 11 | 83% |
+| 5.0  | Knights 4 Christ - Faith (Monmouth Junction-NJ) | 10 / 5 | 2765  | 184.3 | 12 | 80% |
+| 6.1  | Fruits of the Spirit (Racine-WI)                | 9 / 6  | 2190  | 146   | 4  | 75% |
+| 7.0  | Jedi Knights (Shelby Township-MI)               | 9 / 6  | 2645  | 176.3 | 10 | 80% |
+| 8.1  | Wilmington Warriors (Wilmington-NC)             | 8 / 7  | 1955  | 130.3 | 6  | 75% |
+| 9.0  | Tribulation Force (Red Oak-TX)                  | 8 / 7  | 2055  | 137   | 13 | 76% |
+| 10.0 | AAA Batteries (Springfield-MO)                  | 5 / 10 | 1865  | 124.3 | 7  | 75% |
+| 11.0 | Girls of Grace (Jacksonville -AR)               | 5 / 10 | 1755  | 117   | 1  | 83% |
+| 12.0 | Bethlehem Church (Richmond Hill-NY)             | 5 / 10 | 1750  | 116.7 | 5  | 74% |
+| 13.0 | Fireball Ninjas (Perry-IA)                      | 5 / 10 | 1610  | 107.3 | 3  | 90% |
+| 14.0 | In His Image (West Mifflin-PA)                  | 4 / 11 | 1570  | 104.7 |    | 70% |
+| 15.0 | Shoreline (Shoreline-WA)                        | 3 / 12 | 1580  | 105.3 | 4  | 73% |
+| 16.0 | 4K (Montgomery-AL)                              | 1 / 14 | 1440  | 96    | 3  | 72% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer               | Team / Church                                   | Total | Avg   | QO | Q%   |
+|---------:|-----------------------|-------------------------------------------------|------:|------:|---:|-----:|
+| 1        | David Biruduganti     | Naperville (D) (Naperville-IL)                  | 1830  | 122   | 8  | 93%  |
+| 2        | Precious Cyrus-David  | The Overcomers (Houston-TX)                     | 1685  | 112.3 | 6  | 90%  |
+| 3        | Elijah Stewart        | More Than Conquerors (Tallahassee-FL)           | 1395  | 93    | 10 | 83%  |
+| 4        | Samuel Jebaraj        | Knights 4 Christ - Faith (Monmouth Junction-NJ) | 1190  | 79.3  | 4  | 80%  |
+| 5        | Brendan VanOfferen    | Fruits of the Spirit (Racine-WI)                | 1170  | 78    | 2  | 69%  |
+| 6        | Lucy Morency          | Jedi Knights (Shelby Township-MI)               | 1150  | 76.7  | 2  | 96%  |
+| 7        | Corinne Arnold        | Shoreline (Shoreline-WA)                        | 1085  | 72.3  | 4  | 70%  |
+| 8        | Priscilla Adu-Gyamfi  | The Overcomers (Houston-TX)                     | 1045  | 69.7  | 9  | 86%  |
+| 9        | Spencer Morrison      | Minds of the Bible (Apple Valley-MN)            | 980   | 65.3  | 2  | 82%  |
+| 10       | Jocelyn Fredrick      | Knights 4 Christ - Faith (Monmouth Junction-NJ) | 915   | 61    | 2  | 79%  |
+| 11       | Kamelia Skinner       | Girls of Grace (Jacksonville -AR)               | 900   | 60    | 1  | 87%  |
+| 12       | Mackenzie Hight       | Fireball Ninjas (Perry-IA)                      | 880   | 58.7  | 3  | 96%  |
+| 13       | Samuel Padmanabhan    | Jedi Knights (Shelby Township-MI)               | 870   | 58    | 2  | 73%  |
+| 14       | Ezra King             | Tribulation Force (Red Oak-TX)                  | 850   | 56.7  | 11 | 85%  |
+| 15       | Anna Le               | AAA Batteries (Springfield-MO)                  | 845   | 56.3  | 5  | 86%  |
+| 16       | Samuel Biruduganti    | Naperville (D) (Naperville-IL)                  | 825   | 55    | 12 | 84%  |
+| 17       | Noah Janssens         | Tribulation Force (Red Oak-TX)                  | 815   | 54.3  | 2  | 76%  |
+| 18       | Emma Stewart          | More Than Conquerors (Tallahassee-FL)           | 795   | 53    | 3  | 88%  |
+| 19       | Addie Putman          | Minds of the Bible (Apple Valley-MN)            | 765   | 51    | 1  | 87%  |
+| 20       | Lauren Pahl           | Minds of the Bible (Apple Valley-MN)            | 760   | 50.7  | 8  | 83%  |
+| 21       | Corrie Lee Boehling   | Wilmington Warriors (Wilmington-NC)             | 745   | 49.7  | 2  | 80%  |
+| 22       | Paul Ertzberger       | Wilmington Warriors (Wilmington-NC)             | 740   | 49.3  | 1  | 79%  |
+| 23       | Andrew Le             | AAA Batteries (Springfield-MO)                  | 705   | 47    |    | 72%  |
+| 24       | Samuel DeSilva        | Bethlehem Church (Richmond Hill-NY)             | 700   | 46.7  | 4  | 81%  |
+| 25       | Garen Umukoro         | The Overcomers (Houston-TX)                     | 695   | 46.3  | 4  | 91%  |
+| 26       | Aiden Albert          | Knights 4 Christ - Faith (Monmouth Junction-NJ) | 660   | 44    | 6  | 83%  |
+| 27       | Austanne Barney       | Jedi Knights (Shelby Township-MI)               | 625   | 41.7  | 6  | 75%  |
+| 28       | Chloe Glunt           | In His Image (West Mifflin-PA)                  | 610   | 40.7  |    | 91%  |
+| 29       | Marianna Aguero       | Fruits of the Spirit (Racine-WI)                | 605   | 40.3  | 2  | 79%  |
+| 30       | Alana Hight           | Fireball Ninjas (Perry-IA)                      | 595   | 39.7  |    | 81%  |
+| 31       | Charlie Zimmerman     | More Than Conquerors (Tallahassee-FL)           | 565   | 37.7  | 3  | 76%  |
+| 32       | Sara Swain            | Girls of Grace (Jacksonville -AR)               | 480   | 32    |    | 68%  |
+| 33       | Daniel Boehling       | Wilmington Warriors (Wilmington-NC)             | 470   | 31.3  | 3  | 69%  |
+| 34       | Bobby Schoiack        | In His Image (West Mifflin-PA)                  | 400   | 26.7  |    | 70%  |
+| 35       | Aidan Fulfer          | Tribulation Force (Red Oak-TX)                  | 390   | 26    |    | 56%  |
+| 36       | David Girdner         | 4K (Montgomery-AL)                              | 380   | 25.3  |    | 71%  |
+| 37       | Marissa Dankwardt     | In His Image (West Mifflin-PA)                  | 365   | 24.3  |    | 62%  |
+| 38       | Eliana Rivera         | 4K (Montgomery-AL)                              | 340   | 22.7  |    | 80%  |
+| 39       | Vicente Rivera        | 4K (Montgomery-AL)                              | 335   | 22.3  | 3  | 68%  |
+| 40       | Shekinah Biruduganti  | Naperville (D) (Naperville-IL)                  | 335   | 22.3  |    | 94%  |
+| 41       | Eliana Phelps         | AAA Batteries (Springfield-MO)                  | 315   | 21    | 2  | 65%  |
+| 42       | Jon Luc Jobson Larkin | Bethlehem Church (Richmond Hill-NY)             | 305   | 20.3  |    | 75%  |
+| 43       | Cian VanOfferen       | Fruits of the Spirit (Racine-WI)                | 285   | 19    |    | 76%  |
+| 44       | Janae Arnold          | Shoreline (Shoreline-WA)                        | 275   | 18.3  |    | 77%  |
+| 45       | Mayah Johnson         | Bethlehem Church (Richmond Hill-NY)             | 270   | 18    | 1  | 58%  |
+| 46       | Trey Oliver           | 4K (Montgomery-AL)                              | 260   | 17.3  |    | 69%  |
+| 47       | Samantha Anselmo      | Bethlehem Church (Richmond Hill-NY)             | 245   | 16.3  |    | 83%  |
+| 48       | Maya Arnold           | Shoreline (Shoreline-WA)                        | 220   | 14.7  |    | 77%  |
+| 49       | Ciara Jonassaint      | In His Image (West Mifflin-PA)                  | 195   | 13    |    | 65%  |
+| 50       | Lakin Skinner         | Girls of Grace (Jacksonville -AR)               | 180   | 12    |    | 90%  |
+| 51       | Savanna Stephens      | Girls of Grace (Jacksonville -AR)               | 175   | 11.7  |    | 86%  |
+| 52       | Nevaeh Ferguson       | Fireball Ninjas (Perry-IA)                      | 135   | 9     |    | 93%  |
+| 53       | Hannah Hancock        | Bethlehem Church (Richmond Hill-NY)             | 115   | 7.7   |    | 75%  |
+| **\*53** | Emma Kokora           | Bethlehem Church (Richmond Hill-NY)             | 115   | 7.7   |    | 54%  |
+| 54       | Sofia Gonzalez        | 4K (Montgomery-AL)                              | 90    | 6     |    | 71%  |
+| 55       | Trinidy Calvary       | Fruits of the Spirit (Racine-WI)                | 70    | 4.7   |    | 100% |
+| 56       | Razalyn Kramer        | Fruits of the Spirit (Racine-WI)                | 60    | 4     |    | 100% |
+| 57       | Lukas Harries         | Minds of the Bible (Apple Valley-MN)            | 45    | 3     |    | 100% |
+| 58       | Timothy Goss          | 4K (Montgomery-AL)                              | 40    | 2.7   |    | 100% |
+| 59       | Addisyn Wolters       | Girls of Grace (Jacksonville -AR)               | 20    | 1.3   |    | 100% |
+| 60       | Elizabeth Siony       | Naperville (D) (Naperville-IL)                  | 15    | 1     |    | 66%  |
+| 61       | Garrett Crescenti     | Jedi Knights (Shelby Township-MI)               | 0     |       |    |      |
+| **\*61** | JP Dissmore           | More Than Conquerors (Tallahassee-FL)           | 0     |       |    |      |
+| **\*61** | Sarayah Hendricks     | Bethlehem Church (Richmond Hill-NY)             | 0     |       |    |      |
+| **\*61** | Cashmere Saez         | Bethlehem Church (Richmond Hill-NY)             | 0     |       |    |      |
+| **\*61** | Katelynn Do           | 4K (Montgomery-AL)                              | 0     |       |    |      |
+| **\*61** | Kasey Do              | 4K (Montgomery-AL)                              | 0     |       |    |      |
+| **\*61** | Ella Arnold           | Shoreline (Shoreline-WA)                        | 0     |       |    |      |
+| **\*61** | Samantha Powell       | Wilmington Warriors (Wilmington-NC)             | 0     |       |    |      |
+| **\*61** | Parker Christian      | Wilmington Warriors (Wilmington-NC)             | 0     |       |    |      |
+| **\*61** | Jack Willson          | Wilmington Warriors (Wilmington-NC)             | 0     |       |    |      |
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                         | W/L    | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | New Creatures (Beulah-ND)                             | 14 / 1 | 2990  | 199.3 | 16 | 93% |
+| 2.0  | Word Warriors (Brighton -MI)                          | 12 / 3 | 2835  | 189   | 14 | 87% |
+| 3.0  | Exalt The Lord\'s Name Steadfastly (Bothell-WA)       | 11 / 4 | 2665  | 177.7 | 12 | 82% |
+| 4.1  | BC United (Wyckoff-NJ)                                | 10 / 5 | 2550  | 170   | 16 | 81% |
+| 5.0  | Triple Threat (Cedar Hill-TX)                         | 10 / 5 | 2630  | 175.3 | 16 | 82% |
+| 6.0  | Good News Church (Omaha-NE)                           | 9 / 6  | 2750  | 183.3 | 10 | 84% |
+| 7.0  | Spurs (San Antonio-TX)                                | 9 / 6  | 2610  | 174   | 8  | 84% |
+| 8.0  | Radiant Quizzers (Dublin-OH)                          | 9 / 6  | 2260  | 150.7 | 12 | 84% |
+| 9.1  | Grace Red: Pardon the Interruption (New Whiteland-IN) | 8 / 7  | 2580  | 172   | 10 | 81% |
+| 10.0 | WoL Swordbearers (Springfield-VA)                     | 8 / 7  | 2525  | 168.3 | 9  | 78% |
+| 11.1 | Bible Bugs (Fordyce-AR)                               | 6 / 9  | 2295  | 153   | 6  | 82% |
+| 12.0 | ATC Flames (Norcross -GA)                             | 6 / 9  | 2375  | 158.3 | 10 | 83% |
+| 13.0 | Victory Boyz (Lakeland-FL)                            | 4 / 11 | 2120  | 141.3 | 10 | 76% |
+| 14.1 | WKTB (We Know The Bible) (Tucson-AZ)                  | 2 / 13 | 1285  | 85.7  | 2  | 68% |
+| 15.0 | SCC Truth Seekers (Shreveport-LA)                     | 2 / 13 | 1325  | 88.3  | 4  | 76% |
+| 16.0 | Lake Wylie Coyotes (Lake Wylie-SC)                    | 0 / 15 | 280   | 18.7  |    | 73% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                                         | Total | Avg   | QO | Q%   |
+|---------:|---------------------|-------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Jared Demoff        | Word Warriors (Brighton -MI)                          | 1730  | 115.3 | 7  | 88%  |
+| 2        | Larissa Cox         | Grace Red: Pardon the Interruption (New Whiteland-IN) | 1670  | 111.3 | 6  | 84%  |
+| 3        | Jayden Nimako       | Radiant Quizzers (Dublin-OH)                          | 1585  | 105.7 | 8  | 86%  |
+| 4        | Colson Sago         | New Creatures (Beulah-ND)                             | 1570  | 104.7 | 12 | 92%  |
+| 5        | Bethel Dawit        | WoL Swordbearers (Springfield-VA)                     | 1410  | 94    | 6  | 75%  |
+| 6        | Jenny Christopher   | ATC Flames (Norcross -GA)                             | 1345  | 89.7  | 4  | 84%  |
+| 7        | Noah Claunch        | Triple Threat (Cedar Hill-TX)                         | 1255  | 83.7  | 7  | 84%  |
+| 8        | Sancia Gladwin      | Exalt The Lord\'s Name Steadfastly (Bothell-WA)       | 1205  | 80.3  | 3  | 92%  |
+| 9        | Lademi Davies       | Good News Church (Omaha-NE)                           | 1150  | 76.7  | 8  | 86%  |
+| 10       | Kristyn Bauer       | New Creatures (Beulah-ND)                             | 1120  | 74.7  | 3  | 92%  |
+| 11       | Joel Ravela         | Victory Boyz (Lakeland-FL)                            | 1085  | 72.3  | 2  | 79%  |
+| 12       | Elijah Turner       | Bible Bugs (Fordyce-AR)                               | 1055  | 70.3  | 2  | 83%  |
+| 13       | Ansley Hornaday     | Bible Bugs (Fordyce-AR)                               | 1045  | 69.7  | 4  | 80%  |
+| 14       | Trenton Miller      | Spurs (San Antonio-TX)                                | 1040  | 69.3  | 2  | 85%  |
+| 15       | Brooke Kennedy      | BC United (Wyckoff-NJ)                                | 970   | 64.7  | 3  | 77%  |
+| 16       | Iokona Fern         | Good News Church (Omaha-NE)                           | 905   | 60.3  |    | 77%  |
+| 17       | Nathan Bello        | BC United (Wyckoff-NJ)                                | 865   | 57.7  | 12 | 85%  |
+| 18       | Joseph Barajas      | Triple Threat (Cedar Hill-TX)                         | 860   | 57.3  | 8  | 78%  |
+| 19       | Hans Daniel         | ATC Flames (Norcross -GA)                             | 840   | 56    | 5  | 80%  |
+| 20       | Nathan Joiner       | Victory Boyz (Lakeland-FL)                            | 755   | 50.3  | 7  | 79%  |
+| 21       | Braden Tew          | SCC Truth Seekers (Shreveport-LA)                     | 725   | 48.3  | 1  | 87%  |
+| 22       | Gabriella Demoff    | Word Warriors (Brighton -MI)                          | 715   | 47.7  | 7  | 83%  |
+| 23       | Jubilee Ward        | BC United (Wyckoff-NJ)                                | 715   | 47.7  | 1  | 82%  |
+| 24       | Elijah Chadwick     | Exalt The Lord\'s Name Steadfastly (Bothell-WA)       | 700   | 46.7  | 4  | 74%  |
+| 25       | Mabry Haley         | Spurs (San Antonio-TX)                                | 675   | 45    |    | 89%  |
+| 26       | Myah Berkey         | WKTB (We Know The Bible) (Tucson-AZ)                  | 635   | 42.3  | 1  | 73%  |
+| 27       | Faith Poling        | Radiant Quizzers (Dublin-OH)                          | 550   | 36.7  | 4  | 80%  |
+| 28       | Lucky Baldwin       | Exalt The Lord\'s Name Steadfastly (Bothell-WA)       | 535   | 35.7  | 5  | 77%  |
+| 29       | Caroline Tew        | SCC Truth Seekers (Shreveport-LA)                     | 515   | 34.3  | 3  | 73%  |
+| 30       | Adeline Keith       | Triple Threat (Cedar Hill-TX)                         | 515   | 34.3  | 1  | 90%  |
+| 31       | Liana Thomas        | Spurs (San Antonio-TX)                                | 495   | 33    | 3  | 87%  |
+| 32       | Abigail Carlson     | Grace Red: Pardon the Interruption (New Whiteland-IN) | 435   | 29    | 3  | 77%  |
+| 33       | Nolan King          | Good News Church (Omaha-NE)                           | 405   | 27    | 2  | 85%  |
+| 34       | Caris Thomas        | Spurs (San Antonio-TX)                                | 400   | 26.7  | 3  | 76%  |
+| 35       | Elijah Forbord      | Word Warriors (Brighton -MI)                          | 390   | 26    |    | 94%  |
+| 36       | Mason Berkey        | WKTB (We Know The Bible) (Tucson-AZ)                  | 365   | 24.3  | 1  | 64%  |
+| 37       | Joel Doosey         | WoL Swordbearers (Springfield-VA)                     | 315   | 21    |    | 75%  |
+| 38       | Aubryn Sago         | New Creatures (Beulah-ND)                             | 300   | 20    | 1  | 100% |
+| 39       | Sarah Dawit         | WoL Swordbearers (Springfield-VA)                     | 290   | 19.3  | 1  | 94%  |
+| 40       | Rylan Hance         | Victory Boyz (Lakeland-FL)                            | 270   | 18    | 1  | 66%  |
+| 41       | Nathanael Obel      | WoL Swordbearers (Springfield-VA)                     | 255   | 17    | 1  | 77%  |
+| **\*41** | Daniel Priddy       | Grace Red: Pardon the Interruption (New Whiteland-IN) | 255   | 17    | 1  | 76%  |
+| 42       | Samuel Riverson     | WoL Swordbearers (Springfield-VA)                     | 230   | 15.3  | 1  | 79%  |
+| 43       | Lucas Brunson       | Grace Red: Pardon the Interruption (New Whiteland-IN) | 220   | 14.7  |    | 83%  |
+| 44       | Connor Hubbard      | Bible Bugs (Fordyce-AR)                               | 195   | 13    |    | 87%  |
+| 45       | Joel Christopher    | ATC Flames (Norcross -GA)                             | 190   | 12.7  | 1  | 90%  |
+| 46       | Marissa Gephart     | WKTB (We Know The Bible) (Tucson-AZ)                  | 185   | 12.3  |    | 55%  |
+| 47       | Aaron Martin        | Good News Church (Omaha-NE)                           | 150   | 10    |    | 89%  |
+| 48       | Noah Myhill         | Exalt The Lord\'s Name Steadfastly (Bothell-WA)       | 125   | 8.3   |    | 91%  |
+| 49       | Ileina Fern         | Good News Church (Omaha-NE)                           | 110   | 7.3   |    | 100% |
+| 50       | Camilla Joye        | Lake Wylie Coyotes (Lake Wylie-SC)                    | 105   | 7     |    | 79%  |
+| **\*50** | Phoenix Butler      | Lake Wylie Coyotes (Lake Wylie-SC)                    | 105   | 7     |    | 69%  |
+| 51       | Talia Jarrell       | Exalt The Lord\'s Name Steadfastly (Bothell-WA)       | 100   | 6.7   |    | 100% |
+| **\*51** | Grace Hammett       | Radiant Quizzers (Dublin-OH)                          | 100   | 6.7   |    | 100% |
+| 52       | Amaris Bravo        | WKTB (We Know The Bible) (Tucson-AZ)                  | 70    | 4.7   |    | 100% |
+| 53       | Jonathan Paredes    | SCC Truth Seekers (Shreveport-LA)                     | 55    | 3.7   |    | 64%  |
+| 54       | Judah Sears         | WKTB (We Know The Bible) (Tucson-AZ)                  | 30    | 2     |    | 100% |
+| **\*54** | Thomas Ricciardelli | Lake Wylie Coyotes (Lake Wylie-SC)                    | 30    | 2     |    | 100% |
+| **\*54** | Ariana Aristy       | Good News Church (Omaha-NE)                           | 30    | 2     |    | 100% |
+| **\*54** | Ethan Paredes       | SCC Truth Seekers (Shreveport-LA)                     | 30    | 2     |    | 67%  |
+| 55       | Josiah Riverson     | WoL Swordbearers (Springfield-VA)                     | 25    | 1.7   |    | 57%  |
+| **\*55** | Davaney McSwain     | Lake Wylie Coyotes (Lake Wylie-SC)                    | 25    | 1.7   |    | 50%  |
+| 56       | Terrill Walls Jr    | Lake Wylie Coyotes (Lake Wylie-SC)                    | 15    | 1     |    | 100% |
+| **\*56** | Aseda Essandoh      | Radiant Quizzers (Dublin-OH)                          | 15    | 1     |    | 66%  |
+| 57       | Hayden Wright       | Victory Boyz (Lakeland-FL)                            | 10    | .7    |    | 99%  |
+| **\*57** | Konyinsola Sofowora | Radiant Quizzers (Dublin-OH)                          | 10    | .7    |    | 99%  |
+| 58       | Aaron Kefyalew      | WoL Swordbearers (Springfield-VA)                     | 0     |       |    |      |
+| **\*58** | Ezra Kefyalew       | WoL Swordbearers (Springfield-VA)                     | 0     |       |    |      |
+| **\*58** | Jace Hance          | Victory Boyz (Lakeland-FL)                            | 0     |       |    |      |
+| **\*58** | Rachel Fuller       | SCC Truth Seekers (Shreveport-LA)                     | 0     |       |    |      |
+| **\*58** | London Hamilton     | SCC Truth Seekers (Shreveport-LA)                     | 0     |       |    |      |
+| **\*58** | Madison Woodbury    | Lake Wylie Coyotes (Lake Wylie-SC)                    | 0     |       |    |      |
+| **\*58** | Hailey Woodbury     | Lake Wylie Coyotes (Lake Wylie-SC)                    | 0     |       |    |      |
+| **\*58** | Laynie Nutt         | Bible Bugs (Fordyce-AR)                               | 0     |       |    |      |
+| **\*58** | Braley Collins      | Bible Bugs (Fordyce-AR)                               | 0     |       |    |      |
+| **\*58** | Adalyn Hornaday     | Bible Bugs (Fordyce-AR)                               | 0     |       |    |      |
+| **\*58** | Anna Claire Collins | Bible Bugs (Fordyce-AR)                               | 0     |       |    |      |
+| **\*58** | Kerra Nutt          | Bible Bugs (Fordyce-AR)                               | 0     |       |    |      |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                  | W/L    | Total | Avg   | QO | Q%  |
+|-----:|------------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | Double Trouble (Springfield-MO)                | 14 / 1 | 2965  | 197.7 | 22 | 92% |
+| 2.0  | Conquerors Through Christ (Humble-TX)          | 13 / 2 | 2875  | 191.7 | 24 | 85% |
+| 3.0  | 3N1 (Waxahachie-TX)                            | 12 / 3 | 2610  | 174   | 14 | 84% |
+| 4.0  | Naperville (M) (Naperville-IL)                 | 11 / 4 | 2815  | 187.7 | 21 | 80% |
+| 5.0  | The Neighborhood Church Bellevue (Bellevue-WA) | 10 / 5 | 2225  | 148.3 | 7  | 74% |
+| 6.0  | Contagious Valor (Mechanicsville-VA)           | 9 / 6  | 2405  | 160.3 | 5  | 80% |
+| 7.0  | Zion Zelotes (Harrisburg-NC)                   | 8 / 7  | 2565  | 171   | 7  | 85% |
+| 8.0  | ATCS Living Stones (Lawrenceville-GA)          | 7 / 8  | 2005  | 133.7 | 4  | 71% |
+| 9.0  | God\'s Squad (Chandler-AZ)                     | 6 / 9  | 2230  | 148.7 | 4  | 78% |
+| 10.0 | Truth Defenders (Painesville-OH)               | 6 / 9  | 2045  | 136.3 | 8  | 74% |
+| 11.0 | Racine Far From Over (Racine-WI)               | 6 / 9  | 1990  | 132.7 | 4  | 76% |
+| 12.0 | Exodus Expedition (Mount Washington-KY)        | 6 / 9  | 1870  | 124.7 | 6  | 84% |
+| 13.0 | Webster Odlebury\'s (Webster-NY)               | 5 / 10 | 1855  | 123.7 | 7  | 78% |
+| 14.0 | The Avengers of JBQ (Orlando-FL)               | 4 / 11 | 1605  | 107   | 3  | 74% |
+| 15.0 | God\'s Gang (Fargo-ND)                         | 2 / 13 | 1665  | 111   | 5  | 72% |
+| 16.0 | Gateway Master (Shreveport-LA)                 | 1 / 14 | 1000  | 66.7  | 3  | 59% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                                  | Total | Avg   | QO | Q%   |
+|---------:|---------------------|------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Abigail Jones       | Double Trouble (Springfield-MO)                | 1850  | 123.3 | 8  | 90%  |
+| 2        | Joy Escobar         | 3N1 (Waxahachie-TX)                            | 1675  | 111.7 | 8  | 83%  |
+| 3        | Shaymis Powell      | Naperville (M) (Naperville-IL)                 | 1625  | 108.3 | 9  | 80%  |
+| 4        | Naomi Shtyrkalo     | Conquerors Through Christ (Humble-TX)          | 1590  | 106   | 12 | 90%  |
+| 5        | Jonathan Shtyrkalo  | Conquerors Through Christ (Humble-TX)          | 1285  | 85.7  | 12 | 80%  |
+| 6        | Jack Adkins         | Truth Defenders (Painesville-OH)               | 1230  | 82    | 3  | 82%  |
+| 7        | Timothy Mathew      | God\'s Squad (Chandler-AZ)                     | 1210  | 80.7  | 2  | 84%  |
+| 8        | Sarah Jones         | Double Trouble (Springfield-MO)                | 1115  | 74.3  | 14 | 94%  |
+| 9        | Matthew Walker      | Racine Far From Over (Racine-WI)               | 1115  | 74.3  | 2  | 71%  |
+| 10       | Lily Smith          | Exodus Expedition (Mount Washington-KY)        | 1090  | 72.7  | 5  | 91%  |
+| 11       | Jonah Gallo         | The Neighborhood Church Bellevue (Bellevue-WA) | 1075  | 71.7  | 5  | 73%  |
+| 12       | Shaylee Powell      | Naperville (M) (Naperville-IL)                 | 960   | 64    | 12 | 81%  |
+| 13       | Christian Steele    | Contagious Valor (Mechanicsville-VA)           | 870   | 58    | 4  | 83%  |
+| 14       | Ron Kommoji         | ATCS Living Stones (Lawrenceville-GA)          | 805   | 53.7  | 1  | 77%  |
+| 15       | Isaac Salisbury     | Webster Odlebury\'s (Webster-NY)               | 750   | 50    | 1  | 76%  |
+| 16       | Tori Glanzer        | God\'s Gang (Fargo-ND)                         | 745   | 49.7  | 1  | 76%  |
+| 17       | Jason Charwin       | Zion Zelotes (Harrisburg-NC)                   | 735   | 49    | 1  | 89%  |
+| 18       | Rachel Joel         | Zion Zelotes (Harrisburg-NC)                   | 725   | 48.3  | 1  | 81%  |
+| 19       | Payton Durbin       | Exodus Expedition (Mount Washington-KY)        | 680   | 45.3  | 1  | 78%  |
+| 20       | Will Anderson       | The Avengers of JBQ (Orlando-FL)               | 680   | 45.3  |    | 66%  |
+| 21       | Sujjay Karthikeyan  | Zion Zelotes (Harrisburg-NC)                   | 665   | 44.3  | 4  | 81%  |
+| 22       | Hector Rivera       | 3N1 (Waxahachie-TX)                            | 625   | 41.7  | 6  | 85%  |
+| 23       | Patrick Thomas      | Gateway Master (Shreveport-LA)                 | 620   | 41.3  | 1  | 56%  |
+| 24       | Angelina Arasavelli | The Neighborhood Church Bellevue (Bellevue-WA) | 610   | 40.7  |    | 100% |
+| 25       | Nynee Padala        | ATCS Living Stones (Lawrenceville-GA)          | 565   | 37.7  | 1  | 73%  |
+| 26       | Brooks Adams        | Contagious Valor (Mechanicsville-VA)           | 560   | 37.3  | 1  | 72%  |
+| 27       | Ola Alabi           | God\'s Gang (Fargo-ND)                         | 520   | 34.7  | 4  | 73%  |
+| 28       | Anthony Collins     | Truth Defenders (Painesville-OH)               | 500   | 33.3  | 5  | 66%  |
+| 29       | Isaiah Salisbury    | Webster Odlebury\'s (Webster-NY)               | 440   | 29.3  | 5  | 76%  |
+| 30       | Sarah Isabel        | Zion Zelotes (Harrisburg-NC)                   | 440   | 29.3  | 1  | 95%  |
+| 31       | Addison Odle        | Webster Odlebury\'s (Webster-NY)               | 440   | 29.3  |    | 86%  |
+| 32       | Aubrey Spence       | The Avengers of JBQ (Orlando-FL)               | 430   | 28.7  | 3  | 77%  |
+| 33       | Savannah Harper     | Contagious Valor (Mechanicsville-VA)           | 420   | 28    |    | 73%  |
+| 34       | Aiyana Jaramillo    | Racine Far From Over (Racine-WI)               | 355   | 23.7  | 2  | 92%  |
+| **\*34** | Elijah Gallo        | The Neighborhood Church Bellevue (Bellevue-WA) | 355   | 23.7  | 2  | 65%  |
+| 35       | Hans Jacob          | God\'s Squad (Chandler-AZ)                     | 355   | 23.7  | 1  | 76%  |
+| 36       | Joanna Thomas       | God\'s Squad (Chandler-AZ)                     | 330   | 22    | 1  | 79%  |
+| 37       | Gracie Bland        | The Avengers of JBQ (Orlando-FL)               | 330   | 22    |    | 93%  |
+| 38       | Roshini Rayarala    | ATCS Living Stones (Lawrenceville-GA)          | 320   | 21.3  | 2  | 65%  |
+| 39       | Angel Walker        | Contagious Valor (Mechanicsville-VA)           | 320   | 21.3  |    | 100% |
+| **\*39** | Reuben Jaramillo    | Racine Far From Over (Racine-WI)               | 320   | 21.3  |    | 65%  |
+| 40       | Hiram Salinas       | 3N1 (Waxahachie-TX)                            | 310   | 20.7  |    | 83%  |
+| 41       | Anita Mathew        | God\'s Squad (Chandler-AZ)                     | 305   | 20.3  |    | 69%  |
+| 42       | Benita Ayebo        | God\'s Gang (Fargo-ND)                         | 285   | 19    |    | 81%  |
+| 43       | Justin Klco         | Truth Defenders (Painesville-OH)               | 255   | 17    |    | 76%  |
+| 44       | Jason Stroughter    | Gateway Master (Shreveport-LA)                 | 210   | 14    | 2  | 59%  |
+| 45       | Nicholas Tait       | Racine Far From Over (Racine-WI)               | 200   | 13.3  |    | 81%  |
+| 46       | Lainey Kondepudi    | ATCS Living Stones (Lawrenceville-GA)          | 175   | 11.7  |    | 80%  |
+| 47       | Jordan Spence       | The Avengers of JBQ (Orlando-FL)               | 165   | 11    |    | 61%  |
+| 48       | Jeremiah Das        | ATCS Living Stones (Lawrenceville-GA)          | 145   | 9.7   |    | 61%  |
+| 49       | Luke Odle           | Webster Odlebury\'s (Webster-NY)               | 135   | 9     | 1  | 75%  |
+| 50       | Roby Matta          | The Neighborhood Church Bellevue (Bellevue-WA) | 135   | 9     |    | 71%  |
+| 51       | Kaleb Stanley       | Contagious Valor (Mechanicsville-VA)           | 120   | 8     |    | 100% |
+| **\*51** | Josh Hung           | Naperville (M) (Naperville-IL)                 | 120   | 8     |    | 71%  |
+| 52       | Ope Alabi           | God\'s Gang (Fargo-ND)                         | 115   | 7.7   |    | 58%  |
+| 53       | John Hung           | Naperville (M) (Naperville-IL)                 | 110   | 7.3   |    | 86%  |
+| 54       | Kenneth Stanley     | Contagious Valor (Mechanicsville-VA)           | 100   | 6.7   |    | 72%  |
+| **\*54** | Norman Thomas       | Gateway Master (Shreveport-LA)                 | 100   | 6.7   |    | 58%  |
+| 55       | Judah Salisbury     | Webster Odlebury\'s (Webster-NY)               | 95    | 6.3   |    | 91%  |
+| 56       | Lacee Smith         | Gateway Master (Shreveport-LA)                 | 65    | 4.3   |    | 87%  |
+| 57       | Claire Adkins       | Truth Defenders (Painesville-OH)               | 60    | 4     |    | 100% |
+| 58       | Jacob Luxem         | The Neighborhood Church Bellevue (Bellevue-WA) | 50    | 3.3   |    | 100% |
+| 59       | Levi Smith          | Exodus Expedition (Mount Washington-KY)        | 40    | 2.7   |    | 100% |
+| **\*59** | Luke Smith          | Exodus Expedition (Mount Washington-KY)        | 40    | 2.7   |    | 60%  |
+| 60       | Shreya Ganesan      | God\'s Squad (Chandler-AZ)                     | 30    | 2     |    | 66%  |
+| 61       | Patrick Durbin      | Exodus Expedition (Mount Washington-KY)        | 20    | 1.3   |    | 100% |
+| 62       | Berkley Adams       | Contagious Valor (Mechanicsville-VA)           | 15    | 1     |    | 66%  |
+| 63       | Bryson Thomas       | Gateway Master (Shreveport-LA)                 | 10    | .7    |    | 99%  |
+| 64       | Landon Dissmore     | Racine Far From Over (Racine-WI)               | 0     |       |    |      |
+| **\*64** | Zane Smaaladen      | God\'s Gang (Fargo-ND)                         | 0     |       |    |      |
+| **\*64** | Jalen Porter        | Exodus Expedition (Mount Washington-KY)        | 0     |       |    |      |
+| 65       | Eden Salisbury      | Webster Odlebury\'s (Webster-NY)               | -5    | -.3   |    |      |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                       | W/L    | Total | Avg   | QO | Q%  |
+|-----:|-----------------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | Knights 4 Christ - Salvation (Monmouth Junction-NJ) | 14 / 1 | 3265  | 217.7 | 16 | 90% |
+| 2.0  | Guardians of the Gospel (Garland-TX)                | 12 / 3 | 2890  | 192.7 | 16 | 76% |
+| 3.0  | United for Christ (Mustang-OK)                      | 12 / 3 | 2855  | 190.3 | 12 | 82% |
+| 4.0  | Naperville (C) (Naperville-IL)                      | 12 / 3 | 2720  | 181.3 | 18 | 78% |
+| 5.0  | BLC Soldiers of God (Bloomington-MN)                | 9 / 6  | 2505  | 167   | 7  | 83% |
+| 6.0  | Purple Plated Penguins (Chesterfield-MO)            | 8 / 7  | 2295  | 153   | 3  | 80% |
+| 7.0  | Grace Black: Buzzer Bangers (New Whiteland-IN)      | 7 / 8  | 2480  | 165.3 | 9  | 84% |
+| 8.0  | GC Kids (Tallahassee-FL)                            | 7 / 8  | 2165  | 144.3 | 9  | 85% |
+| 9.0  | Sparta Salt (Sparta-WI)                             | 7 / 8  | 2120  | 141.3 | 6  | 77% |
+| 10.0 | Faith Temple (Rochester-NY)                         | 7 / 8  | 2080  | 138.7 | 15 | 78% |
+| 11.1 | Kids on a Mission (Akron-OH)                        | 6 / 9  | 1910  | 127.3 | 7  | 73% |
+| 12.0 | Word Warriors (Hanford-CA)                          | 6 / 9  | 1930  | 128.7 | 5  | 76% |
+| 13.0 | Buzz Hogs (Mabelvale-AR)                            | 5 / 10 | 1825  | 121.7 | 3  | 75% |
+| 14.1 | Anointed Ones (Marietta-GA)                         | 4 / 11 | 1890  | 126   | 4  | 78% |
+| 15.0 | CIA Special Agents (Mendon-MA)                      | 4 / 11 | 1850  | 123.3 | 6  | 73% |
+| 16.0 | What\'s Your Name (Rapid City-SD)                   | 0 / 15 | 645   | 43    |    | 83% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                                       | Total | Avg   | QO | Q%   |
+|---------:|------------------------|-----------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Remiel Brigilin        | Knights 4 Christ - Salvation (Monmouth Junction-NJ) | 1935  | 129   | 10 | 92%  |
+| 2        | Shawn Timothy          | Naperville (C) (Naperville-IL)                      | 1825  | 121.7 | 11 | 85%  |
+| 3        | Christian Alapati      | United for Christ (Mustang-OK)                      | 1645  | 109.7 | 9  | 84%  |
+| 4        | Nathan Koch            | Guardians of the Gospel (Garland-TX)                | 1545  | 103   | 8  | 78%  |
+| 5        | Collin Nester          | GC Kids (Tallahassee-FL)                            | 1355  | 90.3  | 6  | 84%  |
+| 6        | Ben Butler             | Faith Temple (Rochester-NY)                         | 1345  | 89.7  | 6  | 80%  |
+| 7        | Sonika Ramala          | BLC Soldiers of God (Bloomington-MN)                | 1325  | 88.3  | 5  | 86%  |
+| 8        | William Okyere         | Grace Black: Buzzer Bangers (New Whiteland-IN)      | 1305  | 87    | 7  | 85%  |
+| 9        | Hayden Monty           | CIA Special Agents (Mendon-MA)                      | 1295  | 86.3  | 6  | 81%  |
+| 10       | Bryce Helgerson        | Sparta Salt (Sparta-WI)                             | 1270  | 84.7  | 3  | 77%  |
+| 11       | Addison McCullough     | Word Warriors (Hanford-CA)                          | 1130  | 75.3  | 3  | 82%  |
+| 12       | Shirah Ramaji          | Purple Plated Penguins (Chesterfield-MO)            | 1065  | 71    | 2  | 74%  |
+| 13       | Elylah Stager          | Kids on a Mission (Akron-OH)                        | 875   | 58.3  | 4  | 73%  |
+| 14       | Lauryn Jackson         | Buzz Hogs (Mabelvale-AR)                            | 875   | 58.3  | 1  | 82%  |
+| 15       | Steve Joy              | Anointed Ones (Marietta-GA)                         | 865   | 57.7  | 1  | 74%  |
+| 16       | Andrian Kolliegbo      | Grace Black: Buzzer Bangers (New Whiteland-IN)      | 750   | 50    | 1  | 87%  |
+| 17       | Jason Theodore         | Knights 4 Christ - Salvation (Monmouth Junction-NJ) | 735   | 49    | 5  | 89%  |
+| 18       | Andrew Lopez           | Guardians of the Gospel (Garland-TX)                | 730   | 48.7  | 7  | 78%  |
+| 19       | Makayla Reyes          | Naperville (C) (Naperville-IL)                      | 700   | 46.7  | 7  | 76%  |
+| 20       | Chloe Eder             | Kids on a Mission (Akron-OH)                        | 680   | 45.3  | 2  | 71%  |
+| 21       | Hector Siaca           | Faith Temple (Rochester-NY)                         | 660   | 44    | 9  | 77%  |
+| 22       | Freya Brigilin         | Knights 4 Christ - Salvation (Monmouth Junction-NJ) | 595   | 39.7  | 1  | 88%  |
+| 23       | Wesley Horn            | United for Christ (Mustang-OK)                      | 560   | 37.3  |    | 76%  |
+| 24       | Chandler Nester        | GC Kids (Tallahassee-FL)                            | 525   | 35    | 3  | 88%  |
+| 25       | Tania Ruth Anand       | Anointed Ones (Marietta-GA)                         | 520   | 34.7  |    | 93%  |
+| 26       | Josiah Minick          | Buzz Hogs (Mabelvale-AR)                            | 505   | 33.7  | 1  | 63%  |
+| 27       | Sahil Badhe            | Purple Plated Penguins (Chesterfield-MO)            | 500   | 33.3  | 1  | 80%  |
+| 28       | Issac Helgerson        | Sparta Salt (Sparta-WI)                             | 440   | 29.3  | 1  | 73%  |
+| 29       | Ben Elliott            | Purple Plated Penguins (Chesterfield-MO)            | 440   | 29.3  |    | 73%  |
+| 30       | Shamitha Jampana       | BLC Soldiers of God (Bloomington-MN)                | 435   | 29    |    | 84%  |
+| 31       | Hannah Mathew          | BLC Soldiers of God (Bloomington-MN)                | 430   | 28.7  | 2  | 77%  |
+| 32       | Nehemiah Page          | Buzz Hogs (Mabelvale-AR)                            | 430   | 28.7  | 1  | 80%  |
+| 33       | Amayah Pate            | Grace Black: Buzzer Bangers (New Whiteland-IN)      | 425   | 28.3  | 1  | 81%  |
+| 34       | Lillee Solvie          | What\'s Your Name (Rapid City-SD)                   | 420   | 28    |    | 82%  |
+| 35       | Carson Fincher         | United for Christ (Mustang-OK)                      | 385   | 25.7  | 3  | 88%  |
+| 36       | Amaya Allard           | Sparta Salt (Sparta-WI)                             | 370   | 24.7  | 2  | 80%  |
+| 37       | Rylie Pugh             | Guardians of the Gospel (Garland-TX)                | 350   | 23.3  |    | 79%  |
+| 38       | Elizabeth Binion       | Word Warriors (Hanford-CA)                          | 335   | 22.3  | 2  | 64%  |
+| 39       | Dharshine Jayakrishnan | Anointed Ones (Marietta-GA)                         | 325   | 21.7  | 3  | 67%  |
+| 40       | Isaac Elliott          | Purple Plated Penguins (Chesterfield-MO)            | 290   | 19.3  |    | 100% |
+| 41       | Kaylee Williams        | GC Kids (Tallahassee-FL)                            | 285   | 19    |    | 82%  |
+| 42       | Matthew Vengal         | BLC Soldiers of God (Bloomington-MN)                | 280   | 18.7  |    | 83%  |
+| **\*42** | Ezekiel Hamel          | CIA Special Agents (Mendon-MA)                      | 280   | 18.7  |    | 63%  |
+| 43       | Braidan Morais         | CIA Special Agents (Mendon-MA)                      | 255   | 17    |    | 70%  |
+| 44       | Nick McGee             | Kids on a Mission (Akron-OH)                        | 240   | 16    |    | 90%  |
+| 45       | Reese Pugh             | Guardians of the Gospel (Garland-TX)                | 235   | 15.7  | 1  | 65%  |
+| 46       | Alicia Twiford         | Word Warriors (Hanford-CA)                          | 230   | 15.3  |    | 94%  |
+| 47       | Emily Ragains          | What\'s Your Name (Rapid City-SD)                   | 225   | 15    |    | 85%  |
+| 48       | Garrett McElroy        | United for Christ (Mustang-OK)                      | 185   | 12.3  |    | 71%  |
+| 49       | Joshua Gunasingh       | Anointed Ones (Marietta-GA)                         | 180   | 12    |    | 100% |
+| 50       | Gabriel Parra          | Naperville (C) (Naperville-IL)                      | 175   | 11.7  |    | 73%  |
+| 51       | Ethan Stager           | Kids on a Mission (Akron-OH)                        | 125   | 8.3   | 1  | 68%  |
+| 52       | Annika Twiford         | Word Warriors (Hanford-CA)                          | 120   | 8     |    | 75%  |
+| 53       | Makynlee Summers       | Word Warriors (Hanford-CA)                          | 115   | 7.7   |    | 81%  |
+| 54       | Cameron Lykes          | United for Christ (Mustang-OK)                      | 80    | 5.3   |    | 100% |
+| 55       | Jack Altman            | Faith Temple (Rochester-NY)                         | 75    | 5     |    | 75%  |
+| 56       | Issac Briski           | Sparta Salt (Sparta-WI)                             | 40    | 2.7   |    | 100% |
+| 57       | Jones Kanjirkatte      | BLC Soldiers of God (Bloomington-MN)                | 35    | 2.3   |    | 80%  |
+| 58       | AJ Lopez               | Guardians of the Gospel (Garland-TX)                | 30    | 2     |    | 100% |
+| 59       | Mason Monty            | CIA Special Agents (Mendon-MA)                      | 20    | 1.3   |    | 100% |
+| **\*59** | Mariel Parra           | Naperville (C) (Naperville-IL)                      | 20    | 1.3   |    | 44%  |
+| 60       | Cherish Page           | Buzz Hogs (Mabelvale-AR)                            | 15    | 1     |    | 66%  |
+| 61       | Corbin Frydenlund      | Sparta Salt (Sparta-WI)                             | 0     |       |    |      |
+| **\*61** | Abigail Koch           | Guardians of the Gospel (Garland-TX)                | 0     |       |    |      |
+| **\*61** | Judith Ramesh          | Guardians of the Gospel (Garland-TX)                | 0     |       |    |      |
+| **\*61** | Kiley Trott            | Faith Temple (Rochester-NY)                         | 0     |       |    |      |
+| **\*61** | Joshua Torres          | Faith Temple (Rochester-NY)                         | 0     |       |    |      |
+| **\*61** | Richard Torres         | Faith Temple (Rochester-NY)                         | 0     |       |    |      |
+| **\*61** | Aliyah Morais          | CIA Special Agents (Mendon-MA)                      | 0     |       |    |      |
+| **\*61** | Tanner Longacre        | CIA Special Agents (Mendon-MA)                      | 0     |       |    |      |
+| **\*61** | Trinity Terry          | Buzz Hogs (Mabelvale-AR)                            | 0     |       |    |      |
+| **\*61** | Peter Page             | Buzz Hogs (Mabelvale-AR)                            | 0     |       |    |      |
+| **\*61** | Pragnan Nukala         | BLC Soldiers of God (Bloomington-MN)                | 0     |       |    |      |
+| 62       | David Mackey           | Kids on a Mission (Akron-OH)                        | -10   | -.7   |    | 20%  |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                           | W/L    | Total | Avg   | QO | Q%  |
+|-----:|-----------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | The Chosen Ones (Houston-TX)            | 13 / 2 | 3025  | 201.7 | 14 | 91% |
+| 2.0  | Armor of God (Metuchen-NJ)              | 12 / 3 | 2935  | 195.7 | 12 | 80% |
+| 3.1  | Titans for Christ (Phoenix-AZ)          | 11 / 4 | 2590  | 172.7 | 12 | 78% |
+| 4.0  | Naperville (S) (Naperville-IL)          | 11 / 4 | 2825  | 188.3 | 21 | 82% |
+| 5.0  | Gushers (Bristow-VA)                    | 10 / 5 | 2580  | 172   | 8  | 81% |
+| 6.0  | Jedi Quizzers (Springfield-MO)          | 8 / 7  | 2215  | 147.7 | 7  | 78% |
+| 7.0  | Bethel A/G (Askewville-NC)              | 8 / 7  | 2115  | 141   | 11 | 71% |
+| 8.0  | Musketeers (Baxter-MN)                  | 8 / 7  | 1720  | 114.7 | 4  | 75% |
+| 9.0  | Word Wise Quiz Kids (Cordova-TN)        | 7 / 8  | 2045  | 136.3 | 10 | 82% |
+| 10.1 | Sparta Light (Sparta-WI)                | 6 / 9  | 2015  | 134.3 | 3  | 74% |
+| 11.0 | Fluffy Panda Quizzers (Gahanna-OH)      | 6 / 9  | 2140  | 142.7 | 8  | 67% |
+| 12.0 | ATCS Mighty Warriors (Lawrenceville-GA) | 5 / 10 | 1930  | 128.7 | 6  | 75% |
+| 13.0 | Carmel Crusaders (Bonifay-FL)           | 5 / 10 | 1670  | 111.3 | 2  | 66% |
+| 14.0 | Avengers (Hamburg-PA)                   | 5 / 10 | 1600  | 106.7 | 4  | 70% |
+| 15.0 | The Remix (Oswego-KS)                   | 4 / 11 | 1820  | 121.3 | 5  | 85% |
+| 16.0 | Quiz Avengers (North Little Rock-AR)    | 1 / 14 | 1085  | 72.3  |    | 66% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                           | Total | Avg   | QO | Q%   |
+|---------:|---------------------|-----------------------------------------|------:|------:|---:|-----:|
+| 1        | Reagan Stevens      | Naperville (S) (Naperville-IL)          | 1625  | 108.3 | 8  | 84%  |
+| 2        | Brandon Ukonu       | The Chosen Ones (Houston-TX)            | 1485  | 99    | 8  | 89%  |
+| 3        | Samuel Deppe        | Word Wise Quiz Kids (Cordova-TN)        | 1320  | 88    | 9  | 74%  |
+| 4        | Cole Muscari        | Titans for Christ (Phoenix-AZ)          | 1270  | 84.7  | 6  | 79%  |
+| 5        | Kacey Mayfield      | The Remix (Oswego-KS)                   | 1155  | 77    | 1  | 98%  |
+| 6        | Iyanu Akanbi        | The Chosen Ones (Houston-TX)            | 1050  | 70    | 5  | 100% |
+| 7        | Sam Mair            | Fluffy Panda Quizzers (Gahanna-OH)      | 1045  | 69.7  | 4  | 66%  |
+| 8        | Johnathan Dinesh    | Armor of God (Metuchen-NJ)              | 1035  | 69    | 3  | 78%  |
+| 9        | Kaitlyn Ramsey      | Jedi Quizzers (Springfield-MO)          | 1025  | 68.3  | 2  | 78%  |
+| 10       | Irenov Joel         | Armor of God (Metuchen-NJ)              | 980   | 65.3  | 3  | 80%  |
+| 11       | Susan Kambam        | ATCS Mighty Warriors (Lawrenceville-GA) | 975   | 65    | 1  | 75%  |
+| 12       | Kayleigh Henley     | Gushers (Bristow-VA)                    | 965   | 64.3  | 6  | 78%  |
+| 13       | Lindsey Perry       | Bethel A/G (Askewville-NC)              | 915   | 61    | 6  | 74%  |
+| 14       | Sawyer Curtis       | Sparta Light (Sparta-WI)                | 900   | 60    | 2  | 76%  |
+| 15       | McKinley Stevens    | Naperville (S) (Naperville-IL)          | 880   | 58.7  | 13 | 82%  |
+| 16       | Alyssa Ramsey       | Jedi Quizzers (Springfield-MO)          | 785   | 52.3  | 4  | 83%  |
+| 17       | Enoch Anderson      | Musketeers (Baxter-MN)                  | 775   | 51.7  | 3  | 88%  |
+| 18       | Austin Perry        | Bethel A/G (Askewville-NC)              | 740   | 49.3  | 5  | 69%  |
+| 19       | Michael Newland     | Gushers (Bristow-VA)                    | 730   | 48.7  |    | 88%  |
+| 20       | Kiersten Womble     | Carmel Crusaders (Bonifay-FL)           | 710   | 47.3  |    | 74%  |
+| 21       | Anna Jordan         | Quiz Avengers (North Little Rock-AR)    | 705   | 47    |    | 69%  |
+| 22       | Jonathan Guntle     | Avengers (Hamburg-PA)                   | 690   | 46    | 2  | 70%  |
+| 23       | Cade Muscari        | Titans for Christ (Phoenix-AZ)          | 675   | 45    | 6  | 76%  |
+| 24       | Bryan James         | Armor of God (Metuchen-NJ)              | 645   | 43    | 5  | 81%  |
+| 25       | Caleb Karthik       | Fluffy Panda Quizzers (Gahanna-OH)      | 615   | 41    | 2  | 66%  |
+| 26       | Jeremiah Vecchioni  | Sparta Light (Sparta-WI)                | 600   | 40    |    | 81%  |
+| 27       | Andrew Allegra      | Musketeers (Baxter-MN)                  | 585   | 39    |    | 71%  |
+| 28       | Anish Kondreddy     | ATCS Mighty Warriors (Lawrenceville-GA) | 580   | 38.7  | 5  | 73%  |
+| 29       | Grace Noel          | The Remix (Oswego-KS)                   | 575   | 38.3  | 4  | 75%  |
+| 30       | Lizzie Biek         | Titans for Christ (Phoenix-AZ)          | 565   | 37.7  |    | 77%  |
+| 31       | Benjamin Antony     | Word Wise Quiz Kids (Cordova-TN)        | 515   | 34.3  | 1  | 91%  |
+| 32       | Audrey Mason        | Gushers (Bristow-VA)                    | 415   | 27.7  | 2  | 83%  |
+| 33       | Tegan Crowley       | Avengers (Hamburg-PA)                   | 390   | 26    |    | 79%  |
+| 34       | Jacey Pathri        | Fluffy Panda Quizzers (Gahanna-OH)      | 385   | 25.7  | 2  | 67%  |
+| 35       | Jaden Ukonu         | The Chosen Ones (Houston-TX)            | 325   | 21.7  | 1  | 83%  |
+| 36       | Joel Kommoji        | ATCS Mighty Warriors (Lawrenceville-GA) | 315   | 21    |    | 76%  |
+| 37       | Olivia Collins      | Sparta Light (Sparta-WI)                | 310   | 20.7  | 1  | 62%  |
+| 38       | Andrea Mason        | Gushers (Bristow-VA)                    | 310   | 20.7  |    | 76%  |
+| **\*38** | Randi Goodwin       | Bethel A/G (Askewville-NC)              | 310   | 20.7  |    | 62%  |
+| 39       | Micah Warren        | Carmel Crusaders (Bonifay-FL)           | 295   | 19.7  | 2  | 69%  |
+| 40       | Brady WOmble        | Carmel Crusaders (Bonifay-FL)           | 280   | 18.7  |    | 88%  |
+| 41       | Samuel Joshua       | Armor of God (Metuchen-NJ)              | 275   | 18.3  | 1  | 83%  |
+| 42       | Pierce Stevens      | Naperville (S) (Naperville-IL)          | 270   | 18    |    | 75%  |
+| 43       | Judah Guntle        | Avengers (Hamburg-PA)                   | 250   | 16.7  | 1  | 93%  |
+| 44       | Braylon Sutherland  | Quiz Avengers (North Little Rock-AR)    | 220   | 14.7  |    | 58%  |
+| 45       | Rebecca Lee         | Carmel Crusaders (Bonifay-FL)           | 210   | 14    |    | 69%  |
+| 46       | Brant Maschino      | Jedi Quizzers (Springfield-MO)          | 205   | 13.7  | 1  | 77%  |
+| 47       | Sarah Robertson     | Word Wise Quiz Kids (Cordova-TN)        | 170   | 11.3  |    | 100% |
+| 48       | Jason Ukonu         | The Chosen Ones (Houston-TX)            | 165   | 11    |    | 94%  |
+| 49       | Andrew Adamson      | Musketeers (Baxter-MN)                  | 160   | 10.7  | 1  | 75%  |
+| 50       | Ana Obi             | Gushers (Bristow-VA)                    | 160   | 10.7  |    | 82%  |
+| **\*50** | Gabe Parrish        | Musketeers (Baxter-MN)                  | 160   | 10.7  |    | 75%  |
+| 51       | Sophia Curtis       | Sparta Light (Sparta-WI)                | 155   | 10.3  |    | 94%  |
+| 52       | Lynsey Bazemore     | Bethel A/G (Askewville-NC)              | 150   | 10    |    | 88%  |
+| 53       | Charli Fitzgerald   | Avengers (Hamburg-PA)                   | 140   | 9.3   |    | 69%  |
+| 54       | McKenna Black       | Jedi Quizzers (Springfield-MO)          | 135   | 9     |    | 69%  |
+| **\*54** | Quinton Zepp        | Carmel Crusaders (Bonifay-FL)           | 135   | 9     |    | 55%  |
+| 55       | Thomas Yarnall      | Avengers (Hamburg-PA)                   | 110   | 7.3   | 1  | 53%  |
+| 56       | Evan Neerudu        | Fluffy Panda Quizzers (Gahanna-OH)      | 95    | 6.3   |    | 80%  |
+| 57       | Brooklyn Sutherland | Quiz Avengers (North Little Rock-AR)    | 90    | 6     |    | 73%  |
+| 58       | Jasmine Wedgworth   | Quiz Avengers (North Little Rock-AR)    | 70    | 4.7   |    | 86%  |
+| 59       | Brady Williams      | Jedi Quizzers (Springfield-MO)          | 65    | 4.3   |    | 80%  |
+| 60       | Tyler Trexler       | Titans for Christ (Phoenix-AZ)          | 60    | 4     |    | 100% |
+| **\*60** | Hannah Noel         | The Remix (Oswego-KS)                   | 60    | 4     |    | 100% |
+| 61       | Ava Millard         | Sparta Light (Sparta-WI)                | 50    | 3.3   |    | 100% |
+| **\*61** | Esther Siony        | Naperville (S) (Naperville-IL)          | 50    | 3.3   |    | 100% |
+| **\*61** | Sebastian Tisdell   | Musketeers (Baxter-MN)                  | 50    | 3.3   |    | 53%  |
+| 62       | Ava Robertson       | Word Wise Quiz Kids (Cordova-TN)        | 40    | 2.7   |    | 100% |
+| **\*62** | Neiha Peyyala       | ATCS Mighty Warriors (Lawrenceville-GA) | 40    | 2.7   |    | 100% |
+| **\*62** | Sam Lee             | Carmel Crusaders (Bonifay-FL)           | 40    | 2.7   |    | 37%  |
+| 63       | Lane Wolsey         | The Remix (Oswego-KS)                   | 30    | 2     |    | 100% |
+| 64       | Joseph Peyyala      | ATCS Mighty Warriors (Lawrenceville-GA) | 20    | 1.3   |    | 100% |
+| **\*64** | Logan MacPherson    | Titans for Christ (Phoenix-AZ)          | 20    | 1.3   |    | 99%  |
+| **\*64** | Alaina Yarnall      | Avengers (Hamburg-PA)                   | 20    | 1.3   |    | 50%  |
+| 65       | Tayton Hazell       | The Remix (Oswego-KS)                   | 0     |       |    |      |
+| **\*65** | Jamilet Juarez      | Quiz Avengers (North Little Rock-AR)    | 0     |       |    |      |
+| **\*65** | Lennen Juarez       | Quiz Avengers (North Little Rock-AR)    | 0     |       |    |      |
+| **\*65** | Brennan Tisdell     | Musketeers (Baxter-MN)                  | 0     |       |    |      |
+| **\*65** | Elizabeth Adamson   | Musketeers (Baxter-MN)                  | 0     |       |    |      |
+| **\*65** | Belva Fianko        | Gushers (Bristow-VA)                    | 0     |       |    |      |
+| **\*65** | Malayah Thomas      | Avengers (Hamburg-PA)                   | 0     |       |    |      |
+| **\*65** | Sheila Pissarra     | Avengers (Hamburg-PA)                   | 0     |       |    |      |
+| 66       | Ben Allegra         | Musketeers (Baxter-MN)                  | -10   | -.7   |    |      |
+
+
+## Saturday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                       | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-----------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | The Overcomers (Houston-TX)                         | 8 / 1 | 1530  | 170   | 4  | 78% |
+| 2.1  | Knights 4 Christ - Salvation (Monmouth Junction-NJ) | 7 / 2 | 1540  | 171.1 | 6  | 85% |
+| 3.0  | Naperville (D) (Naperville-IL)                      | 7 / 2 | 1615  | 179.4 | 11 | 85% |
+| 4.0  | The Chosen Ones (Houston-TX)                        | 6 / 3 | 1590  | 176.6 | 7  | 91% |
+| 5.0  | Word Warriors (Brighton -MI)                        | 4 / 5 | 1205  | 133.9 | 3  | 75% |
+| 6.0  | Conquerors Through Christ (Humble-TX)               | 3 / 6 | 1385  | 153.9 | 10 | 83% |
+| 7.0  | Guardians of the Gospel (Garland-TX)                | 3 / 6 | 1190  | 132.2 | 5  | 68% |
+| 8.0  | Armor of God (Metuchen-NJ)                          | 3 / 6 | 1190  | 132.2 | 2  | 67% |
+| 9.0  | New Creatures (Beulah-ND)                           | 2 / 7 | 1190  | 132.2 | 1  | 94% |
+| 10.0 | Double Trouble (Springfield-MO)                     | 2 / 7 | 1040  | 115.5 | 3  | 77% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                                       | Total | Avg   | QO | Q%   |
+|---------:|----------------------|-----------------------------------------------------|------:|------:|---:|-----:|
+| 1        | David Biruduganti    | Naperville (D) (Naperville-IL)                      | 1125  | 125   | 6  | 87%  |
+| 2        | Remiel Brigilin      | Knights 4 Christ - Salvation (Monmouth Junction-NJ) | 1040  | 115.6 | 4  | 87%  |
+| 3        | Precious Cyrus-David | The Overcomers (Houston-TX)                         | 895   | 99.4  | 3  | 82%  |
+| 4        | Brandon Ukonu        | The Chosen Ones (Houston-TX)                        | 865   | 96.1  | 4  | 88%  |
+| 5        | Jared Demoff         | Word Warriors (Brighton -MI)                        | 815   | 90.6  | 2  | 77%  |
+| 6        | Jonathan Shtyrkalo   | Conquerors Through Christ (Humble-TX)               | 740   | 82.2  | 7  | 78%  |
+| 7        | Naomi Shtyrkalo      | Conquerors Through Christ (Humble-TX)               | 645   | 71.7  | 3  | 91%  |
+| 8        | Abigail Jones        | Double Trouble (Springfield-MO)                     | 645   | 71.7  | 1  | 73%  |
+| 9        | Nathan Koch          | Guardians of the Gospel (Garland-TX)                | 570   | 63.3  | 4  | 68%  |
+| 10       | Iyanu Akanbi         | The Chosen Ones (Houston-TX)                        | 560   | 62.2  | 3  | 97%  |
+| 11       | Colson Sago          | New Creatures (Beulah-ND)                           | 550   | 61.1  |    | 95%  |
+| 12       | Johnathan Dinesh     | Armor of God (Metuchen-NJ)                          | 480   | 53.3  |    | 76%  |
+| 13       | Samuel Biruduganti   | Naperville (D) (Naperville-IL)                      | 440   | 48.9  | 5  | 81%  |
+| 14       | Irenov Joel          | Armor of God (Metuchen-NJ)                          | 435   | 48.3  | 2  | 69%  |
+| 15       | Priscilla Adu-Gyamfi | The Overcomers (Houston-TX)                         | 430   | 47.8  | 1  | 72%  |
+| 16       | Kristyn Bauer        | New Creatures (Beulah-ND)                           | 410   | 45.6  |    | 88%  |
+| 17       | Sarah Jones          | Double Trouble (Springfield-MO)                     | 395   | 43.9  | 2  | 80%  |
+| 18       | Jason Theodore       | Knights 4 Christ - Salvation (Monmouth Junction-NJ) | 370   | 41.1  | 2  | 83%  |
+| 19       | Gabriella Demoff     | Word Warriors (Brighton -MI)                        | 300   | 33.3  | 1  | 69%  |
+| 20       | Andrew Lopez         | Guardians of the Gospel (Garland-TX)                | 270   | 30    | 1  | 71%  |
+| 21       | Aubryn Sago          | New Creatures (Beulah-ND)                           | 230   | 25.6  | 1  | 100% |
+| 22       | Rylie Pugh           | Guardians of the Gospel (Garland-TX)                | 230   | 25.6  |    | 74%  |
+| 23       | Garen Umukoro        | The Overcomers (Houston-TX)                         | 205   | 22.8  |    | 81%  |
+| 24       | Bryan James          | Armor of God (Metuchen-NJ)                          | 180   | 20    |    | 60%  |
+| 25       | Freya Brigilin       | Knights 4 Christ - Salvation (Monmouth Junction-NJ) | 135   | 15    |    | 80%  |
+| 26       | Reese Pugh           | Guardians of the Gospel (Garland-TX)                | 110   | 12.2  |    | 59%  |
+| 27       | Samuel Joshua        | Armor of God (Metuchen-NJ)                          | 95    | 10.6  |    | 65%  |
+| 28       | Elijah Forbord       | Word Warriors (Brighton -MI)                        | 90    | 10    |    | 100% |
+| 29       | Jaden Ukonu          | The Chosen Ones (Houston-TX)                        | 85    | 9.4   |    | 77%  |
+| 30       | Jason Ukonu          | The Chosen Ones (Houston-TX)                        | 80    | 8.9   |    | 100% |
+| 31       | Elizabeth Siony      | Naperville (D) (Naperville-IL)                      | 30    | 3.3   |    | 100% |
+| 32       | Shekinah Biruduganti | Naperville (D) (Naperville-IL)                      | 20    | 2.2   |    | 100% |
+| 33       | AJ Lopez             | Guardians of the Gospel (Garland-TX)                | 10    | 1.1   |    | 99%  |
+| 34       | Abigail Koch         | Guardians of the Gospel (Garland-TX)                | 0     |       |    |      |
+| **\*34** | Judith Ramesh        | Guardians of the Gospel (Garland-TX)                | 0     |       |    |      |
+
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                   | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | United for Christ (Mustang-OK)                  | 8 / 1 | 1530  | 170   | 4  | 80% |
+| 2.1  | Naperville (C) (Naperville-IL)                  | 6 / 3 | 1380  | 153.3 | 9  | 77% |
+| 3.0  | Naperville (M) (Naperville-IL)                  | 6 / 3 | 1340  | 148.9 | 9  | 75% |
+| 4.0  | Naperville (S) (Naperville-IL)                  | 5 / 4 | 1665  | 185   | 10 | 83% |
+| 5.0  | Titans for Christ (Phoenix-AZ)                  | 5 / 4 | 1410  | 156.6 | 7  | 78% |
+| 6.0  | More Than Conquerors (Tallahassee-FL)           | 5 / 4 | 1300  | 144.4 | 8  | 72% |
+| 7.0  | Exalt The Lord\'s Name Steadfastly (Bothell-WA) | 4 / 5 | 1155  | 128.3 | 1  | 77% |
+| 8.0  | 3N1 (Waxahachie-TX)                             | 3 / 6 | 1235  | 137.2 | 3  | 79% |
+| 9.0  | Minds of the Bible (Apple Valley-MN)            | 2 / 7 | 1305  | 145   | 5  | 84% |
+| 10.0 | BC United (Wyckoff-NJ)                          | 1 / 8 | 1050  | 116.7 | 2  | 79% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                   | Total | Avg   | QO | Q%   |
+|---------:|-------------------|-------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Reagan Stevens    | Naperville (S) (Naperville-IL)                  | 1050  | 116.7 | 5  | 87%  |
+| 2        | Joy Escobar       | 3N1 (Waxahachie-TX)                             | 920   | 102.2 | 3  | 82%  |
+| 3        | Shaymis Powell    | Naperville (M) (Naperville-IL)                  | 845   | 93.9  | 3  | 77%  |
+| 4        | Shawn Timothy     | Naperville (C) (Naperville-IL)                  | 840   | 93.3  | 4  | 75%  |
+| 5        | Christian Alapati | United for Christ (Mustang-OK)                  | 800   | 88.9  | 2  | 80%  |
+| 6        | Elijah Stewart    | More Than Conquerors (Tallahassee-FL)           | 710   | 78.9  | 6  | 73%  |
+| 7        | Cole Muscari      | Titans for Christ (Phoenix-AZ)                  | 605   | 67.2  | 2  | 73%  |
+| 8        | Brooke Kennedy    | BC United (Wyckoff-NJ)                          | 585   | 65    | 1  | 82%  |
+| 9        | Sancia Gladwin    | Exalt The Lord\'s Name Steadfastly (Bothell-WA) | 525   | 58.3  |    | 92%  |
+| 10       | Makayla Reyes     | Naperville (C) (Naperville-IL)                  | 495   | 55    | 5  | 81%  |
+| 11       | Spencer Morrison  | Minds of the Bible (Apple Valley-MN)            | 460   | 51.1  | 1  | 89%  |
+| 12       | Addie Putman      | Minds of the Bible (Apple Valley-MN)            | 440   | 48.9  |    | 89%  |
+| 13       | Shaylee Powell    | Naperville (M) (Naperville-IL)                  | 430   | 47.8  | 6  | 75%  |
+| 14       | Cade Muscari      | Titans for Christ (Phoenix-AZ)                  | 430   | 47.8  | 5  | 78%  |
+| **\*14** | McKinley Stevens  | Naperville (S) (Naperville-IL)                  | 430   | 47.8  | 5  | 76%  |
+| 15       | Emma Stewart      | More Than Conquerors (Tallahassee-FL)           | 405   | 45    | 1  | 79%  |
+| 16       | Lauren Pahl       | Minds of the Bible (Apple Valley-MN)            | 400   | 44.4  | 4  | 82%  |
+| 17       | Wesley Horn       | United for Christ (Mustang-OK)                  | 310   | 34.4  | 1  | 81%  |
+| 18       | Nathan Bello      | BC United (Wyckoff-NJ)                          | 305   | 33.9  | 1  | 76%  |
+| 19       | Lizzie Biek       | Titans for Christ (Phoenix-AZ)                  | 305   | 33.9  |    | 93%  |
+| 20       | Carson Fincher    | United for Christ (Mustang-OK)                  | 230   | 25.6  | 1  | 92%  |
+| 21       | Elijah Chadwick   | Exalt The Lord\'s Name Steadfastly (Bothell-WA) | 195   | 21.7  | 1  | 58%  |
+| 22       | Charlie Zimmerman | More Than Conquerors (Tallahassee-FL)           | 185   | 20.6  | 1  | 65%  |
+| 23       | Pierce Stevens    | Naperville (S) (Naperville-IL)                  | 175   | 19.4  |    | 93%  |
+| **\*23** | Hector Rivera     | 3N1 (Waxahachie-TX)                             | 175   | 19.4  |    | 68%  |
+| **\*23** | Lucky Baldwin     | Exalt The Lord\'s Name Steadfastly (Bothell-WA) | 175   | 19.4  |    | 66%  |
+| 24       | Jubilee Ward      | BC United (Wyckoff-NJ)                          | 160   | 17.8  |    | 78%  |
+| 25       | Noah Myhill       | Exalt The Lord\'s Name Steadfastly (Bothell-WA) | 140   | 15.6  |    | 100% |
+| **\*25** | Hiram Salinas     | 3N1 (Waxahachie-TX)                             | 140   | 15.6  |    | 100% |
+| 26       | Talia Jarrell     | Exalt The Lord\'s Name Steadfastly (Bothell-WA) | 120   | 13.3  |    | 100% |
+| 27       | Cameron Lykes     | United for Christ (Mustang-OK)                  | 100   | 11.1  |    | 100% |
+| 28       | Garrett McElroy   | United for Christ (Mustang-OK)                  | 90    | 10    |    | 58%  |
+| 29       | Tyler Trexler     | Titans for Christ (Phoenix-AZ)                  | 70    | 7.8   |    | 80%  |
+| 30       | Josh Hung         | Naperville (M) (Naperville-IL)                  | 45    | 5     |    | 67%  |
+| 31       | Gabriel Parra     | Naperville (C) (Naperville-IL)                  | 40    | 4.4   |    | 60%  |
+| 32       | John Hung         | Naperville (M) (Naperville-IL)                  | 20    | 2.2   |    | 99%  |
+| 33       | Esther Siony      | Naperville (S) (Naperville-IL)                  | 10    | 1.1   |    | 99%  |
+| 34       | Mariel Parra      | Naperville (C) (Naperville-IL)                  | 5     | .6    |    | 50%  |
+| **\*34** | Lukas Harries     | Minds of the Bible (Apple Valley-MN)            | 5     | .6    |    | 33%  |
+| 35       | Logan MacPherson  | Titans for Christ (Phoenix-AZ)                  | 0     |       |    |      |
+| **\*35** | JP Dissmore       | More Than Conquerors (Tallahassee-FL)           | 0     |       |    |      |
+
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                   | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Triple Threat (Cedar Hill-TX)                   | 8 / 1 | 1565  | 173.9 | 7  | 79% |
+| 2.0  | Good News Church (Omaha-NE)                     | 6 / 3 | 1600  | 177.8 | 7  | 79% |
+| 3.0  | Knights 4 Christ - Faith (Monmouth Junction-NJ) | 6 / 3 | 1385  | 153.9 | 4  | 80% |
+| 4.0  | Jedi Quizzers (Springfield-MO)                  | 6 / 3 | 1355  | 150.5 | 4  | 78% |
+| 5.1  | Contagious Valor (Mechanicsville-VA)            | 5 / 4 | 1400  | 155.5 | 5  | 77% |
+| 6.0  | BLC Soldiers of God (Bloomington-MN)            | 5 / 4 | 1310  | 145.5 | 4  | 79% |
+| 7.0  | Fruits of the Spirit (Racine-WI)                | 4 / 5 | 1090  | 121.1 | 2  | 68% |
+| 8.0  | The Neighborhood Church Bellevue (Bellevue-WA)  | 3 / 6 | 1025  | 113.9 | 1  | 68% |
+| 9.0  | Gushers (Bristow-VA)                            | 2 / 7 | 1045  | 116.1 | 1  | 71% |
+| 10.0 | Purple Plated Penguins (Chesterfield-MO)        | 0 / 9 | 775   | 86.1  |    | 70% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                                   | Total | Avg  | QO | Q%   |
+|---------:|---------------------|-------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Sonika Ramala       | BLC Soldiers of God (Bloomington-MN)            | 795   | 88.3 | 3  | 81%  |
+| 2        | Noah Claunch        | Triple Threat (Cedar Hill-TX)                   | 775   | 86.1 | 3  | 86%  |
+| 3        | Alyssa Ramsey       | Jedi Quizzers (Springfield-MO)                  | 685   | 76.1 | 3  | 83%  |
+| 4        | Lademi Davies       | Good News Church (Omaha-NE)                     | 655   | 72.8 | 4  | 80%  |
+| 5        | Iokona Fern         | Good News Church (Omaha-NE)                     | 590   | 65.6 | 2  | 74%  |
+| 6        | Jocelyn Fredrick    | Knights 4 Christ - Faith (Monmouth Junction-NJ) | 520   | 57.8 | 1  | 77%  |
+| 7        | Joseph Barajas      | Triple Threat (Cedar Hill-TX)                   | 475   | 52.8 | 4  | 72%  |
+| 8        | Samuel Jebaraj      | Knights 4 Christ - Faith (Monmouth Junction-NJ) | 445   | 49.4 |    | 74%  |
+| 9        | Kaitlyn Ramsey      | Jedi Quizzers (Springfield-MO)                  | 425   | 47.2 | 1  | 72%  |
+| 10       | Aiden Albert        | Knights 4 Christ - Faith (Monmouth Junction-NJ) | 420   | 46.7 | 3  | 87%  |
+| 11       | Jonah Gallo         | The Neighborhood Church Bellevue (Bellevue-WA)  | 410   | 45.6 |    | 61%  |
+| 12       | Christian Steele    | Contagious Valor (Mechanicsville-VA)            | 405   | 45   | 1  | 78%  |
+| **\*12** | Brendan VanOfferen  | Fruits of the Spirit (Racine-WI)                | 405   | 45   | 1  | 64%  |
+| 13       | Marianna Aguero     | Fruits of the Spirit (Racine-WI)                | 370   | 41.1 |    | 70%  |
+| 14       | Angelina Arasavelli | The Neighborhood Church Bellevue (Bellevue-WA)  | 350   | 38.9 | 1  | 94%  |
+| 15       | Michael Newland     | Gushers (Bristow-VA)                            | 345   | 38.3 |    | 73%  |
+| 16       | Savannah Harper     | Contagious Valor (Mechanicsville-VA)            | 340   | 37.8 | 1  | 77%  |
+| 17       | Brooks Adams        | Contagious Valor (Mechanicsville-VA)            | 320   | 35.6 |    | 77%  |
+| 18       | Adeline Keith       | Triple Threat (Cedar Hill-TX)                   | 315   | 35   |    | 82%  |
+| 19       | Ben Elliott         | Purple Plated Penguins (Chesterfield-MO)        | 310   | 34.4 |    | 89%  |
+| 20       | Audrey Mason        | Gushers (Bristow-VA)                            | 275   | 30.6 | 1  | 77%  |
+| 21       | Kayleigh Henley     | Gushers (Bristow-VA)                            | 275   | 30.6 |    | 65%  |
+| 22       | Nolan King          | Good News Church (Omaha-NE)                     | 255   | 28.3 | 1  | 80%  |
+| 23       | Shamitha Jampana    | BLC Soldiers of God (Bloomington-MN)            | 255   | 28.3 |    | 82%  |
+| 24       | Cian VanOfferen     | Fruits of the Spirit (Racine-WI)                | 215   | 23.9 | 1  | 68%  |
+| 25       | Isaac Elliott       | Purple Plated Penguins (Chesterfield-MO)        | 215   | 23.9 |    | 92%  |
+| 26       | Shirah Ramaji       | Purple Plated Penguins (Chesterfield-MO)        | 190   | 21.1 |    | 50%  |
+| 27       | Kenneth Stanley     | Contagious Valor (Mechanicsville-VA)            | 165   | 18.3 | 2  | 81%  |
+| 28       | Roby Matta          | The Neighborhood Church Bellevue (Bellevue-WA)  | 140   | 15.6 |    | 80%  |
+| **\*28** | Brant Maschino      | Jedi Quizzers (Springfield-MO)                  | 140   | 15.6 |    | 77%  |
+| 29       | Hannah Mathew       | BLC Soldiers of God (Bloomington-MN)            | 130   | 14.4 | 1  | 70%  |
+| 30       | Andrea Mason        | Gushers (Bristow-VA)                            | 100   | 11.1 |    | 64%  |
+| 31       | Jacob Luxem         | The Neighborhood Church Bellevue (Bellevue-WA)  | 90    | 10   |    | 100% |
+| **\*31** | Angel Walker        | Contagious Valor (Mechanicsville-VA)            | 90    | 10   |    | 100% |
+| 32       | Berkley Adams       | Contagious Valor (Mechanicsville-VA)            | 70    | 7.8  | 1  | 100% |
+| 33       | Jones Kanjirkatte   | BLC Soldiers of God (Bloomington-MN)            | 70    | 7.8  |    | 100% |
+| 34       | Matthew Vengal      | BLC Soldiers of God (Bloomington-MN)            | 65    | 7.2  |    | 77%  |
+| **\*34** | Sahil Badhe         | Purple Plated Penguins (Chesterfield-MO)        | 65    | 7.2  |    | 59%  |
+| 35       | Razalyn Kramer      | Fruits of the Spirit (Racine-WI)                | 60    | 6.7  |    | 100% |
+| **\*35** | Brady Williams      | Jedi Quizzers (Springfield-MO)                  | 60    | 6.7  |    | 78%  |
+| 36       | Ana Obi             | Gushers (Bristow-VA)                            | 50    | 5.6  |    | 75%  |
+| **\*36** | Aaron Martin        | Good News Church (Omaha-NE)                     | 50    | 5.6  |    | 75%  |
+| 37       | McKenna Black       | Jedi Quizzers (Springfield-MO)                  | 45    | 5    |    | 67%  |
+| 38       | Trinidy Calvary     | Fruits of the Spirit (Racine-WI)                | 40    | 4.4  |    | 67%  |
+| 39       | Elijah Gallo        | The Neighborhood Church Bellevue (Bellevue-WA)  | 35    | 3.9  |    | 43%  |
+| 40       | Ileina Fern         | Good News Church (Omaha-NE)                     | 30    | 3.3  |    | 99%  |
+| 41       | Ariana Aristy       | Good News Church (Omaha-NE)                     | 20    | 2.2  |    | 100% |
+| 42       | Kaleb Stanley       | Contagious Valor (Mechanicsville-VA)            | 10    | 1.1  |    | 45%  |
+| 43       | Belva Fianko        | Gushers (Bristow-VA)                            | 0     |      |    |      |
+| **\*43** | Pragnan Nukala      | BLC Soldiers of God (Bloomington-MN)            | 0     |      |    |      |
+
+
+### Orange
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                  | W/L   | Total | Avg   | QO | Q%  |
+|-----:|------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.1  | Spurs (San Antonio-TX)                         | 7 / 2 | 1530  | 170   | 3  | 84% |
+| 2.0  | Jedi Knights (Shelby Township-MI)              | 7 / 2 | 1665  | 185   | 6  | 84% |
+| 3.0  | Bethel A/G (Askewville-NC)                     | 6 / 3 | 1440  | 160   | 4  | 77% |
+| 4.1  | GC Kids (Tallahassee-FL)                       | 5 / 4 | 1420  | 157.8 | 7  | 85% |
+| 5.0  | Wilmington Warriors (Wilmington-NC)            | 5 / 4 | 1230  | 136.7 | 5  | 79% |
+| 6.0  | Grace Black: Buzzer Bangers (New Whiteland-IN) | 4 / 5 | 1460  | 162.2 | 7  | 82% |
+| 7.0  | Musketeers (Baxter-MN)                         | 4 / 5 | 1165  | 129.4 | 4  | 78% |
+| 8.0  | ATCS Living Stones (Lawrenceville-GA)          | 4 / 5 | 1115  | 123.9 | 3  | 64% |
+| 9.0  | Radiant Quizzers (Dublin-OH)                   | 2 / 7 | 1110  | 123.3 | 3  | 81% |
+| 10.0 | Zion Zelotes (Harrisburg-NC)                   | 1 / 8 | 1080  | 120   |    | 77% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                                  | Total | Avg   | QO | Q%   |
+|---------:|---------------------|------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Jayden Nimako       | Radiant Quizzers (Dublin-OH)                   | 920   | 102.2 | 3  | 83%  |
+| 2        | William Okyere      | Grace Black: Buzzer Bangers (New Whiteland-IN) | 900   | 100   | 4  | 85%  |
+| 3        | Collin Nester       | GC Kids (Tallahassee-FL)                       | 880   | 97.8  | 5  | 81%  |
+| 4        | Trenton Miller      | Spurs (San Antonio-TX)                         | 690   | 76.7  | 1  | 88%  |
+| 5        | Lucy Morency        | Jedi Knights (Shelby Township-MI)              | 640   | 71.1  |    | 100% |
+| 6        | Samuel Padmanabhan  | Jedi Knights (Shelby Township-MI)              | 600   | 66.7  | 1  | 79%  |
+| 7        | Lindsey Perry       | Bethel A/G (Askewville-NC)                     | 555   | 61.7  | 2  | 75%  |
+| 8        | Austin Perry        | Bethel A/G (Askewville-NC)                     | 490   | 54.4  | 2  | 78%  |
+| 9        | Daniel Boehling     | Wilmington Warriors (Wilmington-NC)            | 485   | 53.9  | 5  | 78%  |
+| 10       | Ron Kommoji         | ATCS Living Stones (Lawrenceville-GA)          | 485   | 53.9  |    | 70%  |
+| 11       | Andrew Allegra      | Musketeers (Baxter-MN)                         | 460   | 51.1  | 2  | 76%  |
+| 12       | Enoch Anderson      | Musketeers (Baxter-MN)                         | 440   | 48.9  | 2  | 87%  |
+| 13       | Austanne Barney     | Jedi Knights (Shelby Township-MI)              | 425   | 47.2  | 5  | 77%  |
+| 14       | Paul Ertzberger     | Wilmington Warriors (Wilmington-NC)            | 410   | 45.6  |    | 83%  |
+| 15       | Mabry Haley         | Spurs (San Antonio-TX)                         | 390   | 43.3  |    | 87%  |
+| 16       | Amayah Pate         | Grace Black: Buzzer Bangers (New Whiteland-IN) | 350   | 38.9  | 3  | 86%  |
+| 17       | Jason Charwin       | Zion Zelotes (Harrisburg-NC)                   | 345   | 38.3  |    | 77%  |
+| 18       | Corrie Lee Boehling | Wilmington Warriors (Wilmington-NC)            | 335   | 37.2  |    | 76%  |
+| 19       | Nynee Padala        | ATCS Living Stones (Lawrenceville-GA)          | 325   | 36.1  |    | 81%  |
+| **\*19** | Randi Goodwin       | Bethel A/G (Askewville-NC)                     | 325   | 36.1  |    | 73%  |
+| 20       | Chandler Nester     | GC Kids (Tallahassee-FL)                       | 300   | 33.3  | 1  | 89%  |
+| 21       | Rachel Joel         | Zion Zelotes (Harrisburg-NC)                   | 300   | 33.3  |    | 68%  |
+| 22       | Roshini Rayarala    | ATCS Living Stones (Lawrenceville-GA)          | 290   | 32.2  | 3  | 64%  |
+| 23       | Kaylee Williams     | GC Kids (Tallahassee-FL)                       | 240   | 26.7  | 1  | 87%  |
+| 24       | Liana Thomas        | Spurs (San Antonio-TX)                         | 230   | 25.6  | 1  | 81%  |
+| 25       | Sarah Isabel        | Zion Zelotes (Harrisburg-NC)                   | 225   | 25    |    | 85%  |
+| 26       | Caris Thomas        | Spurs (San Antonio-TX)                         | 220   | 24.4  | 1  | 80%  |
+| 27       | Sujjay Karthikeyan  | Zion Zelotes (Harrisburg-NC)                   | 210   | 23.3  |    | 75%  |
+| **\*27** | Andrian Kolliegbo   | Grace Black: Buzzer Bangers (New Whiteland-IN) | 210   | 23.3  |    | 67%  |
+| 28       | Andrew Adamson      | Musketeers (Baxter-MN)                         | 185   | 20.6  |    | 80%  |
+| 29       | Faith Poling        | Radiant Quizzers (Dublin-OH)                   | 150   | 16.7  |    | 81%  |
+| 30       | Sebastian Tisdell   | Musketeers (Baxter-MN)                         | 85    | 9.4   |    | 82%  |
+| 31       | Lynsey Bazemore     | Bethel A/G (Askewville-NC)                     | 70    | 7.8   |    | 100% |
+| 32       | Aseda Essandoh      | Radiant Quizzers (Dublin-OH)                   | 25    | 2.8   |    | 75%  |
+| 33       | Grace Hammett       | Radiant Quizzers (Dublin-OH)                   | 15    | 1.7   |    | 50%  |
+| 34       | Brennan Tisdell     | Musketeers (Baxter-MN)                         | 10    | 1.1   |    | 99%  |
+| **\*34** | Lainey Kondepudi    | ATCS Living Stones (Lawrenceville-GA)          | 10    | 1.1   |    | 43%  |
+| 35       | Jeremiah Das        | ATCS Living Stones (Lawrenceville-GA)          | 5     | .6    |    | 36%  |
+| 36       | Samantha Powell     | Wilmington Warriors (Wilmington-NC)            | 0     |       |    |      |
+| **\*36** | Parker Christian    | Wilmington Warriors (Wilmington-NC)            | 0     |       |    |      |
+| **\*36** | Jack Willson        | Wilmington Warriors (Wilmington-NC)            | 0     |       |    |      |
+| **\*36** | Konyinsola Sofowora | Radiant Quizzers (Dublin-OH)                   | 0     |       |    |      |
+| **\*36** | Garrett Crescenti   | Jedi Knights (Shelby Township-MI)              | 0     |       |    |      |
+| 37       | Gabe Parrish        | Musketeers (Baxter-MN)                         | -5    | -.6   |    | 33%  |
+| **\*37** | Elizabeth Adamson   | Musketeers (Baxter-MN)                         | -5    | -.6   |    |      |
+| **\*37** | Ben Allegra         | Musketeers (Baxter-MN)                         | -5    | -.6   |    |      |
+
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                         | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | WoL Swordbearers (Springfield-VA)                     | 8 / 1 | 1810  | 201.1 | 9  | 81% |
+| 2.0  | Grace Red: Pardon the Interruption (New Whiteland-IN) | 7 / 2 | 1480  | 164.4 | 6  | 83% |
+| 3.0  | God\'s Squad (Chandler-AZ)                            | 6 / 3 | 1615  | 179.4 | 4  | 79% |
+| 4.1  | Tribulation Force (Red Oak-TX)                        | 5 / 4 | 1415  | 157.2 | 7  | 79% |
+| 5.0  | Sparta Light (Sparta-WI)                              | 5 / 4 | 1395  | 155   | 1  | 82% |
+| 6.0  | Sparta Salt (Sparta-WI)                               | 4 / 5 | 1115  | 123.9 | 4  | 76% |
+| 7.0  | Faith Temple (Rochester-NY)                           | 3 / 6 | 1205  | 133.9 | 7  | 71% |
+| 8.0  | Truth Defenders (Painesville-OH)                      | 3 / 6 | 1120  | 124.4 | 7  | 71% |
+| 9.0  | Word Wise Quiz Kids (Cordova-TN)                      | 3 / 6 | 1095  | 121.7 | 3  | 80% |
+| 10.0 | AAA Batteries (Springfield-MO)                        | 1 / 8 | 1030  | 114.4 | 2  | 75% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                                         | Total | Avg   | QO | Q%   |
+|---------:|--------------------|-------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Bethel Dawit       | WoL Swordbearers (Springfield-VA)                     | 1065  | 118.3 | 7  | 80%  |
+| 2        | Larissa Cox        | Grace Red: Pardon the Interruption (New Whiteland-IN) | 985   | 109.4 | 5  | 86%  |
+| 3        | Ben Butler         | Faith Temple (Rochester-NY)                           | 950   | 105.6 | 6  | 81%  |
+| 4        | Timothy Mathew     | God\'s Squad (Chandler-AZ)                            | 915   | 101.7 | 3  | 87%  |
+| 5        | Bryce Helgerson    | Sparta Salt (Sparta-WI)                               | 820   | 91.1  | 3  | 83%  |
+| 6        | Jack Adkins        | Truth Defenders (Painesville-OH)                      | 700   | 77.8  | 3  | 83%  |
+| 7        | Noah Janssens      | Tribulation Force (Red Oak-TX)                        | 695   | 77.2  | 1  | 90%  |
+| 8        | Samuel Deppe       | Word Wise Quiz Kids (Cordova-TN)                      | 620   | 68.9  | 3  | 70%  |
+| 9        | Sawyer Curtis      | Sparta Light (Sparta-WI)                              | 585   | 65    | 1  | 90%  |
+| 10       | Jeremiah Vecchioni | Sparta Light (Sparta-WI)                              | 540   | 60    |    | 83%  |
+| 11       | Andrew Le          | AAA Batteries (Springfield-MO)                        | 505   | 56.1  | 1  | 74%  |
+| 12       | Ezra King          | Tribulation Force (Red Oak-TX)                        | 475   | 52.8  | 6  | 77%  |
+| 13       | Benjamin Antony    | Word Wise Quiz Kids (Cordova-TN)                      | 355   | 39.4  |    | 90%  |
+| 14       | Anthony Collins    | Truth Defenders (Painesville-OH)                      | 345   | 38.3  | 4  | 69%  |
+| 15       | Anita Mathew       | God\'s Squad (Chandler-AZ)                            | 290   | 32.2  |    | 84%  |
+| 16       | Anna Le            | AAA Batteries (Springfield-MO)                        | 285   | 31.7  |    | 74%  |
+| 17       | Sarah Dawit        | WoL Swordbearers (Springfield-VA)                     | 255   | 28.3  | 1  | 93%  |
+| 18       | Aidan Fulfer       | Tribulation Force (Red Oak-TX)                        | 245   | 27.2  |    | 63%  |
+| 19       | Eliana Phelps      | AAA Batteries (Springfield-MO)                        | 240   | 26.7  | 1  | 76%  |
+| 20       | Joanna Thomas      | God\'s Squad (Chandler-AZ)                            | 230   | 25.6  | 1  | 70%  |
+| 21       | Nathanael Obel     | WoL Swordbearers (Springfield-VA)                     | 190   | 21.1  | 1  | 90%  |
+| 22       | Lucas Brunson      | Grace Red: Pardon the Interruption (New Whiteland-IN) | 180   | 20    |    | 85%  |
+| 23       | Hector Siaca       | Faith Temple (Rochester-NY)                           | 175   | 19.4  | 1  | 61%  |
+| 24       | Abigail Carlson    | Grace Red: Pardon the Interruption (New Whiteland-IN) | 170   | 18.9  | 1  | 82%  |
+| 25       | Hans Jacob         | God\'s Squad (Chandler-AZ)                            | 160   | 17.8  |    | 76%  |
+| 26       | Daniel Priddy      | Grace Red: Pardon the Interruption (New Whiteland-IN) | 145   | 16.1  |    | 77%  |
+| **\*26** | Joel Doosey        | WoL Swordbearers (Springfield-VA)                     | 145   | 16.1  |    | 75%  |
+| 27       | Amaya Allard       | Sparta Salt (Sparta-WI)                               | 140   | 15.6  |    | 88%  |
+| 28       | Issac Helgerson    | Sparta Salt (Sparta-WI)                               | 135   | 15    | 1  | 60%  |
+| 29       | Olivia Collins     | Sparta Light (Sparta-WI)                              | 115   | 12.8  |    | 63%  |
+| 30       | Josiah Riverson    | WoL Swordbearers (Springfield-VA)                     | 95    | 10.6  |    | 61%  |
+| 31       | Sarah Robertson    | Word Wise Quiz Kids (Cordova-TN)                      | 90    | 10    |    | 100% |
+| 32       | Sophia Curtis      | Sparta Light (Sparta-WI)                              | 80    | 8.9   |    | 100% |
+| 33       | Ava Millard        | Sparta Light (Sparta-WI)                              | 75    | 8.3   |    | 100% |
+| 34       | Samuel Riverson    | WoL Swordbearers (Springfield-VA)                     | 60    | 6.7   |    | 67%  |
+| 35       | Joshua Torres      | Faith Temple (Rochester-NY)                           | 55    | 6.1   |    | 67%  |
+| **\*35** | Justin Klco        | Truth Defenders (Painesville-OH)                      | 55    | 6.1   |    | 52%  |
+| 36       | Ava Robertson      | Word Wise Quiz Kids (Cordova-TN)                      | 30    | 3.3   |    | 100% |
+| 37       | Jack Altman        | Faith Temple (Rochester-NY)                           | 25    | 2.8   |    | 55%  |
+| 38       | Claire Adkins      | Truth Defenders (Painesville-OH)                      | 20    | 2.2   |    | 99%  |
+| **\*38** | Shreya Ganesan     | God\'s Squad (Chandler-AZ)                            | 20    | 2.2   |    | 99%  |
+| **\*38** | Issac Briski       | Sparta Salt (Sparta-WI)                               | 20    | 2.2   |    | 60%  |
+| 39       | Aaron Kefyalew     | WoL Swordbearers (Springfield-VA)                     | 0     |       |    |      |
+| **\*39** | Ezra Kefyalew      | WoL Swordbearers (Springfield-VA)                     | 0     |       |    |      |
+| **\*39** | Corbin Frydenlund  | Sparta Salt (Sparta-WI)                               | 0     |       |    |      |
+| **\*39** | Kiley Trott        | Faith Temple (Rochester-NY)                           | 0     |       |    |      |
+| **\*39** | Richard Torres     | Faith Temple (Rochester-NY)                           | 0     |       |    |      |
+
+
+### Silver
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                           | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-----------------------------------------|-------|------:|------:|---:|----:|
+| 1.1  | Kids on a Mission (Akron-OH)            | 7 / 2 | 1720  | 191.1 | 6  | 86% |
+| 2.0  | Racine Far From Over (Racine-WI)        | 7 / 2 | 1515  | 168.3 | 2  | 79% |
+| 3.1  | ATC Flames (Norcross -GA)               | 6 / 3 | 1530  | 170   | 7  | 84% |
+| 4.0  | Fluffy Panda Quizzers (Gahanna-OH)      | 6 / 3 | 1475  | 163.9 | 9  | 72% |
+| 5.1  | Bethlehem Church (Richmond Hill-NY)     | 4 / 5 | 1025  | 113.9 | 2  | 75% |
+| 6.0  | Bible Bugs (Fordyce-AR)                 | 4 / 5 | 1315  | 146.1 | 2  | 76% |
+| 7.0  | Girls of Grace (Jacksonville -AR)       | 3 / 6 | 1185  | 131.7 | 3  | 82% |
+| 8.0  | Word Warriors (Hanford-CA)              | 3 / 6 | 1175  | 130.5 | 3  | 82% |
+| 9.0  | Exodus Expedition (Mount Washington-KY) | 3 / 6 | 1090  | 121.1 |    | 85% |
+| 10.0 | ATCS Mighty Warriors (Lawrenceville-GA) | 2 / 7 | 1000  | 111.1 | 2  | 72% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer               | Team / Church                           | Total | Avg   | QO | Q%   |
+|---------:|-----------------------|-----------------------------------------|------:|------:|---:|-----:|
+| 1        | Jenny Christopher     | ATC Flames (Norcross -GA)               | 950   | 105.6 | 2  | 89%  |
+| 2        | Elylah Stager         | Kids on a Mission (Akron-OH)            | 915   | 101.7 | 3  | 85%  |
+| 3        | Elijah Turner         | Bible Bugs (Fordyce-AR)                 | 655   | 72.8  | 1  | 87%  |
+| 4        | Matthew Walker        | Racine Far From Over (Racine-WI)        | 640   | 71.1  |    | 73%  |
+| 5        | Caleb Karthik         | Fluffy Panda Quizzers (Gahanna-OH)      | 635   | 70.6  | 5  | 75%  |
+| 6        | Chloe Eder            | Kids on a Mission (Akron-OH)            | 580   | 64.4  | 3  | 93%  |
+| 7        | Payton Durbin         | Exodus Expedition (Mount Washington-KY) | 550   | 61.1  |    | 84%  |
+| 8        | Addison McCullough    | Word Warriors (Hanford-CA)              | 545   | 60.6  | 2  | 80%  |
+| 9        | Sam Mair              | Fluffy Panda Quizzers (Gahanna-OH)      | 515   | 57.2  | 3  | 64%  |
+| 10       | Ansley Hornaday       | Bible Bugs (Fordyce-AR)                 | 485   | 53.9  | 1  | 72%  |
+| 11       | Reuben Jaramillo      | Racine Far From Over (Racine-WI)        | 485   | 53.9  |    | 80%  |
+| 12       | Hans Daniel           | ATC Flames (Norcross -GA)               | 455   | 50.6  | 4  | 80%  |
+| 13       | Mayah Johnson         | Bethlehem Church (Richmond Hill-NY)     | 450   | 50    | 1  | 74%  |
+| 14       | Lily Smith            | Exodus Expedition (Mount Washington-KY) | 430   | 47.8  |    | 82%  |
+| 15       | Kamelia Skinner       | Girls of Grace (Jacksonville -AR)       | 420   | 46.7  |    | 85%  |
+| 16       | Sara Swain            | Girls of Grace (Jacksonville -AR)       | 360   | 40    |    | 78%  |
+| 17       | Susan Kambam          | ATCS Mighty Warriors (Lawrenceville-GA) | 335   | 37.2  |    | 72%  |
+| 18       | Anish Kondreddy       | ATCS Mighty Warriors (Lawrenceville-GA) | 320   | 35.6  | 2  | 70%  |
+| 19       | Joel Kommoji          | ATCS Mighty Warriors (Lawrenceville-GA) | 320   | 35.6  |    | 76%  |
+| 20       | Elizabeth Binion      | Word Warriors (Hanford-CA)              | 315   | 35    | 1  | 82%  |
+| 21       | Savanna Stephens      | Girls of Grace (Jacksonville -AR)       | 300   | 33.3  | 3  | 83%  |
+| 22       | Samuel DeSilva        | Bethlehem Church (Richmond Hill-NY)     | 290   | 32.2  | 1  | 76%  |
+| 23       | Aiyana Jaramillo      | Racine Far From Over (Racine-WI)        | 270   | 30    | 2  | 82%  |
+| 24       | Jacey Pathri          | Fluffy Panda Quizzers (Gahanna-OH)      | 265   | 29.4  | 1  | 75%  |
+| 25       | Alicia Twiford        | Word Warriors (Hanford-CA)              | 180   | 20    |    | 80%  |
+| 26       | Connor Hubbard        | Bible Bugs (Fordyce-AR)                 | 175   | 19.4  |    | 68%  |
+| 27       | Nick McGee            | Kids on a Mission (Akron-OH)            | 135   | 15    |    | 80%  |
+| 28       | Joel Christopher      | ATC Flames (Norcross -GA)               | 125   | 13.9  | 1  | 81%  |
+| 29       | Samantha Anselmo      | Bethlehem Church (Richmond Hill-NY)     | 125   | 13.9  |    | 70%  |
+| 30       | Nicholas Tait         | Racine Far From Over (Racine-WI)        | 120   | 13.3  |    | 87%  |
+| 31       | Jon Luc Jobson Larkin | Bethlehem Church (Richmond Hill-NY)     | 105   | 11.7  |    | 75%  |
+| 32       | Annika Twiford        | Word Warriors (Hanford-CA)              | 90    | 10    |    | 100% |
+| 33       | Luke Smith            | Exodus Expedition (Mount Washington-KY) | 80    | 8.9   |    | 100% |
+| **\*33** | David Mackey          | Kids on a Mission (Akron-OH)            | 80    | 8.9   |    | 82%  |
+| 34       | Lakin Skinner         | Girls of Grace (Jacksonville -AR)       | 75    | 8.3   |    | 75%  |
+| 35       | Evan Neerudu          | Fluffy Panda Quizzers (Gahanna-OH)      | 60    | 6.7   |    | 78%  |
+| 36       | Hannah Hancock        | Bethlehem Church (Richmond Hill-NY)     | 55    | 6.1   |    | 86%  |
+| 37       | Makynlee Summers      | Word Warriors (Hanford-CA)              | 45    | 5     |    | 83%  |
+| 38       | Addisyn Wolters       | Girls of Grace (Jacksonville -AR)       | 30    | 3.3   |    | 100% |
+| 39       | Neiha Peyyala         | ATCS Mighty Warriors (Lawrenceville-GA) | 25    | 2.8   |    | 75%  |
+| 40       | Levi Smith            | Exodus Expedition (Mount Washington-KY) | 20    | 2.2   |    | 100% |
+| 41       | Patrick Durbin        | Exodus Expedition (Mount Washington-KY) | 10    | 1.1   |    | 99%  |
+| **\*41** | Ethan Stager          | Kids on a Mission (Akron-OH)            | 10    | 1.1   |    | 50%  |
+| 42       | Landon Dissmore       | Racine Far From Over (Racine-WI)        | 0     |       |    |      |
+| **\*42** | Jalen Porter          | Exodus Expedition (Mount Washington-KY) | 0     |       |    |      |
+| **\*42** | Laynie Nutt           | Bible Bugs (Fordyce-AR)                 | 0     |       |    |      |
+| **\*42** | Braley Collins        | Bible Bugs (Fordyce-AR)                 | 0     |       |    |      |
+| **\*42** | Adalyn Hornaday       | Bible Bugs (Fordyce-AR)                 | 0     |       |    |      |
+| **\*42** | Anna Claire Collins   | Bible Bugs (Fordyce-AR)                 | 0     |       |    |      |
+| **\*42** | Kerra Nutt            | Bible Bugs (Fordyce-AR)                 | 0     |       |    |      |
+| **\*42** | Sarayah Hendricks     | Bethlehem Church (Richmond Hill-NY)     | 0     |       |    |      |
+| **\*42** | Cashmere Saez         | Bethlehem Church (Richmond Hill-NY)     | 0     |       |    |      |
+| **\*42** | Emma Kokora           | Bethlehem Church (Richmond Hill-NY)     | 0     |       |    |      |
+| **\*42** | Joseph Peyyala        | ATCS Mighty Warriors (Lawrenceville-GA) | 0     |       |    |      |
+
+
+### Tan
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                        | W/L   | Total | Avg   | QO | Q%  |
+|-----:|--------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Avengers (Hamburg-PA)                | 8 / 1 | 1455  | 161.6 | 4  | 79% |
+| 2.0  | Anointed Ones (Marietta-GA)          | 7 / 2 | 1550  | 172.2 | 8  | 81% |
+| 3.1  | Webster Odlebury\'s (Webster-NY)     | 6 / 3 | 1460  | 162.2 | 3  | 78% |
+| 4.0  | Victory Boyz (Lakeland-FL)           | 6 / 3 | 1520  | 168.9 | 9  | 77% |
+| 5.1  | Carmel Crusaders (Bonifay-FL)        | 5 / 4 | 1390  | 154.4 | 3  | 76% |
+| 6.0  | Buzz Hogs (Mabelvale-AR)             | 5 / 4 | 1185  | 131.7 | 4  | 72% |
+| 7.0  | Fireball Ninjas (Perry-IA)           | 3 / 6 | 1245  | 138.3 | 4  | 88% |
+| 8.1  | The Avengers of JBQ (Orlando-FL)     | 2 / 7 | 1090  | 121.1 | 1  | 73% |
+| 9.0  | WKTB (We Know The Bible) (Tucson-AZ) | 2 / 7 | 775   | 86.1  | 3  | 69% |
+| 10.0 | In His Image (West Mifflin-PA)       | 1 / 8 | 970   | 107.8 | 1  | 76% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                        | Total | Avg   | QO | Q%   |
+|---------:|------------------------|--------------------------------------|------:|------:|---:|-----:|
+| 1        | Joel Ravela            | Victory Boyz (Lakeland-FL)           | 970   | 107.8 | 4  | 83%  |
+| 2        | Steve Joy              | Anointed Ones (Marietta-GA)          | 905   | 100.6 | 6  | 82%  |
+| 3        | Mackenzie Hight        | Fireball Ninjas (Perry-IA)           | 775   | 86.1  | 3  | 91%  |
+| 4        | Lauryn Jackson         | Buzz Hogs (Mabelvale-AR)             | 625   | 69.4  | 3  | 80%  |
+| 5        | Isaac Salisbury        | Webster Odlebury\'s (Webster-NY)     | 570   | 63.3  |    | 80%  |
+| 6        | Kiersten Womble        | Carmel Crusaders (Bonifay-FL)        | 565   | 62.8  |    | 79%  |
+| 7        | Charli Fitzgerald      | Avengers (Hamburg-PA)                | 535   | 59.4  | 1  | 85%  |
+| 8        | Alana Hight            | Fireball Ninjas (Perry-IA)           | 425   | 47.2  | 1  | 84%  |
+| 9        | Addison Odle           | Webster Odlebury\'s (Webster-NY)     | 390   | 43.3  |    | 87%  |
+| 10       | Will Anderson          | The Avengers of JBQ (Orlando-FL)     | 370   | 41.1  |    | 58%  |
+| 11       | Isaiah Salisbury       | Webster Odlebury\'s (Webster-NY)     | 340   | 37.8  | 3  | 77%  |
+| 12       | Myah Berkey            | WKTB (We Know The Bible) (Tucson-AZ) | 330   | 36.7  |    | 70%  |
+| 13       | Rebecca Lee            | Carmel Crusaders (Bonifay-FL)        | 315   | 35    |    | 92%  |
+| 14       | Micah Warren           | Carmel Crusaders (Bonifay-FL)        | 305   | 33.9  | 3  | 72%  |
+| 15       | Marissa Dankwardt      | In His Image (West Mifflin-PA)       | 300   | 33.3  | 1  | 69%  |
+| 16       | Tania Ruth Anand       | Anointed Ones (Marietta-GA)          | 295   | 32.8  |    | 83%  |
+| 17       | Mason Berkey           | WKTB (We Know The Bible) (Tucson-AZ) | 290   | 32.2  | 3  | 70%  |
+| 18       | Dharshine Jayakrishnan | Anointed Ones (Marietta-GA)          | 270   | 30    | 2  | 78%  |
+| 19       | Jordan Spence          | The Avengers of JBQ (Orlando-FL)     | 270   | 30    |    | 73%  |
+| 20       | Nathan Joiner          | Victory Boyz (Lakeland-FL)           | 265   | 29.4  | 2  | 79%  |
+| 21       | Rylan Hance            | Victory Boyz (Lakeland-FL)           | 260   | 28.9  | 3  | 67%  |
+| 22       | Aubrey Spence          | The Avengers of JBQ (Orlando-FL)     | 260   | 28.9  | 1  | 82%  |
+| **\*22** | Nehemiah Page          | Buzz Hogs (Mabelvale-AR)             | 260   | 28.9  | 1  | 74%  |
+| 23       | Thomas Yarnall         | Avengers (Hamburg-PA)                | 250   | 27.8  | 2  | 74%  |
+| 24       | Chloe Glunt            | In His Image (West Mifflin-PA)       | 245   | 27.2  |    | 93%  |
+| 25       | Josiah Minick          | Buzz Hogs (Mabelvale-AR)             | 240   | 26.7  |    | 57%  |
+| 26       | Ciara Jonassaint       | In His Image (West Mifflin-PA)       | 220   | 24.4  |    | 86%  |
+| 27       | Bobby Schoiack         | In His Image (West Mifflin-PA)       | 205   | 22.8  |    | 75%  |
+| 28       | Jonathan Guntle        | Avengers (Hamburg-PA)                | 200   | 22.2  |    | 85%  |
+| 29       | Alaina Yarnall         | Avengers (Hamburg-PA)                | 195   | 21.7  | 1  | 65%  |
+| 30       | Tegan Crowley          | Avengers (Hamburg-PA)                | 195   | 21.7  |    | 87%  |
+| 31       | Gracie Bland           | The Avengers of JBQ (Orlando-FL)     | 190   | 21.1  |    | 100% |
+| 32       | Luke Odle              | Webster Odlebury\'s (Webster-NY)     | 160   | 17.8  |    | 71%  |
+| 33       | Brady WOmble           | Carmel Crusaders (Bonifay-FL)        | 130   | 14.4  |    | 100% |
+| 34       | Quinton Zepp           | Carmel Crusaders (Bonifay-FL)        | 100   | 11.1  |    | 72%  |
+| 35       | Joshua Gunasingh       | Anointed Ones (Marietta-GA)          | 80    | 8.9   |    | 82%  |
+| 36       | Judah Guntle           | Avengers (Hamburg-PA)                | 70    | 7.8   |    | 100% |
+| **\*36** | Judah Sears            | WKTB (We Know The Bible) (Tucson-AZ) | 70    | 7.8   |    | 100% |
+| 37       | Marissa Gephart        | WKTB (We Know The Bible) (Tucson-AZ) | 60    | 6.7   |    | 46%  |
+| 38       | Nevaeh Ferguson        | Fireball Ninjas (Perry-IA)           | 45    | 5     |    | 83%  |
+| 39       | Cherish Page           | Buzz Hogs (Mabelvale-AR)             | 30    | 3.3   |    | 100% |
+| **\*39** | Peter Page             | Buzz Hogs (Mabelvale-AR)             | 30    | 3.3   |    | 100% |
+| 40       | Hayden Wright          | Victory Boyz (Lakeland-FL)           | 25    | 2.8   |    | 75%  |
+| **\*40** | Amaris Bravo           | WKTB (We Know The Bible) (Tucson-AZ) | 25    | 2.8   |    | 75%  |
+| 41       | Sheila Pissarra        | Avengers (Hamburg-PA)                | 10    | 1.1   |    | 99%  |
+| 42       | Trinity Terry          | Buzz Hogs (Mabelvale-AR)             | 0     |       |    |      |
+| **\*42** | Malayah Thomas         | Avengers (Hamburg-PA)                | 0     |       |    |      |
+| **\*42** | Judah Salisbury        | Webster Odlebury\'s (Webster-NY)     | 0     |       |    |      |
+| **\*42** | Eden Salisbury         | Webster Odlebury\'s (Webster-NY)     | 0     |       |    |      |
+| **\*42** | Jace Hance             | Victory Boyz (Lakeland-FL)           | 0     |       |    |      |
+| 43       | Sam Lee                | Carmel Crusaders (Bonifay-FL)        | -20   | -2.2  |    | 20%  |
+
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                        | W/L   | Total | Avg   | QO | Q%  |
+|-----:|--------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | CIA Special Agents (Mendon-MA)       | 9 / 0 | 1830  | 203.3 | 11 | 79% |
+| 2.1  | God\'s Gang (Fargo-ND)               | 7 / 2 | 1540  | 171.1 | 11 | 80% |
+| 3.0  | Shoreline (Shoreline-WA)             | 7 / 2 | 1600  | 177.8 | 8  | 84% |
+| 4.1  | 4K (Montgomery-AL)                   | 5 / 4 | 1370  | 152.2 | 3  | 77% |
+| 5.0  | SCC Truth Seekers (Shreveport-LA)    | 5 / 4 | 1130  | 125.5 | 4  | 66% |
+| 6.1  | Quiz Avengers (North Little Rock-AR) | 4 / 5 | 900   | 100   | 3  | 67% |
+| 7.0  | The Remix (Oswego-KS)                | 4 / 5 | 1540  | 171.1 | 7  | 86% |
+| 8.0  | Gateway Master (Shreveport-LA)       | 2 / 7 | 830   | 92.2  | 2  | 64% |
+| 9.0  | What\'s Your Name (Rapid City-SD)    | 1 / 8 | 590   | 65.5  | 2  | 74% |
+| 10.0 | Lake Wylie Coyotes (Lake Wylie-SC)   | 1 / 8 | 380   | 42.2  |    | 77% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                        | Total | Avg   | QO | Q%   |
+|---------:|---------------------|--------------------------------------|------:|------:|---:|-----:|
+| 1        | Hayden Monty        | CIA Special Agents (Mendon-MA)       | 1305  | 145   | 8  | 91%  |
+| 2        | Corinne Arnold      | Shoreline (Shoreline-WA)             | 1035  | 115   | 6  | 85%  |
+| 3        | Kacey Mayfield      | The Remix (Oswego-KS)                | 905   | 100.6 | 2  | 97%  |
+| 4        | Tori Glanzer        | God\'s Gang (Fargo-ND)               | 830   | 92.2  | 5  | 80%  |
+| 5        | Anna Jordan         | Quiz Avengers (North Little Rock-AR) | 645   | 71.7  | 2  | 69%  |
+| 6        | Braden Tew          | SCC Truth Seekers (Shreveport-LA)    | 575   | 63.9  | 3  | 72%  |
+| 7        | Ola Alabi           | God\'s Gang (Fargo-ND)               | 490   | 54.4  | 6  | 83%  |
+| 8        | Grace Noel          | The Remix (Oswego-KS)                | 450   | 50    | 5  | 79%  |
+| 9        | Patrick Thomas      | Gateway Master (Shreveport-LA)       | 435   | 48.3  | 1  | 57%  |
+| 10       | Vicente Rivera      | 4K (Montgomery-AL)                   | 420   | 46.7  | 3  | 80%  |
+| 11       | Caroline Tew        | SCC Truth Seekers (Shreveport-LA)    | 380   | 42.2  | 1  | 65%  |
+| 12       | Trey Oliver         | 4K (Montgomery-AL)                   | 360   | 40    |    | 78%  |
+| **\*12** | Eliana Rivera       | 4K (Montgomery-AL)                   | 360   | 40    |    | 73%  |
+| 13       | Lillee Solvie       | What\'s Your Name (Rapid City-SD)    | 295   | 32.8  | 2  | 68%  |
+| 14       | Emily Ragains       | What\'s Your Name (Rapid City-SD)    | 295   | 32.8  |    | 79%  |
+| 15       | Maya Arnold         | Shoreline (Shoreline-WA)             | 285   | 31.7  | 1  | 87%  |
+| 16       | Ezekiel Hamel       | CIA Special Agents (Mendon-MA)       | 280   | 31.1  | 2  | 76%  |
+| 17       | Janae Arnold        | Shoreline (Shoreline-WA)             | 280   | 31.1  | 1  | 79%  |
+| 18       | Jason Stroughter    | Gateway Master (Shreveport-LA)       | 275   | 30.6  | 1  | 72%  |
+| 19       | Braidan Morais      | CIA Special Agents (Mendon-MA)       | 220   | 24.4  | 1  | 63%  |
+| 20       | Ethan Paredes       | SCC Truth Seekers (Shreveport-LA)    | 210   | 23.3  |    | 100% |
+| 21       | David Girdner       | 4K (Montgomery-AL)                   | 190   | 21.1  |    | 65%  |
+| 22       | Camilla Joye        | Lake Wylie Coyotes (Lake Wylie-SC)   | 170   | 18.9  |    | 82%  |
+| 23       | Phoenix Butler      | Lake Wylie Coyotes (Lake Wylie-SC)   | 150   | 16.7  |    | 78%  |
+| 24       | Benita Ayebo        | God\'s Gang (Fargo-ND)               | 140   | 15.6  |    | 60%  |
+| 25       | Braylon Sutherland  | Quiz Avengers (North Little Rock-AR) | 135   | 15    | 1  | 57%  |
+| 26       | Hannah Noel         | The Remix (Oswego-KS)                | 110   | 12.2  |    | 86%  |
+| 27       | Brooklyn Sutherland | Quiz Avengers (North Little Rock-AR) | 85    | 9.4   |    | 90%  |
+| 28       | Ope Alabi           | God\'s Gang (Fargo-ND)               | 80    | 8.9   |    | 82%  |
+| 29       | Lane Wolsey         | The Remix (Oswego-KS)                | 75    | 8.3   |    | 89%  |
+| **\*29** | Norman Thomas       | Gateway Master (Shreveport-LA)       | 75    | 8.3   |    | 59%  |
+| 30       | Davaney McSwain     | Lake Wylie Coyotes (Lake Wylie-SC)   | 55    | 6.1   |    | 83%  |
+| 31       | Jasmine Wedgworth   | Quiz Avengers (North Little Rock-AR) | 35    | 3.9   |    | 80%  |
+| **\*31** | Lacee Smith         | Gateway Master (Shreveport-LA)       | 35    | 3.9   |    | 80%  |
+| 32       | Sofia Gonzalez      | 4K (Montgomery-AL)                   | 30    | 3.3   |    | 100% |
+| 33       | Tanner Longacre     | CIA Special Agents (Mendon-MA)       | 20    | 2.2   |    | 100% |
+| 34       | Bryson Thomas       | Gateway Master (Shreveport-LA)       | 10    | 1.1   |    | 99%  |
+| **\*34** | Mason Monty         | CIA Special Agents (Mendon-MA)       | 10    | 1.1   |    | 99%  |
+| **\*34** | Timothy Goss        | 4K (Montgomery-AL)                   | 10    | 1.1   |    | 99%  |
+| 35       | Thomas Ricciardelli | Lake Wylie Coyotes (Lake Wylie-SC)   | 5     | .6    |    | 33%  |
+| 36       | Tayton Hazell       | The Remix (Oswego-KS)                | 0     |       |    |      |
+| **\*36** | Ella Arnold         | Shoreline (Shoreline-WA)             | 0     |       |    |      |
+| **\*36** | Jamilet Juarez      | Quiz Avengers (North Little Rock-AR) | 0     |       |    |      |
+| **\*36** | Lennen Juarez       | Quiz Avengers (North Little Rock-AR) | 0     |       |    |      |
+| **\*36** | Madison Woodbury    | Lake Wylie Coyotes (Lake Wylie-SC)   | 0     |       |    |      |
+| **\*36** | Hailey Woodbury     | Lake Wylie Coyotes (Lake Wylie-SC)   | 0     |       |    |      |
+| **\*36** | Terrill Walls Jr    | Lake Wylie Coyotes (Lake Wylie-SC)   | 0     |       |    |      |
+| **\*36** | Zane Smaaladen      | God\'s Gang (Fargo-ND)               | 0     |       |    |      |
+| **\*36** | Aliyah Morais       | CIA Special Agents (Mendon-MA)       | 0     |       |    |      |
+| **\*36** | Katelynn Do         | 4K (Montgomery-AL)                   | 0     |       |    |      |
+| **\*36** | Kasey Do            | 4K (Montgomery-AL)                   | 0     |       |    |      |
+| **\*36** | Rachel Fuller       | SCC Truth Seekers (Shreveport-LA)    | 0     |       |    |      |
+| **\*36** | London Hamilton     | SCC Truth Seekers (Shreveport-LA)    | 0     |       |    |      |
+| 37       | Jonathan Paredes    | SCC Truth Seekers (Shreveport-LA)    | -35   | -3.9  |    | 15%  |
+

--- a/_pages/jbq/2019/index.md
+++ b/_pages/jbq/2019/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2019 JBQ Season"
+permalink: /jbq/2019/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+<a href="{% link _pages/jbq/2019/nationals.md %}" class="button is-primary">National Finals</a>
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2019/nationals.md
+++ b/_pages/jbq/2019/nationals.md
@@ -1,0 +1,1107 @@
+---
+layout: page
+title: "2019 National Festival: Tucscon, AZ"
+permalink: /jbq/2019/nationals/
+date: "2019-06-08"
+toc_title: Results
+menubar_toc: true
+---
+
+## Friday
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                | W/L    | Total | Avg   | QO | Q%  |
+|-----:|----------------------------------------------|--------|------:|------:|---:|----:|
+| 1.1  | Wayne, NJ (CTI-JOY)                          | 14 / 1 | 2790  | 186   | 9  | 85% |
+| 2.0  | Houston, TX (Gideon\'s Army)                 | 14 / 1 | 2980  | 198.7 | 13 | 81% |
+| 3.1  | Garland, TX (Guardians of the Gospel)        | 12 / 3 | 2815  | 187.7 | 14 | 77% |
+| 4.0  | Wilmington, NC (New Hanover Church)          | 12 / 3 | 2890  | 192.7 | 11 | 82% |
+| 5.1  | Naperville, IL (Naperville (S))              | 9 / 6  | 2750  | 183.3 | 15 | 78% |
+| 6.0  | Shelby Township, MI (John Three Sixteam)     | 9 / 6  | 2610  | 174   | 13 | 87% |
+| 7.0  | Dublin, OH (RLC Diamonds)                    | 8 / 7  | 1955  | 130.3 | 7  | 77% |
+| 8.1  | Chandler, AZ (Overcomers)                    | 7 / 8  | 2040  | 136   | 2  | 79% |
+| 9.0  | Beulah, ND (New Creatures)                   | 7 / 8  | 2505  | 167   | 9  | 90% |
+| 10.1 | Ozone Park, NY (Calvary Assembly of God)     | 6 / 9  | 2085  | 139   | 5  | 76% |
+| 11.0 | Cordova, TN (Word Wise Quiz Kids)            | 6 / 9  | 1925  | 128.3 | 7  | 85% |
+| 12.0 | Bloomington, MN (Bread of Life Church)       | 5 / 10 | 2145  | 143   | 6  | 76% |
+| 13.0 | Two Rivers, WI (Renew Church)                | 4 / 11 | 1680  | 112   | 6  | 71% |
+| 14.0 | Lakeland, FL (Victory Church)                | 3 / 12 | 1730  | 115.3 | 4  | 77% |
+| 15.0 | Roswell, GA (Georgia Christian Assembly)     | 2 / 13 | 1665  | 111   | 2  | 80% |
+| 16.0 | Shreveport, LA (Shreveport Community Church) | 2 / 13 | 1010  | 67.3  | 2  | 67% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer               | Team / Church                                | Total | Avg  | QO | Q%   |
+|---------:|-----------------------|----------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Samuel Biruduganti    | Naperville, IL (Naperville (S))              | 1860  | 124  | 10 | 85%  |
+| 2        | Paul Ertzberger       | Wilmington, NC (New Hanover Church)          | 1575  | 105  | 5  | 92%  |
+| 3        | Lucy Morency          | Shelby Township, MI (John Three Sixteam)     | 1465  | 97.7 | 4  | 97%  |
+| 4        | Benjamin Antony       | Cordova, TN (Word Wise Quiz Kids)            | 1400  | 93.3 | 6  | 90%  |
+| 5        | Sonika Ramala         | Bloomington, MN (Bread of Life Church)       | 1285  | 85.7 | 2  | 85%  |
+| 6        | Nathan Koch           | Garland, TX (Guardians of the Gospel)        | 1225  | 81.7 | 6  | 71%  |
+| 7        | Colson Sago           | Beulah, ND (New Creatures)                   | 1165  | 77.7 | 5  | 96%  |
+| 8        | Kelechi Oriaku        | Wayne, NJ (CTI-JOY)                          | 1150  | 76.7 |    | 87%  |
+| 9        | Priscilla Adu-Gyamfi  | Houston, TX (Gideon\'s Army)                 | 1095  | 73   | 10 | 75%  |
+| 10       | Temaria Murphy        | Lakeland, FL (Victory Church)                | 1025  | 68.3 | 2  | 67%  |
+| 11       | Kristyn Bauer         | Beulah, ND (New Creatures)                   | 980   | 65.3 | 2  | 82%  |
+| 12       | Drew Malchek          | Two Rivers, WI (Renew Church)                | 905   | 60.3 | 4  | 75%  |
+| 13       | Keren Koshy           | Chandler, AZ (Overcomers)                    | 885   | 59   |    | 74%  |
+| 14       | Jason Alicea          | Wayne, NJ (CTI-JOY)                          | 865   | 57.7 |    | 86%  |
+| 15       | Caroline Tew          | Shreveport, LA (Shreveport Community Church) | 845   | 56.3 | 2  | 67%  |
+| 16       | Judith Ramesh         | Garland, TX (Guardians of the Gospel)        | 840   | 56   |    | 84%  |
+| 17       | Simeon Cheeran        | Roswell, GA (Georgia Christian Assembly)     | 785   | 52.3 | 1  | 75%  |
+| 18       | Elliot Rivera         | Wayne, NJ (CTI-JOY)                          | 765   | 51   | 9  | 82%  |
+| 19       | Daniel Boehling       | Wilmington, NC (New Hanover Church)          | 765   | 51   | 3  | 75%  |
+| 20       | Aretha CC-Okeke       | Houston, TX (Gideon\'s Army)                 | 755   | 50.3 |    | 86%  |
+| 21       | Reese Pugh            | Garland, TX (Guardians of the Gospel)        | 750   | 50   | 8  | 80%  |
+| 22       | Tabitha Barney        | Shelby Township, MI (John Three Sixteam)     | 705   | 47   | 9  | 79%  |
+| 23       | Brianna Bobbie        | Ozone Park, NY (Calvary Assembly of God)     | 700   | 46.7 | 1  | 76%  |
+| 24       | Aseda Essandoh        | Dublin, OH (RLC Diamonds)                    | 680   | 45.3 | 1  | 72%  |
+| 25       | Ariella Grimmond      | Ozone Park, NY (Calvary Assembly of God)     | 635   | 42.3 |    | 71%  |
+| 26       | Garen Umukoro         | Houston, TX (Gideon\'s Army)                 | 620   | 41.3 | 3  | 81%  |
+| 27       | Faith Poling          | Dublin, OH (RLC Diamonds)                    | 580   | 38.7 | 6  | 79%  |
+| 28       | Jeremiah Moses Raj    | Roswell, GA (Georgia Christian Assembly)     | 535   | 35.7 |    | 92%  |
+| 29       | Soren Pappas          | Dublin, OH (RLC Diamonds)                    | 515   | 34.3 |    | 95%  |
+| 30       | Timothy Harris        | Naperville, IL (Naperville (S))              | 500   | 33.3 | 4  | 66%  |
+| 31       | Rebeca Jemmott Thomas | Ozone Park, NY (Calvary Assembly of God)     | 495   | 33   | 3  | 82%  |
+| 32       | Joanna Thomas         | Chandler, AZ (Overcomers)                    | 490   | 32.7 |    | 75%  |
+| 33       | Alissa Daniel         | Chandler, AZ (Overcomers)                    | 485   | 32.3 | 2  | 85%  |
+| 34       | Isabella Kirchon      | Lakeland, FL (Victory Church)                | 480   | 32   | 2  | 89%  |
+| 35       | Josh Luckow           | Two Rivers, WI (Renew Church)                | 480   | 32   | 1  | 58%  |
+| 36       | Chidinma Kanu         | Houston, TX (Gideon\'s Army)                 | 445   | 29.7 |    | 96%  |
+| 37       | Jack Willson          | Wilmington, NC (New Hanover Church)          | 440   | 29.3 | 3  | 77%  |
+| 38       | Luke Morency          | Shelby Township, MI (John Three Sixteam)     | 440   | 29.3 |    | 93%  |
+| 39       | Matthew Vengal        | Bloomington, MN (Bread of Life Church)       | 415   | 27.7 | 3  | 68%  |
+| 40       | Jones Kanjirkatte     | Bloomington, MN (Bread of Life Church)       | 390   | 26   | 1  | 74%  |
+| 41       | Aubryn Sago           | Beulah, ND (New Creatures)                   | 360   | 24   | 2  | 95%  |
+| 42       | Rebecca Simjan        | Roswell, GA (Georgia Christian Assembly)     | 345   | 23   | 1  | 78%  |
+| 43       | Shekinah Biruduganti  | Naperville, IL (Naperville (S))              | 335   | 22.3 | 1  | 92%  |
+| 44       | Chloe Siebold         | Two Rivers, WI (Renew Church)                | 295   | 19.7 | 1  | 86%  |
+| 45       | Elizabeth Shelton     | Cordova, TN (Word Wise Quiz Kids)            | 250   | 16.7 | 1  | 71%  |
+| 46       | Jafet Jemmott Thomas  | Ozone Park, NY (Calvary Assembly of God)     | 240   | 16   | 1  | 74%  |
+| 47       | Rylan Hance           | Lakeland, FL (Victory Church)                | 225   | 15   |    | 86%  |
+| 48       | Sam Schneidau         | Cordova, TN (Word Wise Quiz Kids)            | 180   | 12   |    | 100% |
+| **\*48** | Bryan Melvin          | Chandler, AZ (Overcomers)                    | 180   | 12   |    | 81%  |
+| **\*48** | Oye Essandoh          | Dublin, OH (RLC Diamonds)                    | 180   | 12   |    | 69%  |
+| 49       | Eleena Shelton        | Cordova, TN (Word Wise Quiz Kids)            | 105   | 7    |    | 81%  |
+| 50       | Isabelle Erickson     | Shreveport, LA (Shreveport Community Church) | 100   | 6.7  |    | 82%  |
+| 51       | Joel Ertzberger       | Wilmington, NC (New Hanover Church)          | 70    | 4.7  |    | 100% |
+| 52       | Hannah Mathew         | Bloomington, MN (Bread of Life Church)       | 65    | 4.3  |    | 73%  |
+| 53       | Jocelyn Martina       | Naperville, IL (Naperville (S))              | 60    | 4    |    | 100% |
+| 54       | Jovanny Adu-Gyamfi    | Houston, TX (Gideon\'s Army)                 | 40    | 2.7  |    | 100% |
+| 55       | Luke Santee           | Wilmington, NC (New Hanover Church)          | 30    | 2    |    | 100% |
+| 56       | Kesiena Umukoro       | Houston, TX (Gideon\'s Army)                 | 25    | 1.7  |    | 67%  |
+| 57       | London Hamilton       | Shreveport, LA (Shreveport Community Church) | 20    | 1.3  |    | 100% |
+| **\*57** | Annalisa Skelly       | Ozone Park, NY (Calvary Assembly of God)     | 20    | 1.3  |    | 100% |
+| **\*57** | Arielle Erickson      | Shreveport, LA (Shreveport Community Church) | 20    | 1.3  |    | 54%  |
+| 58       | Jahzi Strickland      | Shreveport, LA (Shreveport Community Church) | 15    | 1    |    | 66%  |
+| **\*58** | Jonathan Paredes      | Shreveport, LA (Shreveport Community Church) | 15    | 1    |    | 50%  |
+| 59       | Ella Willson          | Wilmington, NC (New Hanover Church)          | 10    | .7   |    | 99%  |
+| **\*59** | Chisom Joy Oriaku     | Wayne, NJ (CTI-JOY)                          | 10    | .7   |    | 99%  |
+| 60       | Hayden Wright         | Lakeland, FL (Victory Church)                | 0     |      |    |      |
+| **\*60** | Aubrey McNeely        | Shreveport, LA (Shreveport Community Church) | 0     |      |    |      |
+| **\*60** | Shilo Karakkattu      | Chandler, AZ (Overcomers)                    | 0     |      |    |      |
+| **\*60** | Leanna Ramdial        | Ozone Park, NY (Calvary Assembly of God)     | 0     |      |    |      |
+| **\*60** | Abigail Koch          | Garland, TX (Guardians of the Gospel)        | 0     |      |    |      |
+| **\*60** | Johan Vengal          | Bloomington, MN (Bread of Life Church)       | 0     |      |    |      |
+| **\*60** | Nathan Peters         | Bloomington, MN (Bread of Life Church)       | 0     |      |    |      |
+| **\*60** | Arpita Bittu Jampana  | Bloomington, MN (Bread of Life Church)       | 0     |      |    |      |
+| **\*60** | Nathan Nimako         | Dublin, OH (RLC Diamonds)                    | 0     |      |    |      |
+
+### Green
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                            | W/L    | Total | Avg   | QO | Q%  |
+|-----:|----------------------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | Houston, TX (The Chosen Ones)                            | 13 / 2 | 3040  | 202.7 | 16 | 79% |
+| 2.0  | Tallahassee, FL (More Than Conquerors)                   | 12 / 3 | 2955  | 197   | 19 | 85% |
+| 3.0  | Bowling Green, OH (Dayspring Assembly of God)            | 12 / 3 | 2625  | 175   | 9  | 78% |
+| 4.0  | Cedar Hill, TX (Thunder \'n Lightning)                   | 12 / 3 | 2495  | 166.3 | 11 | 75% |
+| 5.0  | Metuchen, NJ (Metuchen Assembly of God)                  | 10 / 5 | 2665  | 177.7 | 7  | 78% |
+| 6.0  | Apple Valley, MN (The Pentateuch)                        | 9 / 6  | 2875  | 191.7 | 16 | 86% |
+| 7.0  | Greenwood, IN (Grace Pardon the Interruption)            | 9 / 6  | 2610  | 174   | 12 | 83% |
+| 8.0  | Richmond Hill, NY (Bethlehem Church)                     | 9 / 6  | 2260  | 150.7 | 5  | 74% |
+| 9.0  | Billings, MT (Fourtify)                                  | 8 / 7  | 2600  | 173.3 | 11 | 81% |
+| 10.0 | Brookfield, WI (CSI: Christ\'s Sanctified Investigators) | 7 / 8  | 2030  | 135.3 | 5  | 90% |
+| 11.1 | Rockford, IL (Life Church)                               | 5 / 10 | 2100  | 140   | 12 | 84% |
+| 12.0 | Lees Summit, MO (Crown Pointe Church)                    | 5 / 10 | 1390  | 92.7  | 1  | 60% |
+| 13.0 | Wesley Chapel, FL (Life Church)                          | 4 / 11 | 1625  | 108.3 | 5  | 76% |
+| 14.0 | Fenton, MI (The Freedom Center)                          | 3 / 12 | 1525  | 101.7 | 6  | 84% |
+| 15.0 | Las Vegas, NV (The Champion Center)                      | 2 / 13 | 1380  | 92    | 1  | 73% |
+| 16.0 | Seminole, TX (First Assembly of God)                     | 0 / 15 | 590   | 39.3  | 1  | 80% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                 | Team / Church                                            | Total | Avg   | QO | Q%   |
+|---------:|-------------------------|----------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Elijah Stewart          | Tallahassee, FL (More Than Conquerors)                   | 1835  | 122.3 | 11 | 83%  |
+| 2        | Spencer Morrison        | Apple Valley, MN (The Pentateuch)                        | 1650  | 110   | 8  | 85%  |
+| 3        | Brandon Ukonu           | Houston, TX (The Chosen Ones)                            | 1425  | 95    | 6  | 82%  |
+| 4        | Kaiden Taylor           | Billings, MT (Fourtify)                                  | 1300  | 86.7  | 6  | 80%  |
+| 5        | Larissa Cox             | Greenwood, IN (Grace Pardon the Interruption)            | 1275  | 85    | 4  | 83%  |
+| 6        | Josiah Smigielski       | Fenton, MI (The Freedom Center)                          | 1255  | 83.7  | 6  | 81%  |
+| 7        | Abilash Balamanoranjith | Metuchen, NJ (Metuchen Assembly of God)                  | 1085  | 72.3  | 2  | 75%  |
+| 8        | Nehemiah Barnes         | Bowling Green, OH (Dayspring Assembly of God)            | 1045  | 69.7  | 6  | 71%  |
+| 9        | Andrey Dmitriev         | Rockford, IL (Life Church)                               | 955   | 63.7  | 2  | 80%  |
+| 10       | Hannah Murray           | Brookfield, WI (CSI: Christ\'s Sanctified Investigators) | 910   | 60.7  | 2  | 97%  |
+| 11       | Ijeoma Ilochonwu        | Rockford, IL (Life Church)                               | 870   | 58    | 9  | 85%  |
+| 12       | trinity hills           | Wesley Chapel, FL (Life Church)                          | 845   | 56.3  | 1  | 78%  |
+| 13       | Jase Cooper             | Billings, MT (Fourtify)                                  | 775   | 51.7  | 3  | 81%  |
+| 14       | Andrew Pickrell         | Cedar Hill, TX (Thunder \'n Lightning)                   | 770   | 51.3  | 2  | 73%  |
+| 15       | Lauren Pahl             | Apple Valley, MN (The Pentateuch)                        | 765   | 51    | 8  | 85%  |
+| 16       | Lucas Brunson           | Greenwood, IN (Grace Pardon the Interruption)            | 765   | 51    | 4  | 78%  |
+| 17       | Iyanu Akanbi            | Houston, TX (The Chosen Ones)                            | 765   | 51    | 2  | 77%  |
+| 18       | Samantha Anselmo        | Richmond Hill, NY (Bethlehem Church)                     | 765   | 51    | 1  | 77%  |
+| 19       | Charlie Zimmerman       | Tallahassee, FL (More Than Conquerors)                   | 760   | 50.7  | 8  | 85%  |
+| 20       | Joel Raj                | Metuchen, NJ (Metuchen Assembly of God)                  | 755   | 50.3  | 1  | 77%  |
+| 21       | Haddie Brookbank        | Lees Summit, MO (Crown Pointe Church)                    | 745   | 49.7  | 1  | 74%  |
+| 22       | Katie Little            | Cedar Hill, TX (Thunder \'n Lightning)                   | 740   | 49.3  | 9  | 75%  |
+| 23       | Samuel Desilva          | Richmond Hill, NY (Bethlehem Church)                     | 735   | 49    | 2  | 77%  |
+| 24       | Jaden Ukonu             | Houston, TX (The Chosen Ones)                            | 680   | 45.3  | 8  | 76%  |
+| 25       | Kendal Davis            | Bowling Green, OH (Dayspring Assembly of God)            | 645   | 43    | 1  | 89%  |
+| 26       | William Okyere          | Greenwood, IN (Grace Pardon the Interruption)            | 570   | 38    | 4  | 89%  |
+| 27       | Elijah Hicks            | Las Vegas, NV (The Champion Center)                      | 560   | 37.3  |    | 70%  |
+| 28       | Elijah Smith            | Bowling Green, OH (Dayspring Assembly of God)            | 550   | 36.7  |    | 84%  |
+| 29       | Abraham Johnson         | Metuchen, NJ (Metuchen Assembly of God)                  | 500   | 33.3  | 3  | 73%  |
+| 30       | jonah karydis           | Wesley Chapel, FL (Life Church)                          | 480   | 32    | 4  | 81%  |
+| 31       | Dominick Forbus         | Las Vegas, NV (The Champion Center)                      | 475   | 31.7  |    | 74%  |
+| 32       | Jadon Sheomangal        | Cedar Hill, TX (Thunder \'n Lightning)                   | 445   | 29.7  |    | 64%  |
+| 33       | Elijah Lapusan          | Seminole, TX (First Assembly of God)                     | 410   | 27.3  |    | 75%  |
+| **\*33** | Gabe Ubert              | Brookfield, WI (CSI: Christ\'s Sanctified Investigators) | 410   | 27.3  |    | 74%  |
+| 34       | Hailey Lane             | Billings, MT (Fourtify)                                  | 395   | 26.3  | 2  | 85%  |
+| 35       | Corneal Lawrence        | Bowling Green, OH (Dayspring Assembly of God)            | 385   | 25.7  | 2  | 77%  |
+| 36       | Aulora Sullivan         | Cedar Hill, TX (Thunder \'n Lightning)                   | 380   | 25.3  |    | 100% |
+| 37       | Jose O\'Brien           | Brookfield, WI (CSI: Christ\'s Sanctified Investigators) | 370   | 24.7  | 2  | 97%  |
+| **\*37** | Samuel Chambuchi        | Richmond Hill, NY (Bethlehem Church)                     | 370   | 24.7  | 2  | 69%  |
+| 38       | Eli Horn                | Brookfield, WI (CSI: Christ\'s Sanctified Investigators) | 345   | 23    | 1  | 92%  |
+| 39       | Reshma Solomon          | Metuchen, NJ (Metuchen Assembly of God)                  | 325   | 21.7  | 1  | 97%  |
+| 40       | Emeka Ilochonwu         | Rockford, IL (Life Church)                               | 275   | 18.3  | 1  | 92%  |
+| 41       | Gavin Burton            | Fenton, MI (The Freedom Center)                          | 270   | 18    |    | 93%  |
+| 42       | George Hoelzel          | Lees Summit, MO (Crown Pointe Church)                    | 260   | 17.3  |    | 60%  |
+| 43       | Josiah Morales          | Las Vegas, NV (The Champion Center)                      | 255   | 17    | 1  | 83%  |
+| 44       | Savanna Barber          | Lees Summit, MO (Crown Pointe Church)                    | 240   | 16    |    | 60%  |
+| 45       | Cienna Field            | Apple Valley, MN (The Pentateuch)                        | 220   | 14.7  |    | 100% |
+| **\*45** | noah ringeisen          | Wesley Chapel, FL (Life Church)                          | 220   | 14.7  |    | 68%  |
+| 46       | Kathryn Dissmore        | Tallahassee, FL (More Than Conquerors)                   | 190   | 12.7  |    | 91%  |
+| 47       | Kamryn LeBlanc          | Seminole, TX (First Assembly of God)                     | 180   | 12    | 1  | 90%  |
+| 48       | Jason Ukonu             | Houston, TX (The Chosen Ones)                            | 170   | 11.3  |    | 90%  |
+| **\*48** | JP Dissmore             | Tallahassee, FL (More Than Conquerors)                   | 170   | 11.3  |    | 90%  |
+| **\*48** | Cashmere Saez           | Richmond Hill, NY (Bethlehem Church)                     | 170   | 11.3  |    | 72%  |
+| 49       | London Lovelace         | Lees Summit, MO (Crown Pointe Church)                    | 160   | 10.7  |    | 49%  |
+| 50       | Hannah Hancock          | Richmond Hill, NY (Bethlehem Church)                     | 140   | 9.3   |    | 100% |
+| 51       | Analise Exley           | Apple Valley, MN (The Pentateuch)                        | 135   | 9     |    | 87%  |
+| 52       | Joshua Sullivan         | Cedar Hill, TX (Thunder \'n Lightning)                   | 130   | 8.7   |    | 79%  |
+| **\*52** | Shayda Morgan           | Billings, MT (Fourtify)                                  | 130   | 8.7   |    | 73%  |
+| 53       | Audriana Hirning        | Apple Valley, MN (The Pentateuch)                        | 105   | 7     |    | 80%  |
+| 54       | Daniel Hayes            | Las Vegas, NV (The Champion Center)                      | 90    | 6     |    | 62%  |
+| 55       | Jon Luc Jobson - Larkin | Richmond Hill, NY (Bethlehem Church)                     | 85    | 5.7   |    | 56%  |
+| 56       | wesley kinsey           | Wesley Chapel, FL (Life Church)                          | 80    | 5.3   |    | 73%  |
+| 57       | Nicholas Nailor         | Cedar Hill, TX (Thunder \'n Lightning)                   | 30    | 2     |    | 99%  |
+| 58       | Macie Pahl              | Apple Valley, MN (The Pentateuch)                        | 0     |       |    | 33%  |
+| **\*58** | Julien Jobson - Larkin  | Richmond Hill, NY (Bethlehem Church)                     | 0     |       |    |      |
+| **\*58** | Chase Cory              | Richmond Hill, NY (Bethlehem Church)                     | 0     |       |    |      |
+| **\*58** | Kynzee LeBlanc          | Seminole, TX (First Assembly of God)                     | 0     |       |    |      |
+| **\*58** | Obi Ilochonwu           | Rockford, IL (Life Church)                               | 0     |       |    |      |
+| **\*58** | Aaron Johnson           | Metuchen, NJ (Metuchen Assembly of God)                  | 0     |       |    |      |
+
+### Lavender
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                | W/L    | Total | Avg   | QO | Q%  |
+|-----:|----------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | San Antonio, TX (Spurs)                      | 14 / 1 | 2815  | 187.7 | 11 | 80% |
+| 2.0  | Holt, MI (Michigan\'s Young Bereans)         | 12 / 3 | 2840  | 189.3 | 17 | 79% |
+| 3.1  | Mustang, OK (United for Christ)              | 11 / 4 | 2820  | 188   | 11 | 83% |
+| 4.0  | Metuchen, NJ (Armor of God)                  | 11 / 4 | 2825  | 188.3 | 11 | 80% |
+| 5.1  | Bothell, WA (MENT to Declare His Glory)      | 10 / 5 | 2525  | 168.3 | 8  | 86% |
+| 6.0  | Gahanna, OH (Fluffy Panda Quizzers)          | 10 / 5 | 2505  | 167   | 13 | 81% |
+| 7.0  | Marietta, GA (Anointed Ones)                 | 8 / 7  | 2255  | 150.3 | 16 | 81% |
+| 8.0  | Lexington, TN (Crosspoint Super Q\'s)        | 7 / 8  | 1685  | 112.3 | 5  | 69% |
+| 9.0  | Lakeville, MN (Celebration Church)           | 6 / 9  | 2145  | 143   | 8  | 76% |
+| 10.0 | Chandler, AZ (God Squad)                     | 6 / 9  | 2095  | 139.7 | 5  | 74% |
+| 11.0 | Concord, NC (The Defenders)                  | 6 / 9  | 2015  | 134.3 | 8  | 71% |
+| 12.0 | Racine, WI (Anointed Avengers for Jesus)     | 6 / 9  | 1980  | 132   | 3  | 75% |
+| 13.1 | Bristow, VA (Chapel Springs Assembly of God) | 5 / 10 | 2135  | 142.3 | 11 | 80% |
+| 14.0 | San Diego, CA (Living Water Bible Church)    | 5 / 10 | 1970  | 131.3 | 6  | 80% |
+| 15.0 | Somerset, KY (Quiz Ninjas)                   | 2 / 13 | 1180  | 78.7  | 5  | 82% |
+| 16.0 | Fort Lauderdale, FL (CLC Messengers of Hope) | 1 / 14 | 1220  | 81.3  | 5  | 86% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                                | Total | Avg   | QO | Q%   |
+|---------:|----------------------|----------------------------------------------|------:|------:|---:|-----:|
+| 1        | Christian Alapati    | Mustang, OK (United for Christ)              | 1645  | 109.7 | 7  | 85%  |
+| 2        | David Egbendewe      | Holt, MI (Michigan\'s Young Bereans)         | 1610  | 107.3 | 9  | 85%  |
+| 3        | Elijah Chadwick      | Bothell, WA (MENT to Declare His Glory)      | 1520  | 101.3 | 3  | 84%  |
+| 4        | Steve Joy            | Marietta, GA (Anointed Ones)                 | 1515  | 101   | 11 | 81%  |
+| 5        | Mabry Haley          | San Antonio, TX (Spurs)                      | 1445  | 96.3  | 3  | 86%  |
+| 6        | Joshua Simon         | Chandler, AZ (God Squad)                     | 1340  | 89.3  | 5  | 78%  |
+| 7        | Andrea Mason         | Bristow, VA (Chapel Springs Assembly of God) | 1205  | 80.3  | 6  | 78%  |
+| 8        | Jacey Pathri         | Gahanna, OH (Fluffy Panda Quizzers)          | 1200  | 80    | 7  | 85%  |
+| 9        | Kailyn Heath         | Lakeville, MN (Celebration Church)           | 1180  | 78.7  | 3  | 82%  |
+| 10       | Luke Hillegass       | Lexington, TN (Crosspoint Super Q\'s)        | 1150  | 76.7  | 2  | 75%  |
+| 11       | Jonathan An          | San Diego, CA (Living Water Bible Church)    | 1125  | 75    | 5  | 76%  |
+| 12       | Caleb Karthik        | Gahanna, OH (Fluffy Panda Quizzers)          | 1040  | 69.3  | 6  | 76%  |
+| 13       | Brady Hansen         | Somerset, KY (Quiz Ninjas)                   | 890   | 59.3  | 5  | 79%  |
+| 14       | Irenov Joel          | Metuchen, NJ (Armor of God)                  | 835   | 55.7  | 1  | 78%  |
+| 15       | Samuel Joshua        | Metuchen, NJ (Armor of God)                  | 800   | 53.3  | 5  | 83%  |
+| 16       | Carson Fincher       | Mustang, OK (United for Christ)              | 770   | 51.3  | 3  | 93%  |
+| 17       | Bryan James          | Metuchen, NJ (Armor of God)                  | 765   | 51    | 5  | 78%  |
+| 18       | Caleb Senthil        | Concord, NC (The Defenders)                  | 760   | 50.7  | 2  | 84%  |
+| 19       | Joshua Gunasingh     | Marietta, GA (Anointed Ones)                 | 740   | 49.3  | 5  | 82%  |
+| 20       | Landon Dissmore      | Racine, WI (Anointed Avengers for Jesus)     | 740   | 49.3  | 2  | 78%  |
+| 21       | Steffi Padmanaban    | Fort Lauderdale, FL (CLC Messengers of Hope) | 705   | 47    | 1  | 82%  |
+| 22       | Miles Pierce         | Concord, NC (The Defenders)                  | 690   | 46    | 5  | 70%  |
+| 23       | Cian Van Offeren     | Racine, WI (Anointed Avengers for Jesus)     | 685   | 45.7  |    | 67%  |
+| 24       | Caris Thomas         | San Antonio, TX (Spurs)                      | 645   | 43    | 7  | 83%  |
+| 25       | Aceline Owusu        | Bristow, VA (Chapel Springs Assembly of God) | 645   | 43    | 5  | 86%  |
+| 26       | Kaden Buher          | Holt, MI (Michigan\'s Young Bereans)         | 615   | 41    | 8  | 73%  |
+| 27       | Victoria Okoh        | Fort Lauderdale, FL (CLC Messengers of Hope) | 515   | 34.3  | 4  | 89%  |
+| 28       | Maria Yevtushenko    | Bothell, WA (MENT to Declare His Glory)      | 515   | 34.3  | 1  | 85%  |
+| 29       | Talia Jarrell        | Bothell, WA (MENT to Declare His Glory)      | 490   | 32.7  | 4  | 89%  |
+| 30       | Tristan Heath        | Lakeville, MN (Celebration Church)           | 490   | 32.7  | 1  | 67%  |
+| 31       | Hayden Garrett       | Lakeville, MN (Celebration Church)           | 480   | 32    | 4  | 81%  |
+| 32       | Liana Thomas         | San Antonio, TX (Spurs)                      | 460   | 30.7  |    | 69%  |
+| 33       | Thomas Hillegass     | Lexington, TN (Crosspoint Super Q\'s)        | 445   | 29.7  | 3  | 64%  |
+| 34       | Andrew Kumar         | Metuchen, NJ (Armor of God)                  | 425   | 28.3  |    | 81%  |
+| **\*34** | Seth Hudson          | Concord, NC (The Defenders)                  | 425   | 28.3  |    | 64%  |
+| 35       | Garrett McElroy      | Mustang, OK (United for Christ)              | 405   | 27    | 1  | 72%  |
+| 36       | Abel Jacob           | Chandler, AZ (God Squad)                     | 400   | 26.7  |    | 66%  |
+| 37       | Hannah Liu           | San Diego, CA (Living Water Bible Church)    | 335   | 22.3  | 1  | 80%  |
+| 38       | Angel Egbendewe      | Holt, MI (Michigan\'s Young Bereans)         | 335   | 22.3  |    | 77%  |
+| 39       | Noah Albarren        | Racine, WI (Anointed Avengers for Jesus)     | 290   | 19.3  | 1  | 74%  |
+| 40       | Janet An             | San Diego, CA (Living Water Bible Church)    | 290   | 19.3  |    | 86%  |
+| 41       | Dorothy Sam          | Gahanna, OH (Fluffy Panda Quizzers)          | 265   | 17.7  |    | 88%  |
+| 42       | Torri Buher          | Holt, MI (Michigan\'s Young Bereans)         | 240   | 16    |    | 82%  |
+| 43       | Shreya Ganesan       | Chandler, AZ (God Squad)                     | 230   | 15.3  |    | 86%  |
+| 44       | Gavin Lewis          | Somerset, KY (Quiz Ninjas)                   | 220   | 14.7  |    | 87%  |
+| 45       | Meredith Haley       | San Antonio, TX (Spurs)                      | 205   | 13.7  | 1  | 81%  |
+| 46       | Tim Liu              | San Diego, CA (Living Water Bible Church)    | 180   | 12    |    | 91%  |
+| 47       | Savannah Albarren    | Racine, WI (Anointed Avengers for Jesus)     | 145   | 9.7   |    | 77%  |
+| **\*47** | Lexie McKennett      | Bristow, VA (Chapel Springs Assembly of God) | 145   | 9.7   |    | 67%  |
+| 48       | Megan Pierce         | Concord, NC (The Defenders)                  | 140   | 9.3   | 1  | 63%  |
+| 49       | Zoe Nerquaye-Tetteh  | Bristow, VA (Chapel Springs Assembly of God) | 140   | 9.3   |    | 79%  |
+| 50       | Ephraim Kurian       | Chandler, AZ (God Squad)                     | 85    | 5.7   |    | 77%  |
+| **\*50** | Tyler Hutcherson     | Lexington, TN (Crosspoint Super Q\'s)        | 85    | 5.7   |    | 58%  |
+| 51       | McKinley Lewis       | Somerset, KY (Quiz Ninjas)                   | 70    | 4.7   |    | 100% |
+| 52       | Trinidy Calvary      | Racine, WI (Anointed Avengers for Jesus)     | 60    | 4     |    | 100% |
+| **\*52** | Cheyanne Barrios     | Racine, WI (Anointed Avengers for Jesus)     | 60    | 4     |    | 100% |
+| 53       | Angel Charles        | Chandler, AZ (God Squad)                     | 50    | 3.3   |    | 100% |
+| **\*53** | Daniel Liu           | San Diego, CA (Living Water Bible Church)    | 50    | 3.3   |    | 86%  |
+| **\*53** | Janessa Walker       | San Antonio, TX (Spurs)                      | 50    | 3.3   |    | 75%  |
+| 54       | Debora Egbendewe     | Holt, MI (Michigan\'s Young Bereans)         | 40    | 2.7   |    | 100% |
+| 55       | Alaina Johnson       | Lexington, TN (Crosspoint Super Q\'s)        | 15    | 1     |    | 100% |
+| **\*55** | Elizabeth Walker     | San Antonio, TX (Spurs)                      | 15    | 1     |    | 50%  |
+| 56       | Bruiyensen Gracelien | Fort Lauderdale, FL (CLC Messengers of Hope) | 0     |       |    |      |
+| **\*56** | Widly Eltine         | Fort Lauderdale, FL (CLC Messengers of Hope) | 0     |       |    |      |
+| **\*56** | Alwin Stephen        | Marietta, GA (Anointed Ones)                 | 0     |       |    |      |
+| **\*56** | Belva Fianko         | Bristow, VA (Chapel Springs Assembly of God) | 0     |       |    |      |
+| **\*56** | Zoey Fischer         | Mustang, OK (United for Christ)              | 0     |       |    |      |
+| **\*56** | Johanna James        | Metuchen, NJ (Armor of God)                  | 0     |       |    |      |
+| **\*56** | Nathan Peter         | Bothell, WA (MENT to Declare His Glory)      | 0     |       |    |      |
+| **\*56** | Summer Lewis         | Somerset, KY (Quiz Ninjas)                   | 0     |       |    |      |
+
+### Pink
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                          | W/L    | Total | Avg   | QO | Q%  |
+|-----:|----------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | Humble, TX (Conquerors Through Christ) | 14 / 1 | 3010  | 200.7 | 22 | 89% |
+| 2.0  | Carrollton, TX (Chain Breakers)        | 12 / 3 | 2735  | 182.3 | 11 | 81% |
+| 3.1  | Naperville, IL (Naperville (D))        | 11 / 4 | 2800  | 186.7 | 20 | 84% |
+| 4.0  | Charlotte, NC (CICF Champions)         | 11 / 4 | 2675  | 178.3 | 6  | 81% |
+| 5.0  | Mechanicsville, VA (Transformers)      | 10 / 5 | 2595  | 173   | 10 | 78% |
+| 6.0  | Fordyce, AR (Bible Bugs)               | 10 / 5 | 2535  | 169   | 13 | 85% |
+| 7.0  | Great Bend, KS (Quizzards of Oz)       | 10 / 5 | 2285  | 152.3 | 9  | 76% |
+| 8.1  | Sparta, WI (Sparta Salt & Light)       | 7 / 8  | 2100  | 140   | 6  | 71% |
+| 9.0  | Cambridge, MA (Pentecostal Tabernacle) | 7 / 8  | 2035  | 135.7 | 4  | 76% |
+| 10.1 | Georgetown, KY (Truth Seekers)         | 6 / 9  | 1915  | 127.7 | 10 | 78% |
+| 11.0 | Minot, ND (Legacy Kids)                | 6 / 9  | 1860  | 124   | 2  | 74% |
+| 12.0 | Indianapolis, IN (The Masterminds)     | 5 / 10 | 2105  | 140.3 | 8  | 77% |
+| 13.1 | Tucson, AZ (The Interrupters)          | 4 / 11 | 1675  | 111.7 | 8  | 75% |
+| 14.0 | Fruitland Park, FL (Triple Truth)      | 4 / 11 | 1950  | 130   | 8  | 73% |
+| 15.0 | Bothell, WA (SOLID)                    | 3 / 12 | 1755  | 117   | 2  | 96% |
+| 16.0 | Colorado Springs, CO (Radiant Church)  | 0 / 15 | 890   | 59.3  |    | 78% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                          | Total | Avg   | QO | Q%   |
+|---------:|------------------------|----------------------------------------|------:|------:|---:|-----:|
+| 1        | McKinley Stevens       | Naperville, IL (Naperville (D))        | 1620  | 108   | 10 | 82%  |
+| 2        | Naomi Shtyrkalo        | Humble, TX (Conquerors Through Christ) | 1565  | 104.3 | 9  | 88%  |
+| 3        | Sarah Klongpayabal     | Carrollton, TX (Chain Breakers)        | 1515  | 101   | 9  | 90%  |
+| 4        | Jonathan Shtyrkalo     | Humble, TX (Conquerors Through Christ) | 1445  | 96.3  | 13 | 91%  |
+| 5        | Elijah Turner          | Fordyce, AR (Bible Bugs)               | 1265  | 84.3  | 4  | 88%  |
+| 6        | Gianna LoGiudice       | Fruitland Park, FL (Triple Truth)      | 1140  | 76    | 7  | 76%  |
+| 7        | Ansley Hornaday        | Fordyce, AR (Bible Bugs)               | 1125  | 75    | 9  | 82%  |
+| 8        | Daima Mashibe          | Georgetown, KY (Truth Seekers)         | 1090  | 72.7  | 4  | 82%  |
+| 9        | Josita Agnes Paulraj   | Charlotte, NC (CICF Champions)         | 980   | 65.3  | 1  | 84%  |
+| 10       | Rebecca Ebenezer Joel  | Charlotte, NC (CICF Champions)         | 920   | 61.3  | 2  | 81%  |
+| 11       | Anna Dangerfield       | Minot, ND (Legacy Kids)                | 920   | 61.3  | 1  | 82%  |
+| 12       | Morgan MacKinney       | Great Bend, KS (Quizzards of Oz)       | 910   | 60.7  |    | 73%  |
+| 13       | Olivia Moses           | Bothell, WA (SOLID)                    | 905   | 60.3  | 1  | 91%  |
+| 14       | Ethan Kihiu            | Indianapolis, IN (The Masterminds)     | 870   | 58    | 2  | 69%  |
+| 15       | Emily Beckham          | Carrollton, TX (Chain Breakers)        | 870   | 58    | 1  | 76%  |
+| 16       | Kenneth Stanley        | Mechanicsville, VA (Transformers)      | 845   | 56.3  | 6  | 78%  |
+| 17       | Christian Steele       | Mechanicsville, VA (Transformers)      | 845   | 56.3  | 3  | 77%  |
+| 18       | Enzi Mashibe           | Georgetown, KY (Truth Seekers)         | 825   | 55    | 6  | 74%  |
+| 19       | Sawyer Curtis          | Sparta, WI (Sparta Salt & Light)       | 815   | 54.3  | 2  | 67%  |
+| 20       | Myah Berkey            | Tucson, AZ (The Interrupters)          | 790   | 52.7  | 1  | 68%  |
+| 21       | Pierce Stevens         | Naperville, IL (Naperville (D))        | 765   | 51    | 10 | 83%  |
+| **\*21** | Chiamara Beulah Odunze | Cambridge, MA (Pentecostal Tabernacle) | 765   | 51    | 1  | 81%  |
+| 22       | Cole MacKinney         | Great Bend, KS (Quizzards of Oz)       | 725   | 48.3  | 9  | 77%  |
+| 23       | Mason Berkey           | Tucson, AZ (The Interrupters)          | 720   | 48    | 7  | 79%  |
+| 24       | Edie Thompson          | Fruitland Park, FL (Triple Truth)      | 720   | 48    | 1  | 76%  |
+| 25       | Brooks Adams           | Mechanicsville, VA (Transformers)      | 665   | 44.3  | 1  | 76%  |
+| 26       | Erin Kihiu             | Indianapolis, IN (The Masterminds)     | 630   | 42    | 2  | 76%  |
+| 27       | Kaymi Thompson         | Indianapolis, IN (The Masterminds)     | 605   | 40.3  | 4  | 87%  |
+| 28       | Olivia Collins         | Sparta, WI (Sparta Salt & Light)       | 540   | 36    | 3  | 79%  |
+| 29       | Ella Krier             | Great Bend, KS (Quizzards of Oz)       | 530   | 35.3  |    | 76%  |
+| 30       | Daniel Rickman         | Colorado Springs, CO (Radiant Church)  | 520   | 34.7  |    | 81%  |
+| 31       | Gideon Legall          | Cambridge, MA (Pentecostal Tabernacle) | 485   | 32.3  | 3  | 73%  |
+| 32       | Kaleb Noel             | Cambridge, MA (Pentecostal Tabernacle) | 485   | 32.3  |    | 72%  |
+| 33       | Amaya Allard           | Sparta, WI (Sparta Salt & Light)       | 410   | 27.3  | 1  | 72%  |
+| 34       | Leiah Gries            | Bothell, WA (SOLID)                    | 380   | 25.3  |    | 100% |
+| **\*34** | Jayva McKibben         | Minot, ND (Legacy Kids)                | 380   | 25.3  |    | 73%  |
+| 35       | Ethan Dangerfield      | Minot, ND (Legacy Kids)                | 340   | 22.7  | 1  | 62%  |
+| 36       | Jotham Edwin           | Charlotte, NC (CICF Champions)         | 335   | 22.3  | 1  | 78%  |
+| 37       | Rolph Presume          | Cambridge, MA (Pentecostal Tabernacle) | 300   | 20    |    | 78%  |
+| 38       | David Mathews          | Carrollton, TX (Chain Breakers)        | 290   | 19.3  | 1  | 69%  |
+| 39       | Enoch Edwin            | Charlotte, NC (CICF Champions)         | 285   | 19    | 2  | 74%  |
+| 40       | Isaac Helgerson        | Sparta, WI (Sparta Salt & Light)       | 260   | 17.3  |    | 56%  |
+| 41       | Daniel Li              | Bothell, WA (SOLID)                    | 250   | 16.7  | 1  | 96%  |
+| 42       | Ivanka Chadwick        | Bothell, WA (SOLID)                    | 220   | 14.7  |    | 100% |
+| **\*42** | Briggs McKibben        | Minot, ND (Legacy Kids)                | 220   | 14.7  |    | 92%  |
+| 43       | Gabriel Parra          | Naperville, IL (Naperville (D))        | 205   | 13.7  |    | 92%  |
+| 44       | Kaleb Stanley          | Mechanicsville, VA (Transformers)      | 180   | 12    |    | 87%  |
+| 45       | Sarah Bradley          | Colorado Springs, CO (Radiant Church)  | 175   | 11.7  |    | 79%  |
+| 46       | Shalom Ebenezer        | Charlotte, NC (CICF Champions)         | 155   | 10.3  |    | 94%  |
+| 47       | Nicholas Ortega        | Tucson, AZ (The Interrupters)          | 125   | 8.3   |    | 91%  |
+| **\*47** | Adalyn Hornaday        | Fordyce, AR (Bible Bugs)               | 125   | 8.3   |    | 81%  |
+| 48       | Esther Siony           | Naperville, IL (Naperville (D))        | 120   | 8     |    | 100% |
+| 49       | Mady Hammeke           | Great Bend, KS (Quizzards of Oz)       | 100   | 6.7   |    | 75%  |
+| 50       | Elizabeth Siony        | Naperville, IL (Naperville (D))        | 95    | 6.3   |    | 91%  |
+| 51       | Briella LoGiudice      | Fruitland Park, FL (Triple Truth)      | 90    | 6     |    | 55%  |
+| 52       | Emaline Rickman        | Colorado Springs, CO (Radiant Church)  | 85    | 5.7   |    | 73%  |
+| 53       | Eli Anderson           | Colorado Springs, CO (Radiant Church)  | 80    | 5.3   |    | 83%  |
+| 54       | Nathan Beckham         | Carrollton, TX (Chain Breakers)        | 60    | 4     |    | 100% |
+| **\*54** | Berkley Adams          | Mechanicsville, VA (Transformers)      | 60    | 4     |    | 100% |
+| 55       | Ava Millard            | Sparta, WI (Sparta Salt & Light)       | 50    | 3.3   |    | 100% |
+| 56       | Kaleb Ortega           | Tucson, AZ (The Interrupters)          | 40    | 2.7   |    | 100% |
+| 57       | Elijah Helgerson       | Sparta, WI (Sparta Salt & Light)       | 30    | 2     |    | 99%  |
+| **\*57** | Emma Anderson          | Colorado Springs, CO (Radiant Church)  | 30    | 2     |    | 62%  |
+| 58       | Anna Claire Collins    | Fordyce, AR (Bible Bugs)               | 20    | 1.3   |    | 100% |
+| **\*58** | Lilly Burton           | Great Bend, KS (Quizzards of Oz)       | 20    | 1.3   |    | 99%  |
+| 59       | Jenna Lopez            | Tucson, AZ (The Interrupters)          | 0     |       |    |      |
+| **\*59** | Wesley Burbank         | Tucson, AZ (The Interrupters)          | 0     |       |    |      |
+| **\*59** | Sophia Curtis          | Sparta, WI (Sparta Salt & Light)       | 0     |       |    |      |
+| **\*59** | Sienna Allard          | Sparta, WI (Sparta Salt & Light)       | 0     |       |    |      |
+| **\*59** | Audrey Inskeep         | Indianapolis, IN (The Masterminds)     | 0     |       |    |      |
+| **\*59** | Kaylee Tidaback        | Georgetown, KY (Truth Seekers)         | 0     |       |    |      |
+| **\*59** | Himaya Mashibe         | Georgetown, KY (Truth Seekers)         | 0     |       |    |      |
+| **\*59** | Rachel Caudill         | Georgetown, KY (Truth Seekers)         | 0     |       |    |      |
+| **\*59** | Elijah Caudill         | Georgetown, KY (Truth Seekers)         | 0     |       |    |      |
+| **\*59** | Audrey Caudill         | Georgetown, KY (Truth Seekers)         | 0     |       |    |      |
+| **\*59** | Braley Collins         | Fordyce, AR (Bible Bugs)               | 0     |       |    |      |
+
+### Yellow
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                   | W/L    | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0  | Monmouth Junction, NJ (Knights 4 Christ -Faith) | 14 / 1 | 3220  | 214.7 | 17 | 86% |
+| 2.0  | Omaha, NE (Good News Church)                    | 12 / 3 | 2795  | 186.3 | 11 | 90% |
+| 3.0  | Naperville, IL (Naperville (M))                 | 11 / 4 | 3160  | 210.7 | 21 | 86% |
+| 4.0  | Shelby Township, MI (Heavenly Hotpockets)       | 10 / 5 | 2515  | 167.7 | 10 | 76% |
+| 5.0  | Bonifay, FL (Carmel Assembly)                   | 10 / 5 | 2390  | 159.3 | 7  | 76% |
+| 6.0  | Garland, TX (Keepers of the Command)            | 10 / 5 | 2280  | 152   | 10 | 73% |
+| 7.0  | Leesburg, VA (SPY Dudes)                        | 10 / 5 | 2245  | 149.7 | 7  | 74% |
+| 8.0  | Askewville, NC (Bethel Assembly of God)         | 9 / 6  | 2460  | 164   | 11 | 82% |
+| 9.1  | Burlington, MA (Mount Hope Christian Center)    | 7 / 8  | 2330  | 155.3 | 5  | 79% |
+| 10.0 | Hibbing, MN (Abundant Life Church)              | 7 / 8  | 2295  | 153   | 11 | 82% |
+| 11.0 | Painesville, OH (Truth Defenders)               | 6 / 9  | 2100  | 140   | 12 | 83% |
+| 12.0 | Phoenix, AZ (Hyped 4 Christ)                    | 5 / 10 | 1765  | 117.7 | 8  | 75% |
+| 13.0 | Bellevue, WA (Neighborhood Church)              | 3 / 12 | 1780  | 118.7 | 8  | 76% |
+| 14.0 | Jenks, OK (Newspring Assembly of God)           | 3 / 12 | 1650  | 110   | 2  | 84% |
+| 15.0 | Mabelvale, AR (Buzz Hogs)                       | 3 / 12 | 1405  | 93.7  | 5  | 75% |
+| 16.0 | Kailua, HI (Kailua Assembly of God)             | 0 / 15 | 945   | 63    | 1  | 65% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                                   | Total | Avg   | QO | Q%   |
+|---------:|----------------------|-------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Shaylee Powell       | Naperville, IL (Naperville (M))                 | 1730  | 115.3 | 10 | 82%  |
+| 2        | Nolan King           | Omaha, NE (Good News Church)                    | 1705  | 113.7 | 6  | 92%  |
+| 3        | Justin Klco          | Painesville, OH (Truth Defenders)               | 1485  | 99    | 8  | 79%  |
+| 4        | Hannah Farnsworth    | Hibbing, MN (Abundant Life Church)              | 1440  | 96    | 6  | 88%  |
+| 5        | Samuel Jebaraj       | Monmouth Junction, NJ (Knights 4 Christ -Faith) | 1265  | 84.3  | 6  | 86%  |
+| 6        | Austin Perry         | Askewville, NC (Bethel Assembly of God)         | 1255  | 83.7  | 6  | 78%  |
+| 7        | Chidie Echefu        | Garland, TX (Keepers of the Command)            | 1215  | 81    | 6  | 72%  |
+| 8        | Jocelyn Fredrick     | Monmouth Junction, NJ (Knights 4 Christ -Faith) | 1205  | 80.3  | 3  | 86%  |
+| 9        | Rahul Padmanabhan    | Shelby Township, MI (Heavenly Hotpockets)       | 1160  | 77.3  | 5  | 85%  |
+| 10       | Josiah Minick        | Mabelvale, AR (Buzz Hogs)                       | 1085  | 72.3  | 5  | 71%  |
+| 11       | Michelle Muddasu     | Burlington, MA (Mount Hope Christian Center)    | 1020  | 68    | 1  | 87%  |
+| 12       | Lindsey Perry        | Askewville, NC (Bethel Assembly of God)         | 970   | 64.7  | 5  | 82%  |
+| 13       | Jayden Suresh        | Naperville, IL (Naperville (M))                 | 940   | 62.7  | 11 | 89%  |
+| 14       | James Bozzay         | Leesburg, VA (SPY Dudes)                        | 870   | 58    | 1  | 69%  |
+| 15       | Aiden Albert         | Monmouth Junction, NJ (Knights 4 Christ -Faith) | 750   | 50    | 8  | 86%  |
+| 16       | Livingstone Iwuamadi | Garland, TX (Keepers of the Command)            | 740   | 49.3  | 4  | 71%  |
+| 17       | Anju Rajakumar       | Burlington, MA (Mount Hope Christian Center)    | 730   | 48.7  | 1  | 82%  |
+| 18       | Ashlin Vanderslice   | Jenks, OK (Newspring Assembly of God)           | 725   | 48.3  |    | 85%  |
+| 19       | David Barney         | Shelby Township, MI (Heavenly Hotpockets)       | 675   | 45    |    | 71%  |
+| 20       | Yatin Mokana         | Bellevue, WA (Neighborhood Church)              | 655   | 43.7  | 1  | 72%  |
+| 21       | Riley Biek           | Phoenix, AZ (Hyped 4 Christ)                    | 635   | 42.3  | 1  | 85%  |
+| 22       | Ayushi Vara          | Bellevue, WA (Neighborhood Church)              | 615   | 41    | 6  | 83%  |
+| 23       | Keira Rogers         | Painesville, OH (Truth Defenders)               | 615   | 41    | 4  | 91%  |
+| 24       | Savonah Jakel        | Kailua, HI (Kailua Assembly of God)             | 615   | 41    |    | 79%  |
+| 25       | Cade Muscari         | Phoenix, AZ (Hyped 4 Christ)                    | 600   | 40    | 7  | 73%  |
+| 26       | Gabriel Otchere      | Leesburg, VA (SPY Dudes)                        | 585   | 39    |    | 95%  |
+| 27       | Brady Womble         | Bonifay, FL (Carmel Assembly)                   | 580   | 38.7  |    | 77%  |
+| 28       | Isaac Farnsworth     | Hibbing, MN (Abundant Life Church)              | 570   | 38    | 4  | 74%  |
+| 29       | Addison Beasley      | Jenks, OK (Newspring Assembly of God)           | 565   | 37.7  |    | 88%  |
+| 30       | John Hetrick         | Omaha, NE (Good News Church)                    | 560   | 37.3  | 5  | 84%  |
+| 31       | Micah Warren         | Bonifay, FL (Carmel Assembly)                   | 540   | 36    | 5  | 80%  |
+| 32       | Isaiah Porter        | Phoenix, AZ (Hyped 4 Christ)                    | 515   | 34.3  |    | 72%  |
+| 33       | Kiersten Womble      | Bonifay, FL (Carmel Assembly)                   | 475   | 31.7  | 1  | 67%  |
+| 34       | Jaden Jablonski      | Leesburg, VA (SPY Dudes)                        | 470   | 31.3  | 3  | 73%  |
+| 35       | Michael Rice         | Shelby Township, MI (Heavenly Hotpockets)       | 465   | 31    | 5  | 70%  |
+| 36       | Abigail Cothran      | Jenks, OK (Newspring Assembly of God)           | 360   | 24    | 2  | 80%  |
+| 37       | Rebecca Lee          | Bonifay, FL (Carmel Assembly)                   | 345   | 23    |    | 92%  |
+| 38       | Jordyn Weir          | Burlington, MA (Mount Hope Christian Center)    | 330   | 22    | 2  | 71%  |
+| 39       | Joe Hetrick          | Omaha, NE (Good News Church)                    | 330   | 22    |    | 94%  |
+| 40       | Taylor Jablonski     | Leesburg, VA (SPY Dudes)                        | 320   | 21.3  | 3  | 74%  |
+| 41       | Quinton Zepp         | Bonifay, FL (Carmel Assembly)                   | 320   | 21.3  | 1  | 78%  |
+| 42       | Macie Lynn Pugh      | Garland, TX (Keepers of the Command)            | 300   | 20    |    | 81%  |
+| 43       | John Hung            | Naperville, IL (Naperville (M))                 | 290   | 19.3  |    | 94%  |
+| 44       | Abigail Farnsworth   | Hibbing, MN (Abundant Life Church)              | 285   | 19    | 1  | 90%  |
+| 45       | Olivia Bazemore      | Askewville, NC (Bethel Assembly of God)         | 235   | 15.7  |    | 96%  |
+| 46       | James Barney         | Shelby Township, MI (Heavenly Hotpockets)       | 215   | 14.3  |    | 78%  |
+| 47       | Sebastian Jakel      | Kailua, HI (Kailua Assembly of God)             | 200   | 13.3  | 1  | 67%  |
+| 48       | Ariana Aristy        | Omaha, NE (Good News Church)                    | 200   | 13.3  |    | 100% |
+| **\*48** | Josh Hung            | Naperville, IL (Naperville (M))                 | 200   | 13.3  |    | 88%  |
+| 49       | Mayope Faleye        | Burlington, MA (Mount Hope Christian Center)    | 190   | 12.7  | 1  | 69%  |
+| 50       | Lucky Bandaru        | Bellevue, WA (Neighborhood Church)              | 185   | 12.3  | 1  | 75%  |
+| 51       | Grace Parnell        | Mabelvale, AR (Buzz Hogs)                       | 185   | 12.3  |    | 87%  |
+| 52       | Maggie Baez          | Mabelvale, AR (Buzz Hogs)                       | 135   | 9     |    | 83%  |
+| **\*52** | Daniel Benston       | Bellevue, WA (Neighborhood Church)              | 135   | 9     |    | 73%  |
+| **\*52** | Adam Theriault       | Bellevue, WA (Neighborhood Church)              | 135   | 9     |    | 63%  |
+| 53       | Samuel Lee           | Bonifay, FL (Carmel Assembly)                   | 130   | 8.7   |    | 53%  |
+| 54       | Hannah Titus         | Burlington, MA (Mount Hope Christian Center)    | 75    | 5     |    | 100% |
+| **\*54** | Kahanuola Kanno      | Kailua, HI (Kailua Assembly of God)             | 75    | 5     |    | 47%  |
+| 55       | Elizabeth Larson     | Bellevue, WA (Neighborhood Church)              | 60    | 4     |    | 100% |
+| 56       | Kai Betsinger        | Kailua, HI (Kailua Assembly of God)             | 40    | 2.7   |    | 50%  |
+| 57       | Jax Betsinger        | Kailua, HI (Kailua Assembly of God)             | 25    | 1.7   |    | 75%  |
+| **\*57** | Jayden Ramesh        | Garland, TX (Keepers of the Command)            | 25    | 1.7   |    | 75%  |
+| 58       | Logan MacPherson     | Phoenix, AZ (Hyped 4 Christ)                    | 20    | 1.3   |    | 50%  |
+| 59       | Elisha Hung          | Naperville, IL (Naperville (M))                 | 0     |       |    |      |
+| **\*59** | Cherish Page         | Mabelvale, AR (Buzz Hogs)                       | 0     |       |    |      |
+| **\*59** | Shane Lowers         | Askewville, NC (Bethel Assembly of God)         | 0     |       |    |      |
+| **\*59** | Roshan Padmanabhan   | Shelby Township, MI (Heavenly Hotpockets)       | 0     |       |    |      |
+| **\*59** | Talitha Konda        | Bellevue, WA (Neighborhood Church)              | 0     |       |    |      |
+| **\*59** | Carson Sandberg      | Leesburg, VA (SPY Dudes)                        | 0     |       |    |      |
+| **\*59** | Crista Bues          | Leesburg, VA (SPY Dudes)                        | 0     |       |    |      |
+| 60       | Joelle Lo            | Kailua, HI (Kailua Assembly of God)             | -5    | -.3   |    |      |
+
+## Saturday
+
+### Blue (C)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                   | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Houston, TX (The Chosen Ones)                   | 8 / 1 | 1595  | 177.2 | 8  | 80% |
+| 2.0  | Omaha, NE (Good News Church)                    | 7 / 2 | 1475  | 163.9 | 3  | 89% |
+| 3.1  | Tallahassee, FL (More Than Conquerors)          | 6 / 3 | 1430  | 158.9 | 8  | 80% |
+| 4.0  | Monmouth Junction, NJ (Knights 4 Christ -Faith) | 6 / 3 | 1630  | 181.1 | 7  | 86% |
+| 5.0  | Humble, TX (Conquerors Through Christ)          | 4 / 5 | 1305  | 145   | 6  | 80% |
+| 6.0  | Houston, TX (Gideon\'s Army)                    | 4 / 5 | 1300  | 144.4 | 6  | 73% |
+| 7.0  | Holt, MI (Michigan\'s Young Bereans)            | 4 / 5 | 1215  | 135   | 6  | 74% |
+| 8.0  | San Antonio, TX (Spurs)                         | 3 / 6 | 1185  | 131.7 | 4  | 75% |
+| 9.0  | Wayne, NJ (CTI-JOY)                             | 2 / 7 | 940   | 104.4 | 3  | 75% |
+| 10.0 | Carrollton, TX (Chain Breakers)                 | 1 / 8 | 1030  | 114.4 | 2  | 75% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                                   | Total | Avg   | QO | Q%   |
+|---------:|----------------------|-------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Nolan King           | Omaha, NE (Good News Church)                    | 950   | 105.6 | 3  | 89%  |
+| 2        | Elijah Stewart       | Tallahassee, FL (More Than Conquerors)          | 945   | 105   | 5  | 77%  |
+| 3        | Brandon Ukonu        | Houston, TX (The Chosen Ones)                   | 890   | 98.9  | 4  | 88%  |
+| 4        | Jocelyn Fredrick     | Monmouth Junction, NJ (Knights 4 Christ -Faith) | 700   | 77.8  | 3  | 85%  |
+| 5        | Jonathan Shtyrkalo   | Humble, TX (Conquerors Through Christ)          | 675   | 75    | 4  | 80%  |
+| 6        | Mabry Haley          | San Antonio, TX (Spurs)                         | 655   | 72.8  | 2  | 75%  |
+| 7        | Naomi Shtyrkalo      | Humble, TX (Conquerors Through Christ)          | 630   | 70    | 2  | 81%  |
+| 8        | David Egbendewe      | Holt, MI (Michigan\'s Young Bereans)            | 620   | 68.9  | 2  | 72%  |
+| 9        | Samuel Jebaraj       | Monmouth Junction, NJ (Knights 4 Christ -Faith) | 535   | 59.4  |    | 87%  |
+| 10       | Sarah Klongpayabal   | Carrollton, TX (Chain Breakers)                 | 505   | 56.1  | 2  | 87%  |
+| 11       | Priscilla Adu-Gyamfi | Houston, TX (Gideon\'s Army)                    | 445   | 49.4  | 4  | 67%  |
+| 12       | Iyanu Akanbi         | Houston, TX (The Chosen Ones)                   | 415   | 46.1  |    | 74%  |
+| 13       | Elliot Rivera        | Wayne, NJ (CTI-JOY)                             | 410   | 45.6  | 3  | 84%  |
+| 14       | Kaden Buher          | Holt, MI (Michigan\'s Young Bereans)            | 400   | 44.4  | 4  | 75%  |
+| 15       | Aiden Albert         | Monmouth Junction, NJ (Knights 4 Christ -Faith) | 395   | 43.9  | 4  | 85%  |
+| 16       | Charlie Zimmerman    | Tallahassee, FL (More Than Conquerors)          | 390   | 43.3  | 3  | 85%  |
+| 17       | Emily Beckham        | Carrollton, TX (Chain Breakers)                 | 340   | 37.8  |    | 72%  |
+| 18       | Garen Umukoro        | Houston, TX (Gideon\'s Army)                    | 325   | 36.1  | 1  | 73%  |
+| 19       | Caris Thomas         | San Antonio, TX (Spurs)                         | 320   | 35.6  | 2  | 83%  |
+| 20       | John Hetrick         | Omaha, NE (Good News Church)                    | 295   | 32.8  |    | 81%  |
+| 21       | Kelechi Oriaku       | Wayne, NJ (CTI-JOY)                             | 280   | 31.1  |    | 65%  |
+| 22       | Jaden Ukonu          | Houston, TX (The Chosen Ones)                   | 275   | 30.6  | 4  | 72%  |
+| 23       | Aretha CC-Okeke      | Houston, TX (Gideon\'s Army)                    | 260   | 28.9  |    | 75%  |
+| 24       | Jason Alicea         | Wayne, NJ (CTI-JOY)                             | 250   | 27.8  |    | 67%  |
+| 25       | Joe Hetrick          | Omaha, NE (Good News Church)                    | 190   | 21.1  |    | 95%  |
+| 26       | David Mathews        | Carrollton, TX (Chain Breakers)                 | 165   | 18.3  |    | 64%  |
+| 27       | Chidinma Kanu        | Houston, TX (Gideon\'s Army)                    | 145   | 16.1  |    | 90%  |
+| 28       | Kesiena Umukoro      | Houston, TX (Gideon\'s Army)                    | 125   | 13.9  | 1  | 79%  |
+| 29       | Angel Egbendewe      | Holt, MI (Michigan\'s Young Bereans)            | 120   | 13.3  |    | 86%  |
+| 30       | Liana Thomas         | San Antonio, TX (Spurs)                         | 100   | 11.1  |    | 64%  |
+| 31       | Meredith Haley       | San Antonio, TX (Spurs)                         | 90    | 10    |    | 65%  |
+| 32       | Kathryn Dissmore     | Tallahassee, FL (More Than Conquerors)          | 70    | 7.8   |    | 71%  |
+| 33       | Debora Egbendewe     | Holt, MI (Michigan\'s Young Bereans)            | 40    | 4.4   |    | 100% |
+| **\*33** | Ariana Aristy        | Omaha, NE (Good News Church)                    | 40    | 4.4   |    | 100% |
+| 34       | Torri Buher          | Holt, MI (Michigan\'s Young Bereans)            | 35    | 3.9   |    | 62%  |
+| 35       | JP Dissmore          | Tallahassee, FL (More Than Conquerors)          | 25    | 2.8   |    | 75%  |
+| 36       | Nathan Beckham       | Carrollton, TX (Chain Breakers)                 | 20    | 2.2   |    | 100% |
+| **\*36** | Jason Ukonu          | Houston, TX (The Chosen Ones)                   | 20    | 2.2   |    | 100% |
+| 37       | Janessa Walker       | San Antonio, TX (Spurs)                         | 10    | 1.1   |    | 99%  |
+| **\*37** | Elizabeth Walker     | San Antonio, TX (Spurs)                         | 10    | 1.1   |    | 99%  |
+| 38       | Chisom Joy Oriaku    | Wayne, NJ (CTI-JOY)                             | 0     |       |    |      |
+| **\*38** | Jovanny Adu-Gyamfi   | Houston, TX (Gideon\'s Army)                    | 0     |       |    |      |
+
+
+### Green (S)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                 | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-----------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Mustang, OK (United for Christ)               | 7 / 2 | 1435  | 159.4 | 6  | 81% |
+| 2.1  | Shelby Township, MI (Heavenly Hotpockets)     | 6 / 3 | 1465  | 162.8 | 2  | 78% |
+| 3.0  | Naperville, IL (Naperville (M))               | 6 / 3 | 1520  | 168.9 | 9  | 79% |
+| 4.0  | Garland, TX (Guardians of the Gospel)         | 5 / 4 | 1175  | 130.5 | 6  | 66% |
+| 5.0  | Cedar Hill, TX (Thunder \'n Lightning)        | 4 / 5 | 1240  | 137.8 | 5  | 68% |
+| 6.0  | Metuchen, NJ (Armor of God)                   | 4 / 5 | 1130  | 125.5 | 4  | 67% |
+| 7.0  | Wilmington, NC (New Hanover Church)           | 4 / 5 | 1040  | 115.5 | 1  | 73% |
+| 8.0  | Charlotte, NC (CICF Champions)                | 3 / 6 | 1155  | 128.3 |    | 77% |
+| 9.0  | Naperville, IL (Naperville (D))               | 3 / 6 | 1075  | 119.4 | 6  | 69% |
+| 10.0 | Bowling Green, OH (Dayspring Assembly of God) | 3 / 6 | 940   | 104.4 | 2  | 62% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer               | Team / Church                                 | Total | Avg   | QO | Q%   |
+|---------:|-----------------------|-----------------------------------------------|------:|------:|---:|-----:|
+| 1        | Shaylee Powell        | Naperville, IL (Naperville (M))               | 1115  | 123.9 | 7  | 82%  |
+| 2        | Christian Alapati     | Mustang, OK (United for Christ)               | 925   | 102.8 | 4  | 84%  |
+| 3        | McKinley Stevens      | Naperville, IL (Naperville (D))               | 670   | 74.4  | 3  | 65%  |
+| 4        | Paul Ertzberger       | Wilmington, NC (New Hanover Church)           | 660   | 73.3  | 1  | 88%  |
+| 5        | Rahul Padmanabhan     | Shelby Township, MI (Heavenly Hotpockets)     | 590   | 65.6  | 1  | 80%  |
+| 6        | David Barney          | Shelby Township, MI (Heavenly Hotpockets)     | 515   | 57.2  |    | 80%  |
+| 7        | Nathan Koch           | Garland, TX (Guardians of the Gospel)         | 505   | 56.1  | 3  | 61%  |
+| 8        | Rebecca Ebenezer Joel | Charlotte, NC (CICF Champions)                | 425   | 47.2  |    | 87%  |
+| 9        | Josita Agnes Paulraj  | Charlotte, NC (CICF Champions)                | 375   | 41.7  |    | 76%  |
+| 10       | Pierce Stevens        | Naperville, IL (Naperville (D))               | 370   | 41.1  | 3  | 76%  |
+| 11       | Katie Little          | Cedar Hill, TX (Thunder \'n Lightning)        | 350   | 38.9  | 4  | 68%  |
+| 12       | Irenov Joel           | Metuchen, NJ (Armor of God)                   | 350   | 38.9  | 1  | 74%  |
+| 13       | Reese Pugh            | Garland, TX (Guardians of the Gospel)         | 345   | 38.3  | 3  | 70%  |
+| 14       | Judith Ramesh         | Garland, TX (Guardians of the Gospel)         | 330   | 36.7  |    | 68%  |
+| 15       | Elijah Smith          | Bowling Green, OH (Dayspring Assembly of God) | 310   | 34.4  |    | 68%  |
+| 16       | Bryan James           | Metuchen, NJ (Armor of God)                   | 285   | 31.7  | 3  | 67%  |
+| 17       | Carson Fincher        | Mustang, OK (United for Christ)               | 285   | 31.7  | 1  | 95%  |
+| 18       | Andrew Pickrell       | Cedar Hill, TX (Thunder \'n Lightning)        | 280   | 31.1  |    | 62%  |
+| 19       | Jayden Suresh         | Naperville, IL (Naperville (M))               | 275   | 30.6  | 2  | 85%  |
+| 20       | Michael Rice          | Shelby Township, MI (Heavenly Hotpockets)     | 270   | 30    | 1  | 73%  |
+| 21       | Samuel Joshua         | Metuchen, NJ (Armor of God)                   | 270   | 30    |    | 61%  |
+| 22       | Jadon Sheomangal      | Cedar Hill, TX (Thunder \'n Lightning)        | 240   | 26.7  |    | 65%  |
+| 23       | Nehemiah Barnes       | Bowling Green, OH (Dayspring Assembly of God) | 235   | 26.1  | 1  | 51%  |
+| 24       | Garrett McElroy       | Mustang, OK (United for Christ)               | 225   | 25    | 1  | 68%  |
+| 25       | Andrew Kumar          | Metuchen, NJ (Armor of God)                   | 225   | 25    |    | 71%  |
+| 26       | Corneal Lawrence      | Bowling Green, OH (Dayspring Assembly of God) | 200   | 22.2  | 1  | 67%  |
+| 27       | Kendal Davis          | Bowling Green, OH (Dayspring Assembly of God) | 195   | 21.7  |    | 71%  |
+| 28       | Aulora Sullivan       | Cedar Hill, TX (Thunder \'n Lightning)        | 190   | 21.1  |    | 71%  |
+| 29       | Daniel Boehling       | Wilmington, NC (New Hanover Church)           | 175   | 19.4  |    | 62%  |
+| 30       | Jotham Edwin          | Charlotte, NC (CICF Champions)                | 140   | 15.6  |    | 68%  |
+| 31       | Joshua Sullivan       | Cedar Hill, TX (Thunder \'n Lightning)        | 135   | 15    | 1  | 79%  |
+| 32       | Enoch Edwin           | Charlotte, NC (CICF Champions)                | 135   | 15    |    | 76%  |
+| 33       | Josh Hung             | Naperville, IL (Naperville (M))               | 95    | 10.6  |    | 71%  |
+| 34       | James Barney          | Shelby Township, MI (Heavenly Hotpockets)     | 90    | 10    |    | 82%  |
+| 35       | Shalom Ebenezer       | Charlotte, NC (CICF Champions)                | 80    | 8.9   |    | 77%  |
+| 36       | Jack Willson          | Wilmington, NC (New Hanover Church)           | 75    | 8.3   |    | 50%  |
+| 37       | Luke Santee           | Wilmington, NC (New Hanover Church)           | 60    | 6.7   |    | 100% |
+| 38       | Nicholas Nailor       | Cedar Hill, TX (Thunder \'n Lightning)        | 45    | 5     |    | 66%  |
+| 39       | Ella Willson          | Wilmington, NC (New Hanover Church)           | 40    | 4.4   |    | 100% |
+| 40       | Joel Ertzberger       | Wilmington, NC (New Hanover Church)           | 35    | 3.9   |    | 80%  |
+| 41       | John Hung             | Naperville, IL (Naperville (M))               | 25    | 2.8   |    | 44%  |
+| 42       | Esther Siony          | Naperville, IL (Naperville (D))               | 20    | 2.2   |    | 99%  |
+| **\*42** | Gabriel Parra         | Naperville, IL (Naperville (D))               | 20    | 2.2   |    | 50%  |
+| 43       | Elisha Hung           | Naperville, IL (Naperville (M))               | 10    | 1.1   |    | 99%  |
+| 44       | Zoey Fischer          | Mustang, OK (United for Christ)               | 0     |       |    |      |
+| **\*44** | Johanna James         | Metuchen, NJ (Armor of God)                   | 0     |       |    |      |
+| **\*44** | Roshan Padmanabhan    | Shelby Township, MI (Heavenly Hotpockets)     | 0     |       |    |      |
+| 45       | Elizabeth Siony       | Naperville, IL (Naperville (D))               | -5    | -.6   |    |      |
+| **\*45** | Abigail Koch          | Garland, TX (Guardians of the Gospel)         | -5    | -.6   |    |      |
+
+
+### Lavender (C)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                            | W/L   | Total | Avg   | QO | Q%  |
+|-----:|------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Bothell, WA (MENT to Declare His Glory)  | 6 / 3 | 1490  | 165.5 | 4  | 95% |
+| 2.0  | Mechanicsville, VA (Transformers)        | 6 / 3 | 1460  | 162.2 | 5  | 76% |
+| 3.0  | Naperville, IL (Naperville (S))          | 6 / 3 | 1405  | 156.1 | 8  | 77% |
+| 4.0  | Garland, TX (Keepers of the Command)     | 5 / 4 | 1455  | 161.6 | 9  | 77% |
+| 5.0  | Shelby Township, MI (John Three Sixteam) | 4 / 5 | 1415  | 157.2 | 2  | 86% |
+| 6.0  | Gahanna, OH (Fluffy Panda Quizzers)      | 4 / 5 | 1340  | 148.9 | 7  | 84% |
+| 7.0  | Apple Valley, MN (The Pentateuch)        | 4 / 5 | 1245  | 138.3 | 6  | 81% |
+| 8.0  | Bonifay, FL (Carmel Assembly)            | 4 / 5 | 1100  | 122.2 | 2  | 72% |
+| 9.0  | Metuchen, NJ (Metuchen Assembly of God)  | 3 / 6 | 1270  | 141.1 | 2  | 74% |
+| 10.0 | Fordyce, AR (Bible Bugs)                 | 3 / 6 | 1235  | 137.2 | 6  | 81% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                 | Team / Church                            | Total | Avg  | QO | Q%   |
+|---------:|-------------------------|------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Samuel Biruduganti      | Naperville, IL (Naperville (S))          | 990   | 110  | 4  | 81%  |
+| 2        | Elijah Chadwick         | Bothell, WA (MENT to Declare His Glory)  | 880   | 97.8 | 2  | 93%  |
+| 3        | Caleb Karthik           | Gahanna, OH (Fluffy Panda Quizzers)      | 780   | 86.7 | 6  | 89%  |
+| 4        | Ansley Hornaday         | Fordyce, AR (Bible Bugs)                 | 735   | 81.7 | 6  | 87%  |
+| 5        | Spencer Morrison        | Apple Valley, MN (The Pentateuch)        | 700   | 77.8 | 3  | 75%  |
+| 6        | Christian Steele        | Mechanicsville, VA (Transformers)        | 695   | 77.2 | 3  | 84%  |
+| 7        | Livingstone Iwuamadi    | Garland, TX (Keepers of the Command)     | 680   | 75.6 | 6  | 79%  |
+| 8        | Lucy Morency            | Shelby Township, MI (John Three Sixteam) | 680   | 75.6 |    | 97%  |
+| 9        | Abilash Balamanoranjith | Metuchen, NJ (Metuchen Assembly of God)  | 650   | 72.2 | 1  | 78%  |
+| 10       | Chidie Echefu           | Garland, TX (Keepers of the Command)     | 640   | 71.1 | 3  | 74%  |
+| 11       | Kenneth Stanley         | Mechanicsville, VA (Transformers)        | 515   | 57.2 | 2  | 76%  |
+| 12       | Jacey Pathri            | Gahanna, OH (Fluffy Panda Quizzers)      | 475   | 52.8 | 1  | 76%  |
+| 13       | Elijah Turner           | Fordyce, AR (Bible Bugs)                 | 440   | 48.9 |    | 70%  |
+| 14       | Lauren Pahl             | Apple Valley, MN (The Pentateuch)        | 405   | 45   | 3  | 85%  |
+| 15       | Luke Morency            | Shelby Township, MI (John Three Sixteam) | 385   | 42.8 |    | 95%  |
+| 16       | Brady Womble            | Bonifay, FL (Carmel Assembly)            | 380   | 42.2 |    | 84%  |
+| 17       | Tabitha Barney          | Shelby Township, MI (John Three Sixteam) | 355   | 39.4 | 2  | 75%  |
+| 18       | Maria Yevtushenko       | Bothell, WA (MENT to Declare His Glory)  | 355   | 39.4 |    | 96%  |
+| **\*18** | Joel Raj                | Metuchen, NJ (Metuchen Assembly of God)  | 355   | 39.4 |    | 77%  |
+| 19       | Timothy Harris          | Naperville, IL (Naperville (S))          | 330   | 36.7 | 4  | 70%  |
+| 20       | Talia Jarrell           | Bothell, WA (MENT to Declare His Glory)  | 255   | 28.3 | 2  | 96%  |
+| 21       | Micah Warren            | Bonifay, FL (Carmel Assembly)            | 205   | 22.8 | 1  | 77%  |
+| 22       | Abraham Johnson         | Metuchen, NJ (Metuchen Assembly of God)  | 195   | 21.7 | 1  | 66%  |
+| 23       | Brooks Adams            | Mechanicsville, VA (Transformers)        | 180   | 20   |    | 65%  |
+| 24       | Samuel Lee              | Bonifay, FL (Carmel Assembly)            | 175   | 19.4 |    | 56%  |
+| 25       | Kiersten Womble         | Bonifay, FL (Carmel Assembly)            | 145   | 16.1 |    | 57%  |
+| 26       | Macie Lynn Pugh         | Garland, TX (Keepers of the Command)     | 140   | 15.6 |    | 80%  |
+| 27       | Quinton Zepp            | Bonifay, FL (Carmel Assembly)            | 135   | 15   | 1  | 75%  |
+| 28       | Dorothy Sam             | Gahanna, OH (Fluffy Panda Quizzers)      | 85    | 9.4  |    | 90%  |
+| 29       | Cienna Field            | Apple Valley, MN (The Pentateuch)        | 80    | 8.9  |    | 100% |
+| **\*29** | Shekinah Biruduganti    | Naperville, IL (Naperville (S))          | 80    | 8.9  |    | 89%  |
+| 30       | Audriana Hirning        | Apple Valley, MN (The Pentateuch)        | 60    | 6.7  |    | 100% |
+| **\*30** | Rebecca Lee             | Bonifay, FL (Carmel Assembly)            | 60    | 6.7  |    | 100% |
+| 31       | Adalyn Hornaday         | Fordyce, AR (Bible Bugs)                 | 50    | 5.6  |    | 100% |
+| **\*31** | Reshma Solomon          | Metuchen, NJ (Metuchen Assembly of God)  | 50    | 5.6  |    | 75%  |
+| **\*31** | Kaleb Stanley           | Mechanicsville, VA (Transformers)        | 50    | 5.6  |    | 57%  |
+| 32       | Berkley Adams           | Mechanicsville, VA (Transformers)        | 20    | 2.2  |    | 100% |
+| **\*32** | Aaron Johnson           | Metuchen, NJ (Metuchen Assembly of God)  | 20    | 2.2  |    | 100% |
+| 33       | Jocelyn Martina         | Naperville, IL (Naperville (S))          | 10    | 1.1  |    | 99%  |
+| **\*33** | Anna Claire Collins     | Fordyce, AR (Bible Bugs)                 | 10    | 1.1  |    | 99%  |
+| 34       | Jayden Ramesh           | Garland, TX (Keepers of the Command)     | 0     |      |    |      |
+| **\*34** | Macie Pahl              | Apple Valley, MN (The Pentateuch)        | 0     |      |    |      |
+| **\*34** | Analise Exley           | Apple Valley, MN (The Pentateuch)        | 0     |      |    |      |
+| **\*34** | Braley Collins          | Fordyce, AR (Bible Bugs)                 | 0     |      |    |      |
+| **\*34** | Nathan Peter            | Bothell, WA (MENT to Declare His Glory)  | 0     |      |    |      |
+
+
+### Orange (S)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                 | W/L   | Total | Avg   | QO | Q%  |
+|-----:|-----------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Richmond Hill, NY (Bethlehem Church)          | 7 / 2 | 1400  | 155.5 | 6  | 75% |
+| 2.1  | Greenwood, IN (Grace Pardon the Interruption) | 6 / 3 | 1480  | 164.4 | 5  | 82% |
+| 3.0  | Askewville, NC (Bethel Assembly of God)       | 6 / 3 | 1385  | 153.9 | 6  | 75% |
+| 4.0  | Sparta, WI (Sparta Salt & Light)              | 5 / 4 | 1460  | 162.2 | 6  | 71% |
+| 5.0  | Leesburg, VA (SPY Dudes)                      | 4 / 5 | 1325  | 147.2 | 4  | 74% |
+| 6.0  | Great Bend, KS (Quizzards of Oz)              | 4 / 5 | 1225  | 136.1 |    | 69% |
+| 7.0  | Chandler, AZ (Overcomers)                     | 4 / 5 | 1185  | 131.7 | 1  | 78% |
+| 8.0  | Lexington, TN (Crosspoint Super Q\'s)         | 4 / 5 | 935   | 103.9 | 6  | 69% |
+| 9.0  | Marietta, GA (Anointed Ones)                  | 3 / 6 | 1225  | 136.1 | 7  | 81% |
+| 10.0 | Dublin, OH (RLC Diamonds)                     | 2 / 7 | 1110  | 123.3 | 3  | 82% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                 | Team / Church                                 | Total | Avg   | QO | Q%  |
+|---------:|-------------------------|-----------------------------------------------|------:|------:|---:|----:|
+| 1        | Sawyer Curtis           | Sparta, WI (Sparta Salt & Light)              | 920   | 102.2 | 4  | 81% |
+| 2        | Steve Joy               | Marietta, GA (Anointed Ones)                  | 820   | 91.1  | 6  | 77% |
+| 3        | Larissa Cox             | Greenwood, IN (Grace Pardon the Interruption) | 775   | 86.1  | 1  | 81% |
+| 4        | Austin Perry            | Askewville, NC (Bethel Assembly of God)       | 735   | 81.7  | 4  | 75% |
+| 5        | James Bozzay            | Leesburg, VA (SPY Dudes)                      | 705   | 78.3  | 1  | 85% |
+| 6        | Keren Koshy             | Chandler, AZ (Overcomers)                     | 640   | 71.1  |    | 85% |
+| 7        | Samuel Desilva          | Richmond Hill, NY (Bethlehem Church)          | 625   | 69.4  | 4  | 75% |
+| 8        | Luke Hillegass          | Lexington, TN (Crosspoint Super Q\'s)         | 590   | 65.6  | 4  | 69% |
+| 9        | Morgan MacKinney        | Great Bend, KS (Quizzards of Oz)              | 575   | 63.9  |    | 73% |
+| 10       | Lindsey Perry           | Askewville, NC (Bethel Assembly of God)       | 550   | 61.1  | 2  | 72% |
+| 11       | Joshua Gunasingh        | Marietta, GA (Anointed Ones)                  | 405   | 45    | 1  | 87% |
+| 12       | William Okyere          | Greenwood, IN (Grace Pardon the Interruption) | 390   | 43.3  | 3  | 95% |
+| 13       | Soren Pappas            | Dublin, OH (RLC Diamonds)                     | 380   | 42.2  |    | 89% |
+| 14       | Ella Krier              | Great Bend, KS (Quizzards of Oz)              | 350   | 38.9  |    | 80% |
+| 15       | Samantha Anselmo        | Richmond Hill, NY (Bethlehem Church)          | 345   | 38.3  |    | 83% |
+| 16       | Lucas Brunson           | Greenwood, IN (Grace Pardon the Interruption) | 315   | 35    | 1  | 71% |
+| 17       | Faith Poling            | Dublin, OH (RLC Diamonds)                     | 305   | 33.9  | 2  | 91% |
+| 18       | Jaden Jablonski         | Leesburg, VA (SPY Dudes)                      | 300   | 33.3  | 3  | 69% |
+| 19       | Jon Luc Jobson - Larkin | Richmond Hill, NY (Bethlehem Church)          | 300   | 33.3  | 2  | 74% |
+| 20       | Alissa Daniel           | Chandler, AZ (Overcomers)                     | 245   | 27.2  | 1  | 79% |
+| 21       | Thomas Hillegass        | Lexington, TN (Crosspoint Super Q\'s)         | 235   | 26.1  | 2  | 68% |
+| 22       | Aseda Essandoh          | Dublin, OH (RLC Diamonds)                     | 225   | 25    | 1  | 59% |
+| 23       | Isaac Helgerson         | Sparta, WI (Sparta Salt & Light)              | 225   | 25    |    | 80% |
+| 24       | Oye Essandoh            | Dublin, OH (RLC Diamonds)                     | 200   | 22.2  |    | 91% |
+| 25       | Cole MacKinney          | Great Bend, KS (Quizzards of Oz)              | 185   | 20.6  |    | 59% |
+| 26       | Gabriel Otchere         | Leesburg, VA (SPY Dudes)                      | 180   | 20    |    | 67% |
+| 27       | Joanna Thomas           | Chandler, AZ (Overcomers)                     | 160   | 17.8  |    | 65% |
+| 28       | Olivia Collins          | Sparta, WI (Sparta Salt & Light)              | 150   | 16.7  | 1  | 58% |
+| 29       | Bryan Melvin            | Chandler, AZ (Overcomers)                     | 140   | 15.6  |    | 74% |
+| 30       | Amaya Allard            | Sparta, WI (Sparta Salt & Light)              | 135   | 15    | 1  | 64% |
+| 31       | Taylor Jablonski        | Leesburg, VA (SPY Dudes)                      | 135   | 15    |    | 65% |
+| 32       | Olivia Bazemore         | Askewville, NC (Bethel Assembly of God)       | 105   | 11.7  |    | 92% |
+| **\*32** | Mady Hammeke            | Great Bend, KS (Quizzards of Oz)              | 105   | 11.7  |    | 72% |
+| 33       | Tyler Hutcherson        | Lexington, TN (Crosspoint Super Q\'s)         | 100   | 11.1  |    | 69% |
+| 34       | Cashmere Saez           | Richmond Hill, NY (Bethlehem Church)          | 65    | 7.2   |    | 73% |
+| 35       | Hannah Hancock          | Richmond Hill, NY (Bethlehem Church)          | 40    | 4.4   |    | 75% |
+| 36       | Ava Millard             | Sparta, WI (Sparta Salt & Light)              | 35    | 3.9   |    | 80% |
+| 37       | Samuel Chambuchi        | Richmond Hill, NY (Bethlehem Church)          | 20    | 2.2   |    | 50% |
+| 38       | Julien Jobson - Larkin  | Richmond Hill, NY (Bethlehem Church)          | 10    | 1.1   |    | 99% |
+| **\*38** | Alaina Johnson          | Lexington, TN (Crosspoint Super Q\'s)         | 10    | 1.1   |    | 99% |
+| **\*38** | Carson Sandberg         | Leesburg, VA (SPY Dudes)                      | 10    | 1.1   |    | 99% |
+| **\*38** | Lilly Burton            | Great Bend, KS (Quizzards of Oz)              | 10    | 1.1   |    | 50% |
+| 39       | Chase Cory              | Richmond Hill, NY (Bethlehem Church)          | 0     |       |    |     |
+| **\*39** | Shilo Karakkattu        | Chandler, AZ (Overcomers)                     | 0     |       |    |     |
+| **\*39** | Nathan Nimako           | Dublin, OH (RLC Diamonds)                     | 0     |       |    |     |
+| **\*39** | Alwin Stephen           | Marietta, GA (Anointed Ones)                  | 0     |       |    |     |
+| **\*39** | Crista Bues             | Leesburg, VA (SPY Dudes)                      | 0     |       |    |     |
+| **\*39** | Shane Lowers            | Askewville, NC (Bethel Assembly of God)       | 0     |       |    |     |
+| **\*39** | Elijah Helgerson        | Sparta, WI (Sparta Salt & Light)              | 0     |       |    |     |
+| **\*39** | Sophia Curtis           | Sparta, WI (Sparta Salt & Light)              | 0     |       |    |     |
+| **\*39** | Sienna Allard           | Sparta, WI (Sparta Salt & Light)              | 0     |       |    |     |
+
+
+### Pink (C)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                            | W/L   | Total | Avg   | QO | Q%  |
+|-----:|----------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Ozone Park, NY (Calvary Assembly of God)                 | 7 / 2 | 1540  | 171.1 | 2  | 78% |
+| 2.1  | Hibbing, MN (Abundant Life Church)                       | 6 / 3 | 1195  | 132.8 | 2  | 85% |
+| 3.0  | Beulah, ND (New Creatures)                               | 6 / 3 | 1470  | 163.3 | 5  | 90% |
+| 4.1  | Brookfield, WI (CSI: Christ\'s Sanctified Investigators) | 5 / 4 | 1315  | 146.1 | 4  | 85% |
+| 5.0  | Chandler, AZ (God Squad)                                 | 5 / 4 | 1375  | 152.8 | 4  | 76% |
+| 6.1  | Lakeville, MN (Celebration Church)                       | 4 / 5 | 1355  | 150.5 | 4  | 73% |
+| 7.0  | Burlington, MA (Mount Hope Christian Center)             | 4 / 5 | 1440  | 160   | 1  | 80% |
+| 8.1  | Georgetown, KY (Truth Seekers)                           | 3 / 6 | 805   | 89.4  | 4  | 64% |
+| 9.0  | Cambridge, MA (Pentecostal Tabernacle)                   | 3 / 6 | 1260  | 140   | 1  | 71% |
+| 10.0 | Billings, MT (Fourtify)                                  | 2 / 7 | 1160  | 128.9 | 4  | 72% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                                            | Total | Avg  | QO | Q%   |
+|---------:|------------------------|----------------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Kailyn Heath           | Lakeville, MN (Celebration Church)                       | 760   | 84.4 | 2  | 79%  |
+| **\*1**  | Joshua Simon           | Chandler, AZ (God Squad)                                 | 760   | 84.4 | 2  | 75%  |
+| 2        | Michelle Muddasu       | Burlington, MA (Mount Hope Christian Center)             | 740   | 82.2 | 1  | 90%  |
+| 3        | Hannah Farnsworth      | Hibbing, MN (Abundant Life Church)                       | 670   | 74.4 | 1  | 85%  |
+| 4        | Colson Sago            | Beulah, ND (New Creatures)                               | 665   | 73.9 | 2  | 93%  |
+| 5        | Brianna Bobbie         | Ozone Park, NY (Calvary Assembly of God)                 | 615   | 68.3 | 1  | 81%  |
+| 6        | Kaiden Taylor          | Billings, MT (Fourtify)                                  | 610   | 67.8 | 2  | 64%  |
+| 7        | Kristyn Bauer          | Beulah, ND (New Creatures)                               | 560   | 62.2 | 1  | 88%  |
+| 8        | Ariella Grimmond       | Ozone Park, NY (Calvary Assembly of God)                 | 550   | 61.1 |    | 85%  |
+| 9        | Daima Mashibe          | Georgetown, KY (Truth Seekers)                           | 520   | 57.8 | 3  | 66%  |
+| 10       | Anju Rajakumar         | Burlington, MA (Mount Hope Christian Center)             | 460   | 51.1 |    | 90%  |
+| 11       | Kaleb Noel             | Cambridge, MA (Pentecostal Tabernacle)                   | 440   | 48.9 |    | 89%  |
+| 12       | Jose O\'Brien          | Brookfield, WI (CSI: Christ\'s Sanctified Investigators) | 430   | 47.8 | 3  | 90%  |
+| 13       | Hannah Murray          | Brookfield, WI (CSI: Christ\'s Sanctified Investigators) | 400   | 44.4 |    | 94%  |
+| 14       | Tristan Heath          | Lakeville, MN (Celebration Church)                       | 345   | 38.3 | 2  | 68%  |
+| 15       | Jase Cooper            | Billings, MT (Fourtify)                                  | 330   | 36.7 | 1  | 76%  |
+| 16       | Isaac Farnsworth       | Hibbing, MN (Abundant Life Church)                       | 315   | 35   | 1  | 78%  |
+| 17       | Chiamara Beulah Odunze | Cambridge, MA (Pentecostal Tabernacle)                   | 305   | 33.9 |    | 67%  |
+| 18       | Abel Jacob             | Chandler, AZ (God Squad)                                 | 295   | 32.8 | 2  | 74%  |
+| 19       | Enzi Mashibe           | Georgetown, KY (Truth Seekers)                           | 285   | 31.7 | 1  | 62%  |
+| 20       | Gabe Ubert             | Brookfield, WI (CSI: Christ\'s Sanctified Investigators) | 280   | 31.1 |    | 74%  |
+| 21       | Gideon Legall          | Cambridge, MA (Pentecostal Tabernacle)                   | 275   | 30.6 | 1  | 67%  |
+| 22       | Shreya Ganesan         | Chandler, AZ (God Squad)                                 | 270   | 30   |    | 87%  |
+| 23       | Hayden Garrett         | Lakeville, MN (Celebration Church)                       | 250   | 27.8 |    | 72%  |
+| 24       | Aubryn Sago            | Beulah, ND (New Creatures)                               | 245   | 27.2 | 2  | 89%  |
+| 25       | Rolph Presume          | Cambridge, MA (Pentecostal Tabernacle)                   | 240   | 26.7 |    | 70%  |
+| 26       | Hailey Lane            | Billings, MT (Fourtify)                                  | 220   | 24.4 | 1  | 80%  |
+| 27       | Rebeca Jemmott Thomas  | Ozone Park, NY (Calvary Assembly of God)                 | 215   | 23.9 | 1  | 70%  |
+| 28       | Abigail Farnsworth     | Hibbing, MN (Abundant Life Church)                       | 210   | 23.3 |    | 100% |
+| 29       | Eli Horn               | Brookfield, WI (CSI: Christ\'s Sanctified Investigators) | 205   | 22.8 | 1  | 81%  |
+| 30       | Jafet Jemmott Thomas   | Ozone Park, NY (Calvary Assembly of God)                 | 160   | 17.8 |    | 76%  |
+| 31       | Jordyn Weir            | Burlington, MA (Mount Hope Christian Center)             | 135   | 15   |    | 71%  |
+| 32       | Hannah Titus           | Burlington, MA (Mount Hope Christian Center)             | 80    | 8.9  |    | 100% |
+| 33       | Angel Charles          | Chandler, AZ (God Squad)                                 | 60    | 6.7  |    | 100% |
+| 34       | Mayope Faleye          | Burlington, MA (Mount Hope Christian Center)             | 25    | 2.8  |    | 44%  |
+| 35       | Kaylee Tidaback        | Georgetown, KY (Truth Seekers)                           | 0     |      |    |      |
+| **\*35** | Himaya Mashibe         | Georgetown, KY (Truth Seekers)                           | 0     |      |    |      |
+| **\*35** | Rachel Caudill         | Georgetown, KY (Truth Seekers)                           | 0     |      |    |      |
+| **\*35** | Elijah Caudill         | Georgetown, KY (Truth Seekers)                           | 0     |      |    |      |
+| **\*35** | Audrey Caudill         | Georgetown, KY (Truth Seekers)                           | 0     |      |    |      |
+| **\*35** | Shayda Morgan          | Billings, MT (Fourtify)                                  | 0     |      |    |      |
+| **\*35** | Annalisa Skelly        | Ozone Park, NY (Calvary Assembly of God)                 | 0     |      |    |      |
+| **\*35** | Leanna Ramdial         | Ozone Park, NY (Calvary Assembly of God)                 | 0     |      |    |      |
+| 36       | Ephraim Kurian         | Chandler, AZ (God Squad)                                 | -10   | -1.1 |    |      |
+
+
+### Silver (C)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                            | W/L   | Total | Avg   | QO | Q%  |
+|-----:|------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Bloomington, MN (Bread of Life Church)   | 7 / 2 | 1610  | 178.9 | 9  | 78% |
+| 2.0  | Rockford, IL (Life Church)               | 5 / 4 | 1480  | 164.4 | 8  | 84% |
+| 3.0  | Indianapolis, IN (The Masterminds)       | 5 / 4 | 1280  | 142.2 | 5  | 72% |
+| 4.0  | Minot, ND (Legacy Kids)                  | 5 / 4 | 1240  | 137.8 | 2  | 77% |
+| 5.0  | Cordova, TN (Word Wise Quiz Kids)        | 5 / 4 | 1230  | 136.7 | 6  | 83% |
+| 6.0  | Phoenix, AZ (Hyped 4 Christ)             | 5 / 4 | 1215  | 135   | 5  | 76% |
+| 7.0  | Lees Summit, MO (Crown Pointe Church)    | 5 / 4 | 1200  | 133.3 | 2  | 63% |
+| 8.0  | Racine, WI (Anointed Avengers for Jesus) | 4 / 5 | 1350  | 150   | 2  | 77% |
+| 9.0  | Concord, NC (The Defenders)              | 2 / 7 | 1050  | 116.7 | 4  | 66% |
+| 10.0 | Painesville, OH (Truth Defenders)        | 2 / 7 | 890   | 98.9  | 5  | 77% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                            | Total | Avg   | QO | Q%   |
+|---------:|----------------------|------------------------------------------|------:|------:|---:|-----:|
+| 1        | Benjamin Antony      | Cordova, TN (Word Wise Quiz Kids)        | 955   | 106.1 | 5  | 90%  |
+| 2        | Andrey Dmitriev      | Rockford, IL (Life Church)               | 840   | 93.3  | 4  | 83%  |
+| 3        | Haddie Brookbank     | Lees Summit, MO (Crown Pointe Church)    | 745   | 82.8  | 1  | 77%  |
+| 4        | Matthew Vengal       | Bloomington, MN (Bread of Life Church)   | 670   | 74.4  | 5  | 79%  |
+| 5        | Justin Klco          | Painesville, OH (Truth Defenders)        | 665   | 73.9  | 4  | 74%  |
+| 6        | Sonika Ramala        | Bloomington, MN (Bread of Life Church)   | 585   | 65    | 2  | 76%  |
+| 7        | Cian Van Offeren     | Racine, WI (Anointed Avengers for Jesus) | 565   | 62.8  |    | 71%  |
+| 8        | Erin Kihiu           | Indianapolis, IN (The Masterminds)       | 555   | 61.7  |    | 78%  |
+| 9        | Ijeoma Ilochonwu     | Rockford, IL (Life Church)               | 510   | 56.7  | 4  | 80%  |
+| 10       | Caleb Senthil        | Concord, NC (The Defenders)              | 500   | 55.6  | 2  | 83%  |
+| 11       | Anna Dangerfield     | Minot, ND (Legacy Kids)                  | 495   | 55    |    | 75%  |
+| 12       | Landon Dissmore      | Racine, WI (Anointed Avengers for Jesus) | 475   | 52.8  | 1  | 81%  |
+| 13       | Ethan Kihiu          | Indianapolis, IN (The Masterminds)       | 465   | 51.7  | 3  | 63%  |
+| 14       | Cade Muscari         | Phoenix, AZ (Hyped 4 Christ)             | 390   | 43.3  | 4  | 79%  |
+| 15       | Seth Hudson          | Concord, NC (The Defenders)              | 335   | 37.2  | 1  | 67%  |
+| 16       | Jayva McKibben       | Minot, ND (Legacy Kids)                  | 330   | 36.7  |    | 86%  |
+| 17       | Jones Kanjirkatte    | Bloomington, MN (Bread of Life Church)   | 325   | 36.1  | 2  | 79%  |
+| 18       | Isaiah Porter        | Phoenix, AZ (Hyped 4 Christ)             | 315   | 35    |    | 75%  |
+| 19       | Riley Biek           | Phoenix, AZ (Hyped 4 Christ)             | 300   | 33.3  | 1  | 71%  |
+| 20       | Briggs McKibben      | Minot, ND (Legacy Kids)                  | 280   | 31.1  | 1  | 93%  |
+| 21       | Kaymi Thompson       | Indianapolis, IN (The Masterminds)       | 260   | 28.9  | 2  | 74%  |
+| 22       | Keira Rogers         | Painesville, OH (Truth Defenders)        | 225   | 25    | 1  | 83%  |
+| 23       | London Lovelace      | Lees Summit, MO (Crown Pointe Church)    | 210   | 23.3  | 1  | 50%  |
+| 24       | Logan MacPherson     | Phoenix, AZ (Hyped 4 Christ)             | 210   | 23.3  |    | 72%  |
+| 25       | Miles Pierce         | Concord, NC (The Defenders)              | 205   | 22.8  | 1  | 57%  |
+| 26       | Savanna Barber       | Lees Summit, MO (Crown Pointe Church)    | 150   | 16.7  |    | 68%  |
+| 27       | Elizabeth Shelton    | Cordova, TN (Word Wise Quiz Kids)        | 140   | 15.6  | 1  | 63%  |
+| 28       | Ethan Dangerfield    | Minot, ND (Legacy Kids)                  | 135   | 15    | 1  | 61%  |
+| 29       | Sam Schneidau        | Cordova, TN (Word Wise Quiz Kids)        | 120   | 13.3  |    | 100% |
+| 30       | Emeka Ilochonwu      | Rockford, IL (Life Church)               | 110   | 12.2  |    | 100% |
+| 31       | Noah Albarren        | Racine, WI (Anointed Avengers for Jesus) | 95    | 10.6  | 1  | 63%  |
+| 32       | George Hoelzel       | Lees Summit, MO (Crown Pointe Church)    | 95    | 10.6  |    | 53%  |
+| 33       | Savannah Albarren    | Racine, WI (Anointed Avengers for Jesus) | 85    | 9.4   |    | 77%  |
+| 34       | Cheyanne Barrios     | Racine, WI (Anointed Avengers for Jesus) | 80    | 8.9   |    | 100% |
+| 35       | Trinidy Calvary      | Racine, WI (Anointed Avengers for Jesus) | 50    | 5.6   |    | 100% |
+| 36       | Hannah Mathew        | Bloomington, MN (Bread of Life Church)   | 30    | 3.3   |    | 67%  |
+| 37       | Obi Ilochonwu        | Rockford, IL (Life Church)               | 20    | 2.2   |    | 100% |
+| 38       | Eleena Shelton       | Cordova, TN (Word Wise Quiz Kids)        | 15    | 1.7   |    | 75%  |
+| 39       | Megan Pierce         | Concord, NC (The Defenders)              | 10    | 1.1   |    | 40%  |
+| 40       | Johan Vengal         | Bloomington, MN (Bread of Life Church)   | 0     |       |    |      |
+| **\*40** | Nathan Peters        | Bloomington, MN (Bread of Life Church)   | 0     |       |    |      |
+| **\*40** | Arpita Bittu Jampana | Bloomington, MN (Bread of Life Church)   | 0     |       |    |      |
+| **\*40** | Audrey Inskeep       | Indianapolis, IN (The Masterminds)       | 0     |       |    |      |
+
+
+### Tan (S)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                | W/L   | Total | Avg   | QO | Q%  |
+|-----:|----------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Bristow, VA (Chapel Springs Assembly of God) | 6 / 3 | 1615  | 179.4 | 9  | 82% |
+| 2.0  | Bellevue, WA (Neighborhood Church)           | 5 / 4 | 1380  | 153.3 | 3  | 83% |
+| 3.0  | Two Rivers, WI (Renew Church)                | 5 / 4 | 1345  | 149.4 | 5  | 76% |
+| 4.0  | Fruitland Park, FL (Triple Truth)            | 5 / 4 | 1335  | 148.3 | 7  | 76% |
+| 5.0  | San Diego, CA (Living Water Bible Church)    | 5 / 4 | 1280  | 142.2 | 4  | 81% |
+| 6.0  | Lakeland, FL (Victory Church)                | 5 / 4 | 1260  | 140   | 6  | 75% |
+| 7.0  | Wesley Chapel, FL (Life Church)              | 4 / 5 | 1255  | 139.4 | 5  | 78% |
+| 8.0  | Fenton, MI (The Freedom Center)              | 4 / 5 | 1225  | 136.1 | 6  | 85% |
+| 9.0  | Jenks, OK (Newspring Assembly of God)        | 4 / 5 | 1125  | 125   | 2  | 83% |
+| 10.0 | Tucson, AZ (The Interrupters)                | 2 / 7 | 905   | 100.5 | 8  | 66% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                                | Total | Avg   | QO | Q%   |
+|---------:|---------------------|----------------------------------------------|------:|------:|---:|-----:|
+| 1        | Josiah Smigielski   | Fenton, MI (The Freedom Center)              | 1075  | 119.4 | 6  | 86%  |
+| 2        | Andrea Mason        | Bristow, VA (Chapel Springs Assembly of God) | 865   | 96.1  | 5  | 75%  |
+| 3        | Gianna LoGiudice    | Fruitland Park, FL (Triple Truth)            | 810   | 90    | 6  | 80%  |
+| 4        | Jonathan An         | San Diego, CA (Living Water Bible Church)    | 755   | 83.9  | 3  | 78%  |
+| 5        | trinity hills       | Wesley Chapel, FL (Life Church)              | 735   | 81.7  | 3  | 75%  |
+| 6        | Temaria Murphy      | Lakeland, FL (Victory Church)                | 645   | 71.7  | 3  | 67%  |
+| 7        | Josh Luckow         | Two Rivers, WI (Renew Church)                | 600   | 66.7  | 3  | 74%  |
+| 8        | Aceline Owusu       | Bristow, VA (Chapel Springs Assembly of God) | 545   | 60.6  | 4  | 87%  |
+| 9        | Addison Beasley     | Jenks, OK (Newspring Assembly of God)        | 520   | 57.8  |    | 100% |
+| 10       | Edie Thompson       | Fruitland Park, FL (Triple Truth)            | 470   | 52.2  | 1  | 77%  |
+| 11       | Isabella Kirchon    | Lakeland, FL (Victory Church)                | 435   | 48.3  | 3  | 86%  |
+| 12       | Myah Berkey         | Tucson, AZ (The Interrupters)                | 430   | 47.8  | 2  | 61%  |
+| 13       | Mason Berkey        | Tucson, AZ (The Interrupters)                | 415   | 46.1  | 6  | 70%  |
+| 14       | Drew Malchek        | Two Rivers, WI (Renew Church)                | 415   | 46.1  |    | 68%  |
+| 15       | Lucky Bandaru       | Bellevue, WA (Neighborhood Church)           | 370   | 41.1  |    | 76%  |
+| **\*15** | Ashlin Vanderslice  | Jenks, OK (Newspring Assembly of God)        | 370   | 41.1  |    | 76%  |
+| 16       | Hannah Liu          | San Diego, CA (Living Water Bible Church)    | 345   | 38.3  | 1  | 91%  |
+| 17       | jonah karydis       | Wesley Chapel, FL (Life Church)              | 335   | 37.2  | 2  | 83%  |
+| 18       | Chloe Siebold       | Two Rivers, WI (Renew Church)                | 330   | 36.7  | 2  | 85%  |
+| 19       | Yatin Mokana        | Bellevue, WA (Neighborhood Church)           | 325   | 36.1  |    | 81%  |
+| 20       | Ayushi Vara         | Bellevue, WA (Neighborhood Church)           | 285   | 31.7  | 2  | 85%  |
+| 21       | Abigail Cothran     | Jenks, OK (Newspring Assembly of God)        | 235   | 26.1  | 2  | 81%  |
+| 22       | Daniel Benston      | Bellevue, WA (Neighborhood Church)           | 210   | 23.3  |    | 90%  |
+| 23       | Rylan Hance         | Lakeland, FL (Victory Church)                | 180   | 20    |    | 73%  |
+| 24       | Gavin Burton        | Fenton, MI (The Freedom Center)              | 150   | 16.7  |    | 81%  |
+| 25       | Lexie McKennett     | Bristow, VA (Chapel Springs Assembly of God) | 140   | 15.6  |    | 100% |
+| 26       | noah ringeisen      | Wesley Chapel, FL (Life Church)              | 135   | 15    |    | 73%  |
+| 27       | Adam Theriault      | Bellevue, WA (Neighborhood Church)           | 125   | 13.9  | 1  | 87%  |
+| 28       | Daniel Liu          | San Diego, CA (Living Water Bible Church)    | 105   | 11.7  |    | 86%  |
+| 29       | Janet An            | San Diego, CA (Living Water Bible Church)    | 80    | 8.9   |    | 55%  |
+| 30       | Zoe Nerquaye-Tetteh | Bristow, VA (Chapel Springs Assembly of God) | 65    | 7.2   |    | 80%  |
+| 31       | Briella LoGiudice   | Fruitland Park, FL (Triple Truth)            | 55    | 6.1   |    | 56%  |
+| 32       | wesley kinsey       | Wesley Chapel, FL (Life Church)              | 50    | 5.6   |    | 100% |
+| **\*32** | Nicholas Ortega     | Tucson, AZ (The Interrupters)                | 50    | 5.6   |    | 71%  |
+| 33       | Talitha Konda       | Bellevue, WA (Neighborhood Church)           | 40    | 4.4   |    | 100% |
+| 34       | Elizabeth Larson    | Bellevue, WA (Neighborhood Church)           | 25    | 2.8   |    | 75%  |
+| 35       | Kaleb Ortega        | Tucson, AZ (The Interrupters)                | 10    | 1.1   |    | 99%  |
+| **\*35** | Jenna Lopez         | Tucson, AZ (The Interrupters)                | 10    | 1.1   |    | 99%  |
+| 36       | Tim Liu             | San Diego, CA (Living Water Bible Church)    | 0     |       |    | 50%  |
+| **\*36** | Belva Fianko        | Bristow, VA (Chapel Springs Assembly of God) | 0     |       |    |      |
+| **\*36** | Hayden Wright       | Lakeland, FL (Victory Church)                | 0     |       |    |      |
+| 37       | Wesley Burbank      | Tucson, AZ (The Interrupters)                | -5    | -.6   |    |      |
+
+
+### Yellow (S)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #    | Team / Church                                | W/L   | Total | Avg   | QO | Q%  |
+|-----:|----------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0  | Roswell, GA (Georgia Christian Assembly)     | 8 / 1 | 1805  | 200.5 | 4  | 85% |
+| 2.1  | Mabelvale, AR (Buzz Hogs)                    | 7 / 2 | 1490  | 165.5 | 7  | 87% |
+| 3.0  | Las Vegas, NV (The Champion Center)          | 7 / 2 | 1540  | 171.1 | 5  | 80% |
+| 4.1  | Fort Lauderdale, FL (CLC Messengers of Hope) | 6 / 3 | 1655  | 183.9 | 13 | 94% |
+| 5.0  | Bothell, WA (SOLID)                          | 6 / 3 | 1765  | 196.1 | 8  | 95% |
+| 6.0  | Kailua, HI (Kailua Assembly of God)          | 4 / 5 | 1195  | 132.8 | 5  | 78% |
+| 7.0  | Shreveport, LA (Shreveport Community Church) | 3 / 6 | 1050  | 116.7 | 1  | 68% |
+| 8.1  | Somerset, KY (Quiz Ninjas)                   | 2 / 7 | 1115  | 123.9 | 8  | 84% |
+| 9.0  | Colorado Springs, CO (Radiant Church)        | 2 / 7 | 905   | 100.5 | 2  | 79% |
+| 10.0 | Seminole, TX (First Assembly of God)         | 0 / 9 | 495   | 55    |    | 75% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                                | Total | Avg  | QO | Q%   |
+|---------:|----------------------|----------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Josiah Minick        | Mabelvale, AR (Buzz Hogs)                    | 1170  | 130  | 7  | 85%  |
+| 2        | Steffi Padmanaban    | Fort Lauderdale, FL (CLC Messengers of Hope) | 1035  | 115  | 4  | 96%  |
+| 3        | Olivia Moses         | Bothell, WA (SOLID)                          | 890   | 98.9 | 3  | 90%  |
+| 4        | Caroline Tew         | Shreveport, LA (Shreveport Community Church) | 805   | 89.4 | 1  | 71%  |
+| 5        | Brady Hansen         | Somerset, KY (Quiz Ninjas)                   | 745   | 82.8 | 6  | 79%  |
+| 6        | Simeon Cheeran       | Roswell, GA (Georgia Christian Assembly)     | 730   | 81.1 | 1  | 82%  |
+| 7        | Savonah Jakel        | Kailua, HI (Kailua Assembly of God)          | 655   | 72.8 | 3  | 87%  |
+| 8        | Jeremiah Moses Raj   | Roswell, GA (Georgia Christian Assembly)     | 655   | 72.8 |    | 90%  |
+| 9        | Elijah Hicks         | Las Vegas, NV (The Champion Center)          | 630   | 70   |    | 80%  |
+| 10       | Victoria Okoh        | Fort Lauderdale, FL (CLC Messengers of Hope) | 620   | 68.9 | 9  | 93%  |
+| 11       | Dominick Forbus      | Las Vegas, NV (The Champion Center)          | 580   | 64.4 | 3  | 82%  |
+| 12       | Daniel Rickman       | Colorado Springs, CO (Radiant Church)        | 505   | 56.1 | 2  | 71%  |
+| 13       | Daniel Li            | Bothell, WA (SOLID)                          | 475   | 52.8 | 4  | 98%  |
+| 14       | Rebecca Simjan       | Roswell, GA (Georgia Christian Assembly)     | 420   | 46.7 | 3  | 84%  |
+| 15       | Gavin Lewis          | Somerset, KY (Quiz Ninjas)                   | 355   | 39.4 | 2  | 91%  |
+| 16       | Sebastian Jakel      | Kailua, HI (Kailua Assembly of God)          | 320   | 35.6 | 2  | 73%  |
+| 17       | Leiah Gries          | Bothell, WA (SOLID)                          | 310   | 34.4 | 1  | 96%  |
+| 18       | Josiah Morales       | Las Vegas, NV (The Champion Center)          | 260   | 28.9 | 1  | 82%  |
+| 19       | Elijah Lapusan       | Seminole, TX (First Assembly of God)         | 255   | 28.3 |    | 61%  |
+| 20       | Kamryn LeBlanc       | Seminole, TX (First Assembly of God)         | 240   | 26.7 |    | 93%  |
+| 21       | Sarah Bradley        | Colorado Springs, CO (Radiant Church)        | 215   | 23.9 |    | 100% |
+| 22       | Maggie Baez          | Mabelvale, AR (Buzz Hogs)                    | 200   | 22.2 |    | 95%  |
+| 23       | Isabelle Erickson    | Shreveport, LA (Shreveport Community Church) | 145   | 16.1 |    | 72%  |
+| 24       | Grace Parnell        | Mabelvale, AR (Buzz Hogs)                    | 125   | 13.9 |    | 82%  |
+| 25       | Kahanuola Kanno      | Kailua, HI (Kailua Assembly of God)          | 105   | 11.7 |    | 81%  |
+| 26       | Emaline Rickman      | Colorado Springs, CO (Radiant Church)        | 100   | 11.1 |    | 100% |
+| 27       | Ivanka Chadwick      | Bothell, WA (SOLID)                          | 90    | 10   |    | 100% |
+| 28       | Kai Betsinger        | Kailua, HI (Kailua Assembly of God)          | 85    | 9.4  |    | 67%  |
+| 29       | Eli Anderson         | Colorado Springs, CO (Radiant Church)        | 80    | 8.9  |    | 100% |
+| 30       | Daniel Hayes         | Las Vegas, NV (The Champion Center)          | 70    | 7.8  | 1  | 67%  |
+| 31       | Jonathan Paredes     | Shreveport, LA (Shreveport Community Church) | 45    | 5    |    | 58%  |
+| 32       | Arielle Erickson     | Shreveport, LA (Shreveport Community Church) | 25    | 2.8  |    | 50%  |
+| 33       | London Hamilton      | Shreveport, LA (Shreveport Community Church) | 20    | 2.2  |    | 100% |
+| **\*33** | McKinley Lewis       | Somerset, KY (Quiz Ninjas)                   | 20    | 2.2  |    | 100% |
+| **\*33** | Jax Betsinger        | Kailua, HI (Kailua Assembly of God)          | 20    | 2.2  |    | 60%  |
+| 34       | Joelle Lo            | Kailua, HI (Kailua Assembly of God)          | 10    | 1.1  |    | 99%  |
+| **\*34** | Aubrey McNeely       | Shreveport, LA (Shreveport Community Church) | 10    | 1.1  |    | 99%  |
+| 35       | Emma Anderson        | Colorado Springs, CO (Radiant Church)        | 5     | .6   |    | 50%  |
+| 36       | Jahzi Strickland     | Shreveport, LA (Shreveport Community Church) | 0     |      |    | 40%  |
+| **\*36** | Kynzee LeBlanc       | Seminole, TX (First Assembly of God)         | 0     |      |    |      |
+| **\*36** | Cherish Page         | Mabelvale, AR (Buzz Hogs)                    | 0     |      |    |      |
+| **\*36** | Bruiyensen Gracelien | Fort Lauderdale, FL (CLC Messengers of Hope) | 0     |      |    |      |
+| **\*36** | Widly Eltine         | Fort Lauderdale, FL (CLC Messengers of Hope) | 0     |      |    |      |
+| **\*36** | Summer Lewis         | Somerset, KY (Quiz Ninjas)                   | 0     |      |    |      |

--- a/_pages/jbq/2020/index.md
+++ b/_pages/jbq/2020/index.md
@@ -1,12 +1,12 @@
 ---
 layout: page
-title: "2022 JBQ Season"
-permalink: /jbq/2022/
+title: "2020 JBQ Season"
+permalink: /jbq/2020/
 date: "2023-04-10"
 ---
 
 ## Nationals
-<a href="{% link _pages/jbq/2022/nationals.md %}" class="button is-primary">National Finals</a>
+National Festival was cancelled this year due to the COVID-19 pandemic.
 
 ## Tournaments
 If you have results, please email <hello@biblequiz.com>.

--- a/_pages/jbq/2021/index.md
+++ b/_pages/jbq/2021/index.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: "2021 JBQ Season"
+permalink: /jbq/2021/
 date: "2023-04-10"
 ---
 

--- a/_pages/jbq/2021/nationals.md
+++ b/_pages/jbq/2021/nationals.md
@@ -1,7 +1,8 @@
 ---
 layout: page
 title: "2021 National Festival: Kansas City, MO"
-date: "2023-04-22"
+permalink: /jbq/2021/nationals/
+date: "2021-06-12"
 toc_title: Results
 menubar_toc: true
 ---
@@ -547,7 +548,7 @@ menubar_toc: true
 | **\*34** | Isabella Darko       | Garland, TX (Keepers of the Command)            | 0     |       |    |      |
 
 
-### Lavendar
+### Lavender
 
 #### Teams
 

--- a/_pages/jbq/2022/nationals.md
+++ b/_pages/jbq/2022/nationals.md
@@ -1,7 +1,8 @@
 ---
 layout: page
 title: "2022 National Festival: Oak Creek, WI"
-date: "2023-04-22"
+permalink: /jbq/2022/nationals/
+date: "2022-06-11"
 toc_title: Results
 menubar_toc: true
 ---
@@ -630,7 +631,7 @@ menubar_toc: true
 | **\*35** | Benjamin Adu-gyamfi     | Houston, TX (The Chosen Warriors)           | -5    | -.6   |    |      |
 
 
-### Lavendar
+### Lavender
 
 #### Teams
 

--- a/_pages/jbq/index.md
+++ b/_pages/jbq/index.md
@@ -16,3 +16,19 @@ toc_title: Decades
 ## 2020s
 * [2022]({% link _pages/jbq/2022/index.md %})
 * [2021]({% link _pages/jbq/2021/index.md %})
+* [2020]({% link _pages/jbq/2020/index.md %})
+
+## 2010s
+* [2019]({% link _pages/jbq/2019/index.md %})
+* [2018]({% link _pages/jbq/2018/index.md %})
+* [2017]({% link _pages/jbq/2017/index.md %})
+* [2016]({% link _pages/jbq/2016/index.md %})
+* [2015]({% link _pages/jbq/2015/index.md %})
+* [2014]({% link _pages/jbq/2014/index.md %})
+* [2013]({% link _pages/jbq/2013/index.md %})
+* [2012]({% link _pages/jbq/2012/index.md %})
+* [2011]({% link _pages/jbq/2011/index.md %})
+* [2010]({% link _pages/jbq/2011/index.md %})
+
+## 2000s
+* [2009]({% link _pages/jbq/2009/index.md %})


### PR DESCRIPTION
1. Copy the remaining JBQ Nationals from jbq.org/epost to biblequiz.com
2. Add `Gemfile.lock` to `.gitignore`