### PR TITLE
Expand Search to include pages

### DIFF
--- a/_pages/search.html
+++ b/_pages/search.html
@@ -7,7 +7,7 @@ permalink: /search/
 <div id="search-container">
     <div class="field has-addons">
         <div class="control has-icons-left is-expanded">
-          <input id="search-input" class="input" type="text" placeholder="Search Blog ...">
+          <input id="search-input" class="input" type="text" placeholder="Search Site ...">
           <span class="icon is-small is-left">
             <i class="fas fa-search"></i>
           </span>

--- a/search.json
+++ b/search.json
@@ -8,6 +8,14 @@
       "url"      : "{{ site.baseurl }}{{ post.url }}",
       "category" : "{{ post.categories | join: ', '}}",
       "date"     : "{{ post.date | date: "%B %e, %Y" }}"
-    } {% unless forloop.last %},{% endunless %}
+    },
+  {% endfor %}
+  {% for page in site.pages %}{% if page.title and page.title != "" and page.title != "Blog" and page.title != "Search" %}{% assign title = page.title | escape %}{% else %}{% continue %}{%endif%}
+    {% unless forloop.first %},{% endunless %}
+    {
+      "title"    : "{{ title }}",
+      "url"      : "{{ site.baseurl }}{{ page.url }}"{% if page.date %},
+      "date"     : "{{ page.date | date: "%B %e, %Y" }}"{% endif %}
+    }
   {% endfor %}
 ]

--- a/search.json
+++ b/search.json
@@ -10,7 +10,7 @@
       "date"     : "{{ post.date | date: "%B %e, %Y" }}"
     },
   {% endfor %}
-  {% for page in site.pages %}{% if page.title and page.title != "" and page.title != "Blog" and page.title != "Search" %}{% assign title = page.title | escape %}{% else %}{% continue %}{%endif%}
+  {% for page in site.pages %}{% if page.title and page.title != "" and page.title != "Blog" and page.title != "Search" and page.url != "/admin/" %}{% assign title = page.title | escape %}{% else %}{% continue %}{%endif%}
     {% unless forloop.first %},{% endunless %}
     {
       "title"    : "{{ title }}",


### PR DESCRIPTION
The `/search` page only searches blog posts, rather than the entire site. This change expands the scope of the search.