### PR TITLE
Add missing teams/individuals missed during initial JBQ.org import

### DIFF
--- a/_data/imported/2019.yml
+++ b/_data/imported/2019.yml
@@ -27,6 +27,11 @@ jbq:
     scope: district
     scopeLabel: North Texas
     scoresLink: /jbq/2019/districts/north-texas/
+  - name: "2019 Oklahoma District Finals"
+    scope: district
+    scopeLabel: Oklahoma
+    dates: Feb 23, 2019
+    scoresLink: /jbq/2019/districts/oklahoma/
   - name: "2019 Peninsular-Florida District Finals"
     scope: district
     scopeLabel: Peninsular-Florida

--- a/_data/imported/2020.yml
+++ b/_data/imported/2020.yml
@@ -1,20 +1,25 @@
 jbq:
   districtFinals:
+  - name: "2020 Georgia District Finals"
+    scope: district
+    scopeLabel: Georgia
+    scoresLink: /jbq/2020/districts/georgia/
+    dates: Mar 7, 2020
   - name: "2020 North Texas District Finals"
     scope: district
     scopeLabel: North Texas
     scoresLink: /jbq/2020/districts/north-texas/
+    dates: Mar 7, 2020
+  - name: "2020 Peninsular-Florida District Finals"
+    scope: district
+    scopeLabel: Peninsular-Florida
+    scoresLink: /jbq/2020/districts/peninsular-florida/
     dates: Mar 7, 2020
   - name: "2020 Oklahoma District Finals"
     scope: district
     scopeLabel: Oklahoma
     scoresLink: /jbq/2020/districts/oklahoma/
     dates: Feb 29, 2020
-  - name: "2020 Peninsular-Florida District Finals"
-    scope: district
-    scopeLabel: Peninsular-Florida
-    scoresLink: /jbq/2020/districts/peninsular-florida/
-    dates: Mar 7, 2020
   - name: "2020 Pennsylvania-Delaware District Finals"
     scope: district
     scopeLabel: Pennsylvania-Delaware

--- a/_data/imported/2021.yml
+++ b/_data/imported/2021.yml
@@ -28,6 +28,11 @@ jbq:
     scopeLabel: North Texas
     scoresLink: /jbq/2021/districts/north-texas/
     dates: Mar 13 & 27, 2021
+  - name: "2021 Northwest District Finals"
+    scope: district
+    scopeLabel: Northwest
+    scoresLink: /jbq/2021/districts/northwest/
+    dates: May 2, 2021
   - name: "2021 Oklahoma District Finals"
     scope: district
     scopeLabel: Oklahoma
@@ -50,6 +55,10 @@ jbq:
     locationCity: Various Locations
     dates: Mar 13, 2021
     scoresLink: /jbq/2022/tournaments/carolina-classic/
+  - name: "2021 Corona Classic"
+    scope: tournament
+    dates: Jan 31, 2021
+    scoresLink: /jbq/2021/tournaments/corona-classic/
   - name: "Snow Bowl"
     scope: tournament
     dates: Dec 5, 2020
@@ -70,6 +79,12 @@ tbq:
     scope: tournament
     dates: Mar 7, 2021
     scoresLink: /history/2021/tournaments/windy-city-classic/
+  - name: John Crabtree
+    scope: tournament
+    locationName: First Assembly of God
+    locationCity: Normal, IL
+    dates: Feb 26 - 27, 2021
+    scoresLink: /jbq/2021/tournaments/john-crabtree/
   - name: "Mid-Winter Classic"
     dates: Jan 16, 2021
     scoresLink: /history/2021/tournaments/mid-winter-classic/

--- a/_data/imported/2022.yml
+++ b/_data/imported/2022.yml
@@ -30,6 +30,11 @@ jbq:
     scopeLabel: Arkansas
     scoresLink: /jbq/2022/districts/arkansas/
     dates: Apr 2, 2022
+  - name: "2022 Georgia District Finals"
+    scope: district
+    scopeLabel: Georgia
+    scoresLink: /jbq/2022/districts/georgia/
+    dates: Mar 5, 2023
   - name: "2022 Illinois District Finals"
     scope: district
     scopeLabel: Illinois
@@ -50,6 +55,11 @@ jbq:
     scopeLabel: North Texas
     scoresLink: /jbq/2022/districts/north-texas/
     dates: Mar 26, 2022
+  - name: "2022 Northwest District Finals"
+    scope: district
+    scopeLabel: Northwest
+    scoresLink: /jbq/2022/districts/northwest/
+    dates: Mar 12, 2022
   - name: "2022 Oklahoma District Finals"
     scope: district
     scopeLabel: Oklahoma

--- a/_data/imported/2023.yml
+++ b/_data/imported/2023.yml
@@ -15,6 +15,11 @@ jbq:
     scopeLabel: Kansas
     scoresLink: /jbq/2023/districts/kansas/
     dates: Apr 18, 2023
+  - name: "2023 North Carolina District Finals"
+    scope: district
+    scopeLabel: North Carolina
+    scoresLink: /jbq/2023/districts/north-carolina/
+    dates: Apr 16, 2022
   - name: "2023 North Texas District Finals"
     scope: district
     scopeLabel: North Texas
@@ -40,6 +45,11 @@ jbq:
     scopeLabel: Wisconsin / Northern Missouri
     scoresLink: /jbq/2023/districts/wisconsin-northern-missouri/
     dates: Mar 25, 2023
+  - name: "2023 Georgia District Finals"
+    scope: district
+    scopeLabel: Georgia
+    scoresLink: /jbq/2023/districts/georgia/
+    dates: Mar 4, 2023
   tournament:
   - name: John Crabtree
     scope: tournament
@@ -57,6 +67,11 @@ jbq:
     scopeLabel: Arkansas
     scoresLink: /jbq/2023/other/arkansas-districts-qualifying/
     dates: Mar 4, 2023
+  - name: "North Carolina Semi Finals"
+    scope: district
+    scopeLabel: North Carolina
+    scoresLink: /jbq/2023/other/north-carolina-semi-finals/
+    dates: Apr 16, 2023
 tbq:
   tournament:
   - name: Windy City Classic

--- a/_pages/history/2013/tournaments/missouri-classic.md
+++ b/_pages/history/2013/tournaments/missouri-classic.md
@@ -12,7 +12,7 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## A League
+## A1 League
 
 ### Teams
 
@@ -63,6 +63,55 @@ menubar_toc_static:
 | 25 | Anna Plank          | Ministering Spirits               | Moberly-MO-1st A/G            | 40    | 5.00   |    |
 | 26 | Eme Akpan           | ASK (Awesome Stupendous Kwizzers) | Florissant-MO-Grace           | 25    | 3.13   |    |
 | 27 | Liz Amirault        | Ministering Spirits               | Moberly-MO-1st A/G            | 20    | 2.50   |    |
+
+## A2 League
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team           | Church                           | W/L | Total | Avg    |
+|--:|----------------|----------------------------------|-----|------:|-------:|
+| 1 | EFC            | Grand Island-NE-Evangelical Free | 6/0 | 965   | 160.83 |
+| 2 | Labor Pains    | Springfield-MO-King\'s Chapel    | 5/1 | 485   | 80.83  |
+| 3 | Central AG     | Springfield-MO-Central AG        | 3/3 | 445   | 74.17  |
+| 4 | Not in Thought | Fort Worth-TX-Harvest AG         | 3/3 | 610   | 101.67 |
+| 5 | Moberly        | Moberly-MO-Moberly 1st AG        | 2/4 | 370   | 61.67  |
+| 6 | CrossPoint     | Portage-WI-CrossPoint AG         | 2/4 | 295   | 49.17  |
+| 7 | By Name        | Christian Chapel                 | 0/6 | 225   | 37.50  |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer                            | Team           | Church                           | Total | Avg    | QO |
+|---:|------------------------------------|----------------|----------------------------------|------:|-------:|---:|
+| 1  | Luke Hamilton                      | EFC            | Grand Island-NE-Evangelical Free | 755   | 125.83 | 6  |
+| 2  | Andrew VanHorn                     | Not in Thought | Fort Worth-TX-Harvest AG         | 450   | 75.00  | 4  |
+| 3  | Lucas Hying                        | Moberly        | Moberly-MO-Moberly 1st AG        | 385   | 64.17  | 3  |
+| 4  | Kara Peters                        | Labor Pains    | Springfield-MO-King\'s Chapel    | 370   | 61.67  | 4  |
+| 5  | Nathan Hazard                      | CrossPoint     | Portage-WI-CrossPoint AG         | 260   | 43.33  | 3  |
+| 6  | Caroline Oss                       | Central AG     | Springfield-MO-Central AG        | 260   | 43.33  | 2  |
+| 7  | Josh Frederick                     | EFC            | Grand Island-NE-Evangelical Free | 220   | 36.67  | 3  |
+| 8  | Amie Oss                           | Central AG     | Springfield-MO-Central AG        | 185   | 30.83  | 1  |
+| 9  | J.B. VanHorn                       | Not in Thought | Fort Worth-TX-Harvest AG         | 165   | 27.50  | 1  |
+| 10 | Cherokee Hill                      | By Name        | Christian Chapel                 | 140   | 23.33  | 2  |
+| 11 | Brock Peters                       | Labor Pains    | Springfield-MO-King\'s Chapel    | 115   | 19.17  |    |
+| 12 | Rhianna Benson                     | By Name        | Christian Chapel                 | 85    | 14.17  |    |
+| 13 | Victoria Roesler                   | CrossPoint     | Portage-WI-CrossPoint AG         | 45    | 7.50   |    |
+| 14 | Nick Hying                         | Moberly        | Moberly-MO-Moberly 1st AG        | 5     | .83    |    |
+| 15 | Zechariah Crosby                   | Not in Thought | Fort Worth-TX-Harvest AG         |       | .00    |    |
+| 15 | Cyera Young                        | Moberly        | Moberly-MO-Moberly 1st AG        |       | .00    |    |
+| 15 | Kyle Frederick - Middle School     | EFC            | Grand Island-NE-Evangelical Free |       | .00    |    |
+| 15 | Michaela Frederick - Middle School | EFC            | Grand Island-NE-Evangelical Free |       | .00    |    |
+| 15 | Bri James                          | Moberly        | Moberly-MO-Moberly 1st AG        |       | .00    |    |
+| 15 | Kay Garrett                        | Moberly        | Moberly-MO-Moberly 1st AG        |       | .00    |    |
+| 16 | Quintin Risch                      | Moberly        | Moberly-MO-Moberly 1st AG        | -10   | -1.67  |    |
+| 16 | Jordan Bauer                       | CrossPoint     | Portage-WI-CrossPoint AG         | -10   | -1.67  |    |
+| 16 | Christian Frederick                | EFC            | Grand Island-NE-Evangelical Free | -10   | -1.67  |    |
+| 16 | C J Risch                          | Moberly        | Moberly-MO-Moberly 1st AG        | -10   | -1.67  |    |
+| 17 | Chandler Kellett                   | Not in Thought | Fort Worth-TX-Harvest AG         | -5    | -0.83  |    |
+
 
 
 ## Middle School

--- a/_pages/history/2016/tournaments/gold-cup.md
+++ b/_pages/history/2016/tournaments/gold-cup.md
@@ -12,46 +12,7 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## Bronze
-
-### Teams
-
-*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
-
-| # | Team                    | Church                      | W/L | Total | Avg    |
-|--:|-------------------------|-----------------------------|-----|------:|-------:|
-| 1 | Unschooled Ordinary Men | Evangel Temple-Springfield, | 3/2 | 660   | 132.00 |
-| 2 | Rivergate-Bryan         | Rivergate                   | 3/2 | 500   | 100.00 |
-| 3 | Trinity Blood & Fire    | Trinity Church              | 3/2 | 495   | 99.00  |
-| 4 | Trinity Violent Winds   | Trinity Church              | 2/3 | 495   | 99.00  |
-| 5 | Oaks                    | The Oaks                    | 1/3 | 195   | 48.75  |
-
-### Individuals
-
-*Ties broken by QuizOuts (Scores sorted by TOTAL)*
-
-| #  | Quizzer             | Team                    | Church                      | Total | Avg   | QO |
-|---:|---------------------|-------------------------|-----------------------------|------:|------:|---:|
-| 1  | Erin Asbjornson     | Trinity Violent Winds   | Trinity Church              | 400   | 80.00 | 3  |
-| 2  | John Cohen          | Rivergate-Bryan         | Rivergate                   | 295   | 59.00 | 3  |
-| 3  | Kambria Braithwaite | Unschooled Ordinary Men | Evangel Temple-Springfield, | 295   | 59.00 | 2  |
-| 4  | Ashlee Gallinger    | Unschooled Ordinary Men | Evangel Temple-Springfield, | 265   | 53.00 | 2  |
-| 5  | Joy Alayande        | Trinity Blood & Fire    | Trinity Church              | 250   | 50.00 | 1  |
-| 6  | Sarah Cohen         | Rivergate-Bryan         | Rivergate                   | 185   | 37.00 | 2  |
-| 7  | Danielle Asbjornson | Trinity Blood & Fire    | Trinity Church              | 165   | 33.00 | 1  |
-| 8  | Darren Rogers       | Oaks                    | The Oaks                    | 105   | 26.25 | 1  |
-| 9  | Chad Gallinger      | Unschooled Ordinary Men | Evangel Temple-Springfield, | 100   | 20.00 |    |
-| 10 | Ross Wyche          | Trinity Blood & Fire    | Trinity Church              | 80    | 16.00 |    |
-| 11 | Juliet Amadi        | Trinity Violent Winds   | Trinity Church              | 70    | 14.00 |    |
-| 12 | Anna O'neil         | Oaks                    | The Oaks                    | 65    | 16.25 |    |
-| 13 | David John          | Trinity Violent Winds   | Trinity Church              | 25    | 5.00  |    |
-| 13 | Azariah Rogers      | Oaks                    | The Oaks                    | 25    | 6.25  |    |
-| 14 | David Cohen         | Rivergate-Bryan         | Rivergate                   | 20    | 4.00  |    |
-| 15 | Stephanie Nieves    | Oaks                    | The Oaks                    |       | .00   |    |
-| 15 | Imani Love          | Oaks                    | The Oaks                    |       | .00   |    |
-
-
-## Gold
+## Gold Division
 
 ### Teams
 
@@ -90,3 +51,73 @@ menubar_toc_static:
 | 15 | Chris Adams         | Memorial-King                                | Memorial AG                 |       | .00    |    |
 | 15 | Izzy Lashley-Bobb   | Overlooked in the Daily Distribution of Food | Muskogee 1st AG             |       | .00    |    |
 
+## Silver Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team             | Church                | W/L | Total | Avg    |
+|--:|------------------|-----------------------|-----|------:|-------:|
+| 1 | Life 360         | Life 360              | 6/0 | 1035  | 172.50 |
+| 2 | Trinity G-Squad  | Trinity Church        | 3/3 | 340   | 56.67  |
+| 3 | Harvest Ft Worth | Harvest AG-Fort Worth | 3/3 | 295   | 49.17  |
+| 4 | Trinity Warriors | Trinity Church        | 0/6 | 155   | 25.83  |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer         | Team             | Church                | Total | Avg    | QO |
+|---:|-----------------|------------------|-----------------------|------:|-------:|---:|
+| 1  | Cameron Ramsey  | Life 360         | Life 360              | 665   | 110.83 | 5  |
+| 2  | Austin Ramsey   | Life 360         | Life 360              | 370   | 61.67  | 4  |
+| 3  | Jack Rall       | Harvest Ft Worth | Harvest AG-Fort Worth | 240   | 40.00  | 1  |
+| 4  | Kaylen Hames    | Trinity G-Squad  | Trinity Church        | 225   | 37.50  | 3  |
+| 5  | Ethan Pickrell  | Trinity Warriors | Trinity Church        | 95    | 15.83  |    |
+| 6  | Elizabeth Sims  | Trinity G-Squad  | Trinity Church        | 80    | 13.33  |    |
+| 7  | Joseph Hames    | Trinity Warriors | Trinity Church        | 60    | 10.00  |    |
+| 8  | Rachel Bridges  | Harvest Ft Worth | Harvest AG-Fort Worth | 35    | 5.83   |    |
+| 8  | Julia Sullivan  | Trinity G-Squad  | Trinity Church        | 35    | 5.83   |    |
+| 9  | Ashley Fortney  | Harvest Ft Worth | Harvest AG-Fort Worth | 20    | 3.33   |    |
+| 10 | Gannon Breig    | Life 360         | Life 360              | 10    | 1.67   |    |
+| 11 | Isaiah Wilburn  | Trinity Warriors | Trinity Church        |       | .00    |    |
+| 12 | Jackson Widhalm | Life 360         | Life 360              | -10   | -1.67  |    |
+
+## Bronze Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                    | Church                      | W/L | Total | Avg    |
+|--:|-------------------------|-----------------------------|-----|------:|-------:|
+| 1 | Unschooled Ordinary Men | Evangel Temple-Springfield, | 3/2 | 660   | 132.00 |
+| 2 | Rivergate-Bryan         | Rivergate                   | 3/2 | 500   | 100.00 |
+| 3 | Trinity Blood & Fire    | Trinity Church              | 3/2 | 495   | 99.00  |
+| 4 | Trinity Violent Winds   | Trinity Church              | 2/3 | 495   | 99.00  |
+| 5 | Oaks                    | The Oaks                    | 1/3 | 195   | 48.75  |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                    | Church                      | Total | Avg   | QO |
+|---:|---------------------|-------------------------|-----------------------------|------:|------:|---:|
+| 1  | Erin Asbjornson     | Trinity Violent Winds   | Trinity Church              | 400   | 80.00 | 3  |
+| 2  | John Cohen          | Rivergate-Bryan         | Rivergate                   | 295   | 59.00 | 3  |
+| 3  | Kambria Braithwaite | Unschooled Ordinary Men | Evangel Temple-Springfield, | 295   | 59.00 | 2  |
+| 4  | Ashlee Gallinger    | Unschooled Ordinary Men | Evangel Temple-Springfield, | 265   | 53.00 | 2  |
+| 5  | Joy Alayande        | Trinity Blood & Fire    | Trinity Church              | 250   | 50.00 | 1  |
+| 6  | Sarah Cohen         | Rivergate-Bryan         | Rivergate                   | 185   | 37.00 | 2  |
+| 7  | Danielle Asbjornson | Trinity Blood & Fire    | Trinity Church              | 165   | 33.00 | 1  |
+| 8  | Darren Rogers       | Oaks                    | The Oaks                    | 105   | 26.25 | 1  |
+| 9  | Chad Gallinger      | Unschooled Ordinary Men | Evangel Temple-Springfield, | 100   | 20.00 |    |
+| 10 | Ross Wyche          | Trinity Blood & Fire    | Trinity Church              | 80    | 16.00 |    |
+| 11 | Juliet Amadi        | Trinity Violent Winds   | Trinity Church              | 70    | 14.00 |    |
+| 12 | Anna O'neil         | Oaks                    | The Oaks                    | 65    | 16.25 |    |
+| 13 | David John          | Trinity Violent Winds   | Trinity Church              | 25    | 5.00  |    |
+| 13 | Azariah Rogers      | Oaks                    | The Oaks                    | 25    | 6.25  |    |
+| 14 | David Cohen         | Rivergate-Bryan         | Rivergate                   | 20    | 4.00  |    |
+| 15 | Stephanie Nieves    | Oaks                    | The Oaks                    |       | .00   |    |
+| 15 | Imani Love          | Oaks                    | The Oaks                    |       | .00   |    |

--- a/_pages/history/2016/tournaments/missouri-classic.md
+++ b/_pages/history/2016/tournaments/missouri-classic.md
@@ -12,41 +12,11 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## M-Challenger
+## A Division
 
-### Teams
+### Preliminaries
 
-*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
-
-| # | Team                    | Church             | W/L | Total | Avg    |
-|--:|-------------------------|--------------------|-----|------:|-------:|
-| 1 | Unschooled Ordinary Men | James River Church | 2/0 | 285   | 142.50 |
-| 2 | Women at the River      | James River Church | 1/1 | 145   | 72.50  |
-| 3 | The Quizzing Intestines | Central AG         | 0/2 | 5     | 2.50   |
-
-### Individuals
-
-*Ties broken by QuizOuts (Scores sorted by TOTAL)*
-
-| #  | Quizzer          | Team                    | Church             | Total | Avg    | QO |
-|---:|------------------|-------------------------|--------------------|------:|-------:|---:|
-| 1  | Davis Garrison   | Unschooled Ordinary Men | James River Church | 210   | 105.00 | 1  |
-| 2  | Joseph Bogun     | Unschooled Ordinary Men | James River Church | 75    | 37.50  |    |
-| 3  | Olivia Chrastina | Women at the River      | James River Church | 70    | 35.00  | 1  |
-| 4  | Zara Rethman     | Women at the River      | James River Church | 70    | 35.00  |    |
-| 5  | John Georgiades  | The Quizzing Intestines | Central AG         | 20    | 10.00  |    |
-| 6  | Sarah Roberts    | Women at the River      | James River Church | 15    | 7.50   |    |
-| 7  | Nico Georgiades  | The Quizzing Intestines | Central AG         | 10    | 5.00   |    |
-| 8  | Jackson Woodward | The Quizzing Intestines | Central AG         | 5     | 2.50   |    |
-| 9  | David Cox        | Unschooled Ordinary Men | James River Church |       | .00    |    |
-| 9  | Mareena Bogun    | Women at the River      | James River Church |       | .00    |    |
-| 10 | Macquen Strobel  | The Quizzing Intestines | Central AG         | -30   | -15    |    |
-| 11 | Lexi Roberts     | Women at the River      | James River Church | -5    | -2.5   |    |
-
-
-## A League
-
-### Teams
+#### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
@@ -60,7 +30,7 @@ menubar_toc_static:
 | 6 | Trinity Cedar Hill         | Trinity Cedar Hill  | 1/5 | 185   | 30.83  |
 | 7 | The Oaks                   | The Oaks Fellowship | 1/5 | 155   | 25.83  |
 
-### Individuals
+#### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
@@ -91,10 +61,9 @@ menubar_toc_static:
 | 19 | Merisa Rodriguez    | Tongues of Fire            | Christian Life AG   |       | .00   |    |
 | 20 | Elizabeth Hames     | Trinity Cedar Hill         | Trinity Cedar Hill  | -25   | -4.17 |    |
 
+### Champion
 
-## A-Champion
-
-### Teams
+#### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
@@ -125,10 +94,41 @@ menubar_toc_static:
 | 12 | Cade Chrastina     | James River - John         | James River Church | 10    | 3.33   |    |
 | 13 | Kara Peters        | May Another Take His Place | Evangel Temple     |       | .00    |    |
 
+### Challenger
 
-## Experience
+#### Teams
 
-### Teams
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team               | Church              | W/L | Total | Avg    |
+|--:|--------------------|---------------------|-----|------:|-------:|
+| 1 | Trinity Cedar Hill | Trinity Cedar Hill  | 2/0 | 210   | 105.00 |
+| 2 | Tongues of Fire    | Christian Life AG   | 1/1 | 210   | 105.00 |
+| 3 | The Oaks           | The Oaks Fellowship | 0/2 | 115   | 57.50  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| # | Quizzer             | Team               | Church              | Total | Avg   | QO |
+|--:|---------------------|--------------------|---------------------|------:|------:|---:|
+| 1 | Cammi Kjetland      | Tongues of Fire    | Christian Life AG   | 160   | 80.00 | 1  |
+| 2 | Josh Barajas        | Trinity Cedar Hill | Trinity Cedar Hill  | 110   | 55.00 | 1  |
+| 3 | Triston Rosario     | Trinity Cedar Hill | Trinity Cedar Hill  | 100   | 50.00 | 1  |
+| 3 | Gabe Lapusan        | The Oaks           | The Oaks Fellowship | 100   | 50.00 | 1  |
+| 4 | Brianna McKinley    | Tongues of Fire    | Christian Life AG   | 30    | 15.00 |    |
+| 5 | Kyla Schrock        | The Oaks           | The Oaks Fellowship | 25    | 12.50 |    |
+| 6 | Matthew McKinley    | Tongues of Fire    | Christian Life AG   | 20    | 10.00 |    |
+| 7 | John David Sullivan | Trinity Cedar Hill | Trinity Cedar Hill  | 5     | 2.50  |    |
+| 8 | Cameron Berta       | The Oaks           | The Oaks Fellowship |       | .00   |    |
+| 8 | Merisa Rodriguez    | Tongues of Fire    | Christian Life AG   |       | .00   |    |
+| 9 | Elizabeth Hames     | Trinity Cedar Hill | Trinity Cedar Hill  | -5    | -2.5  |    |
+
+## Experience Division
+
+### Preliminaries
+
+#### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
@@ -142,7 +142,7 @@ menubar_toc_static:
 | 6 | Therefore            | James River Church  | 1/5 | 265   | 44.17  |
 | 7 | The Oaks Experience  | The Oaks Fellowship | 0/6 | 175   | 29.17  |
 
-### Individuals
+#### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
@@ -171,10 +171,72 @@ menubar_toc_static:
 | 19 | Jeremy Eden         | Therefore            | James River Church  | -30   | -5    |    |
 | 20 | Stephanie Nieves    | The Oaks Experience  | The Oaks Fellowship | -10   | -1.67 |    |
 
+### Champion
 
-## Middle School
+#### Teams
 
-### Teams
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                 | Church             | W/L | Total | Avg    |
+|--:|----------------------|--------------------|-----|------:|-------:|
+| 1 | Blood and Fire       | Trinity Cedar Hill | 3/0 | 585   | 195.00 |
+| 2 | Amazed and Perplexed | James River Church | 2/1 | 430   | 143.33 |
+| 3 | Team-Evangel Temple  | Evangel Temple     | 1/2 | 465   | 155.00 |
+| 4 | Joy in Your Presence | James River Church | 0/3 | 355   | 118.33 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                 | Church             | Total | Avg    | QO |
+|---:|---------------------|----------------------|--------------------|------:|-------:|---:|
+| 1  | Emily Edwards       | Blood and Fire       | Trinity Cedar Hill | 310   | 103.33 | 3  |
+| 2  | Ashlee Gallinger    | Team-Evangel Temple  | Evangel Temple     | 280   | 93.33  | 3  |
+| 3  | Quinnlyn Jenkins    | Amazed and Perplexed | James River Church | 195   | 65.00  | 1  |
+| 4  | Naomi McNaughton    | Amazed and Perplexed | James River Church | 195   | 65.00  |    |
+| 5  | Kambria Braithwaite | Team-Evangel Temple  | Evangel Temple     | 185   | 61.67  | 1  |
+| 6  | Julianna Torbett    | Joy in Your Presence | James River Church | 180   | 60.00  | 1  |
+| 7  | Joy Alayande        | Blood and Fire       | Trinity Cedar Hill | 165   | 55.00  |    |
+| 8  | Kaiya Braswell      | Joy in Your Presence | James River Church | 135   | 45.00  |    |
+| 9  | Danielle Asbjornson | Blood and Fire       | Trinity Cedar Hill | 125   | 41.67  | 1  |
+| 10 | Jake Ward           | Amazed and Perplexed | James River Church | 40    | 13.33  |    |
+| 10 | Abby Cox            | Joy in Your Presence | James River Church | 40    | 13.33  |    |
+| 11 | Brent Battaglia     | Amazed and Perplexed | James River Church |       | .00    |    |
+| 11 | Chad Gallinger      | Team-Evangel Temple  | Evangel Temple     |       | .00    |    |
+| 12 | Erin Asbjornson     | Blood and Fire       | Trinity Cedar Hill | -15   | -5     |    |
+
+### Challenger
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                 | Church              | W/L | Total | Avg   |
+|--:|----------------------|---------------------|-----|------:|------:|
+| 1 | We are not Sad U see | Central AG          | 2/0 | 195   | 97.50 |
+| 2 | The Oaks Experience  | The Oaks Fellowship | 1/1 | 50    | 25.00 |
+| 3 | Therefore            | James River Church  | 0/2 | 125   | 62.50 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| # | Quizzer            | Team                 | Church              | Total | Avg   | QO |
+|--:|--------------------|----------------------|---------------------|------:|------:|---:|
+| 1 | Abby Illum         | We are not Sad U see | Central AG          | 155   | 77.50 | 1  |
+| 2 | Darek Graves       | Therefore            | James River Church  | 115   | 57.50 | 1  |
+| 3 | Anna O\'Neil       | The Oaks Experience  | The Oaks Fellowship | 60    | 30.00 |    |
+| 4 | Lexi Parry         | We are not Sad U see | Central AG          | 40    | 20.00 |    |
+| 5 | Jeremy Eden        | Therefore            | James River Church  | 10    | 5.00  |    |
+| 6 | Brandon Mudersbach | Therefore            | James River Church  |       | .00   |    |
+| 6 | Lewis Groh         | Therefore            | James River Church  |       | .00   |    |
+| 7 | Stephanie Nieves   | The Oaks Experience  | The Oaks Fellowship | -10   | -5    |    |
+
+## Middle School Division
+
+### Preliminaries
+
+#### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
@@ -188,7 +250,7 @@ menubar_toc_static:
 | 6 | Unschooled Ordinary Men     | James River Church | 2/4 | 650   | 108.33 |
 | 7 | The Quizzing Intestines     | Central AG         | 0/6 | 35    | 5.83   |
 
-### Individuals
+#### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
@@ -223,4 +285,72 @@ menubar_toc_static:
 | 22 | Emilia Bogun         | Four Unmarried Daughters    | James River Church |       | .00    |    |
 | 23 | John Georgiades      | The Quizzing Intestines     | Central AG         | -35   | -5.83  |    |
 | 24 | Olivia Chrastina     | Women at the River          | James River Church | -30   | -5     |    |
+
+### Champion
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                        | Church             | W/L | Total | Avg    |
+|--:|-----------------------------|--------------------|-----|------:|-------:|
+| 1 | Four Unmarried Daughters    | James River Church | 2/1 | 630   | 210.00 |
+| 2 | No One Else Dared Join Them | James River Church | 2/1 | 310   | 103.33 |
+| 3 | Philosophers                | James River Church | 1/2 | 360   | 120.00 |
+| 4 | Trinity Cedar Hill MS       | Trinity Cedar Hill | 1/2 | 365   | 121.67 |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer              | Team                        | Church             | Total | Avg    | QO |
+|---:|----------------------|-----------------------------|--------------------|------:|-------:|---:|
+| 1  | Joanne Sinniah       | Four Unmarried Daughters    | James River Church | 415   | 138.33 | 3  |
+| 2  | Paige Chrastina      | Four Unmarried Daughters    | James River Church | 190   | 63.33  | 2  |
+| 3  | Abigail Dasal        | Philosophers                | James River Church | 190   | 63.33  | 1  |
+| 4  | Ethan Pickrell       | Trinity Cedar Hill MS       | Trinity Cedar Hill | 180   | 60.00  | 2  |
+| 5  | Kaylen Hames         | Trinity Cedar Hill MS       | Trinity Cedar Hill | 160   | 53.33  | 1  |
+| 6  | Mercy Germany        | Philosophers                | James River Church | 140   | 46.67  |    |
+| 7  | Gavin Griffith       | No One Else Dared Join Them | James River Church | 130   | 43.33  | 1  |
+| 8  | Jonathan Dasal       | No One Else Dared Join Them | James River Church | 130   | 43.33  |    |
+| 9  | Josiah Smith         | No One Else Dared Join Them | James River Church | 50    | 16.67  |    |
+| 10 | Vanessa Ellingsworth | Philosophers                | James River Church | 30    | 10.00  |    |
+| 11 | Ally O\'Connell      | Four Unmarried Daughters    | James River Church | 25    | 8.33   |    |
+| 11 | Julia Sullivan       | Trinity Cedar Hill MS       | Trinity Cedar Hill | 25    | 8.33   |    |
+| 12 | Acacia Graves        | No One Else Dared Join Them | James River Church |       | .00    |    |
+| 12 | Elizabeth Sims       | Trinity Cedar Hill MS       | Trinity Cedar Hill |       | .00    |    |
+| 12 | Hayden Ballard       | No One Else Dared Join Them | James River Church |       | .00    |    |
+| 12 | Daphne Graves        | Philosophers                | James River Church |       | .00    |    |
+| 12 | Emilia Bogun         | Four Unmarried Daughters    | James River Church |       | .00    |    |
+
+### Challenger
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                    | Church             | W/L | Total | Avg    |
+|--:|-------------------------|--------------------|-----|------:|-------:|
+| 1 | Unschooled Ordinary Men | James River Church | 2/0 | 285   | 142.50 |
+| 2 | Women at the River      | James River Church | 1/1 | 145   | 72.50  |
+| 3 | The Quizzing Intestines | Central AG         | 0/2 | 5     | 2.50   |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer          | Team                    | Church             | Total | Avg    | QO |
+|---:|------------------|-------------------------|--------------------|------:|-------:|---:|
+| 1  | Davis Garrison   | Unschooled Ordinary Men | James River Church | 210   | 105.00 | 1  |
+| 2  | Joseph Bogun     | Unschooled Ordinary Men | James River Church | 75    | 37.50  |    |
+| 3  | Olivia Chrastina | Women at the River      | James River Church | 70    | 35.00  | 1  |
+| 4  | Zara Rethman     | Women at the River      | James River Church | 70    | 35.00  |    |
+| 5  | John Georgiades  | The Quizzing Intestines | Central AG         | 20    | 10.00  |    |
+| 6  | Sarah Roberts    | Women at the River      | James River Church | 15    | 7.50   |    |
+| 7  | Nico Georgiades  | The Quizzing Intestines | Central AG         | 10    | 5.00   |    |
+| 8  | Jackson Woodward | The Quizzing Intestines | Central AG         | 5     | 2.50   |    |
+| 9  | David Cox        | Unschooled Ordinary Men | James River Church |       | .00    |    |
+| 9  | Mareena Bogun    | Women at the River      | James River Church |       | .00    |    |
+| 10 | Macquen Strobel  | The Quizzing Intestines | Central AG         | -30   | -15    |    |
+| 11 | Lexi Roberts     | Women at the River      | James River Church | -5    | -2.5   |    |
 

--- a/_pages/history/2017/tournaments/empire-classic.md
+++ b/_pages/history/2017/tournaments/empire-classic.md
@@ -193,3 +193,35 @@ menubar_toc_static:
 | 19 | Alex Stewart       | Wyckoff,NJ (Nat)    | Bethany                    |       | .00   |    |
 | 19 | Tyler Robinson     | Metuchen            | Metuchen AG                |       | .00   |    |
 | 19 | Tristan Velicky    | Wyckoff,NJ (Paul)   | Bethany                    |       | .00   |    |
+
+## MSQ
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team               | Church                     | W/L | Total | Avg    |
+|--:|--------------------|----------------------------|-----|------:|-------:|
+| 1 | Smithtown,NY       | Smithtown Christian School | 8/1 | 1535  | 170.56 |
+| 2 | Deposit,NY (Brian) | Maple Lane AG              | 5/4 | 490   | 54.44  |
+| 3 | Wyckoff,NJ (Joyce) | Bethany                    | 4/5 | 325   | 36.11  |
+| 4 | Phantom            | Sacrificed                 | 1/8 |       | .00    |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer          | Team               | Church                     | Total | Avg   | QO |
+|---:|------------------|--------------------|----------------------------|------:|------:|---:|
+| 1  | Hannah Fiormonti | Smithtown,NY       | Smithtown Christian School | 650   | 72.22 | 7  |
+| 2  | Katie Pellegrino | Smithtown,NY       | Smithtown Christian School | 445   | 49.44 | 3  |
+| 3  | Bobby Reuter     | Smithtown,NY       | Smithtown Christian School | 440   | 48.89 | 4  |
+| 4  | Noah Alguire     | Deposit,NY (Brian) | Maple Lane AG              | 335   | 37.22 | 2  |
+| 5  | Melody Ward      | Wyckoff,NJ (Joyce) | Bethany                    | 195   | 21.67 | 1  |
+| 6  | Ethan Hurst      | Deposit,NY (Brian) | Maple Lane AG              | 125   | 13.89 |    |
+| 7  | Nicholas Velicky | Wyckoff,NJ (Joyce) | Bethany                    | 70    | 7.78  |    |
+| 8  | Eddy Coutinho    | Wyckoff,NJ (Joyce) | Bethany                    | 35    | 3.89  |    |
+| 9  | Josiah Hodkinson | Deposit,NY (Brian) | Maple Lane AG              | 30    | 3.33  |    |
+| 10 | Naomi Ward       | Wyckoff,NJ (Joyce) | Bethany                    | 25    | 2.78  |    |
+| 11 | Camille Bello    | Wyckoff,NJ (Joyce) | Bethany                    |       | .00   |    |
+

--- a/_pages/history/2017/tournaments/gobblefest.md
+++ b/_pages/history/2017/tournaments/gobblefest.md
@@ -205,6 +205,62 @@ menubar_toc_static:
 | 7 | Lauren Powers   | 2\. Lighthouse Christian Fellowship, Pennsburg, PA |        |       | .00   |    |
 | 7 | Jessica Cordero | 2\. Lighthouse Christian Fellowship, Pennsburg, PA |        |       | .00   |    |
 
+## Experience Saturday
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                                               | Church | W/L | Total | Avg   |
+|--:|----------------------------------------------------|--------|-----|------:|------:|
+| 1 | 1\. Hamlin A/G, Lake Ariel, PA                     |        | 5/0 | 460   | 92.00 |
+| 2 | 2\. Lighthouse Christian Fellowship, Pennsburg, PA |        | 0/5 | 75    | 15.00 |
+| 3 | Ghost                                              |        | 0/0 |       | .00   |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| # | Quizzer         | Team                                               | Church | Total | Avg   | QO |
+|--:|-----------------|----------------------------------------------------|--------|------:|------:|---:|
+| 1 | Emma Gilligan   | 1\. Hamlin A/G, Lake Ariel, PA                     |        | 225   | 45.00 | 1  |
+| 2 | Judah Miller    | 1\. Hamlin A/G, Lake Ariel, PA                     |        | 205   | 41.00 |    |
+| 3 | Jadyn Selfinger | 2\. Lighthouse Christian Fellowship, Pennsburg, PA |        | 50    | 10.00 |    |
+| 4 | Haley Strocchia | 1\. Hamlin A/G, Lake Ariel, PA                     |        | 30    | 6.00  |    |
+| 5 | Austin Rompilla | 2\. Lighthouse Christian Fellowship, Pennsburg, PA |        | 25    | 5.00  |    |
+| 6 | Kaija Gerlach   | 1\. Hamlin A/G, Lake Ariel, PA                     |        |       | .00   |    |
+| 6 | Lauren Powers   | 2\. Lighthouse Christian Fellowship, Pennsburg, PA |        |       | .00   |    |
+| 6 | Jessica Cordero | 2\. Lighthouse Christian Fellowship, Pennsburg, PA |        |       | .00   |    |
+
+## Experience Finals
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                                 | Church | W/L | Total | Avg    |
+|--:|--------------------------------------|--------|-----|------:|-------:|
+| 1 | 3\. Fountain of Life, Burlington, NJ |        | 1/0 | 100   | 100.00 |
+| 2 | Experience Total                     |        | 0/1 | 45    | 45.00  |
+| 3 | Ghost                                |        | 0/0 |       | .00    |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| # | Quizzer         | Team                                 | Church | Total | Avg    | QO |
+|--:|-----------------|--------------------------------------|--------|------:|-------:|---:|
+| 1 | Joyce Ijalana   | 3\. Fountain of Life, Burlington, NJ |        | 105   | 105.00 | 1  |
+| 2 | Emma Gilligan   | Experience Total                     |        | 40    | 40.00  |    |
+| 3 | Jadyn Selfinger | Experience Total                     |        | 15    | 15.00  |    |
+| 4 | Hiley Strocchia | Experience Total                     |        |       | .00    |    |
+| 4 | Judah Miller    | Experience Total                     |        |       | .00    |    |
+| 4 | Kaija Gerlach   | Experience Total                     |        |       | .00    |    |
+| 4 | Jayson Njoga    | 3\. Fountain of Life, Burlington, NJ |        |       | .00    |    |
+| 5 | Austin Rompilla | Experience Total                     |        | -10   | -10    |    |
+| 6 | Isaiah Castro   | 3\. Fountain of Life, Burlington, NJ |        | -5    | -5     |    |
+
+
 
 ## MS/PD/B Division PURPLE
 
@@ -346,6 +402,41 @@ menubar_toc_static:
 | 9  | Ethan Hurst       | 2\. Redeemer Church, Utica, NY     |        | -15   | -7.5  |    |
 | 10 | Josiah Hodkinson  | 2\. Redeemer Church, Utica, NY     |        | -10   | -5    |    |
 
+## Purple Top 4 Finals
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                                               | Church | W/L | Total | Avg    |
+|--:|----------------------------------------------------|--------|-----|------:|-------:|
+| 1 | 4\. Mechanicsville Christian Cntr, Mechanicsville, |        | 3/0 | 480   | 160.00 |
+| 2 | 8\. Calvary Temple International, Wayne, NJ        |        | 2/1 | 465   | 155.00 |
+| 3 | 5\. Hamlin A/G, Lake Ariel, PA                     |        | 1/2 | 485   | 161.67 |
+| 4 | 3\. Lighthouse Christian Fellowship, Pennsburg, PA |        | 0/3 | 210   | 70.00  |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                                               | Church | Total | Avg    | QO |
+|---:|-------------------|----------------------------------------------------|--------|------:|-------:|---:|
+| 1  | Natalie Bartkow   | 5\. Hamlin A/G, Lake Ariel, PA                     |        | 395   | 131.67 | 3  |
+| 2  | Rachel Smith      | 4\. Mechanicsville Christian Cntr, Mechanicsville, |        | 325   | 108.33 | 3  |
+| 3  | Joel Botros       | 8\. Calvary Temple International, Wayne, NJ        |        | 255   | 85.00  | 2  |
+| 4  | Caleb Cook        | 8\. Calvary Temple International, Wayne, NJ        |        | 200   | 66.67  | 2  |
+| 5  | Julia Beal        | 3\. Lighthouse Christian Fellowship, Pennsburg, PA |        | 195   | 65.00  | 1  |
+| 6  | Will Rittenhouse  | 4\. Mechanicsville Christian Cntr, Mechanicsville, |        | 145   | 48.33  | 1  |
+| 7  | Ana Claflin       | 5\. Hamlin A/G, Lake Ariel, PA                     |        | 90    | 30.00  |    |
+| 8  | Karissa West      | 3\. Lighthouse Christian Fellowship, Pennsburg, PA |        | 20    | 6.67   |    |
+| 9  | Bernard Luitjohan | 4\. Mechanicsville Christian Cntr, Mechanicsville, |        | 10    | 3.33   |    |
+| 9  | Alyssa Rocha      | 8\. Calvary Temple International, Wayne, NJ        |        | 10    | 3.33   |    |
+| 10 | Melody Botros     | 8\. Calvary Temple International, Wayne, NJ        |        |       | .00    |    |
+| 10 | Luke Powers       | 3\. Lighthouse Christian Fellowship, Pennsburg, PA |        |       | .00    |    |
+| 10 | Liliana Gambino   | 8\. Calvary Temple International, Wayne, NJ        |        |       | .00    |    |
+| 10 | Kiara West        | 3\. Lighthouse Christian Fellowship, Pennsburg, PA |        |       | .00    |    |
+| 11 | Mason Powers      | 3\. Lighthouse Christian Fellowship, Pennsburg, PA |        | -5    | -1.67  |    |
+
 
 ## Red 2nd 4 Finals
 
@@ -379,4 +470,38 @@ menubar_toc_static:
 | 8 | Gavin Gray       | 6\. Mechanicsville Christian Cntr, Mechanicsville, |        |       | .00    |    |
 | 8 | Eric Carty       | 8\. Living Hope Worship Cntr, Swedesboro, NJ       |        |       | .00    |    |
 | 9 | Micah DeSanto    | 8\. Living Hope Worship Cntr, Swedesboro, NJ       |        | -15   | -15    |    |
+
+## Red Top 4 Finals
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                                 | Church | W/L | Total | Avg    |
+|--:|--------------------------------------|--------|-----|------:|-------:|
+| 1 | 7\. Green Ridge A/G, Scranton, PA    |        | 1/0 | 190   | 190.00 |
+| 2 | 5\. Smithtown, NY                    |        | 1/0 | 120   | 120.00 |
+| 3 | 9\. Maple Lane Assembly, Deposit, NY |        | 0/1 | 125   | 125.00 |
+| 4 | 1\. First A/G, Waynesburg, PA        |        | 0/1 | 60    | 60.00  |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer            | Team                                 | Church | Total | Avg    | QO |
+|---:|--------------------|--------------------------------------|--------|------:|-------:|---:|
+| 1  | Rachel Bradshaw    | 7\. Green Ridge A/G, Scranton, PA    |        | 125   | 125.00 | 1  |
+| 2  | Hannah Fioramonti  | 5\. Smithtown, NY                    |        | 90    | 90.00  | 1  |
+| 3  | Aaron Rozelle      | 9\. Maple Lane Assembly, Deposit, NY |        | 80    | 80.00  | 1  |
+| 4  | Gabby Acor         | 1\. First A/G, Waynesburg, PA        |        | 50    | 50.00  |    |
+| 5  | Danielle Seymour   | 9\. Maple Lane Assembly, Deposit, NY |        | 45    | 45.00  |    |
+| 6  | Kathryn Pellegrino | 5\. Smithtown, NY                    |        | 35    | 35.00  |    |
+| 6  | Dawn Kroptavich    | 7\. Green Ridge A/G, Scranton, PA    |        | 35    | 35.00  |    |
+| 7  | Sydney Kimmel      | 7\. Green Ridge A/G, Scranton, PA    |        | 30    | 30.00  |    |
+| 8  | Joseph Benco       | 1\. First A/G, Waynesburg, PA        |        | 20    | 20.00  |    |
+| 9  | Sarah Smith        | 7\. Green Ridge A/G, Scranton, PA    |        |       | .00    |    |
+| 9  | Nathan Rozelle     | 9\. Maple Lane Assembly, Deposit, NY |        |       | .00    |    |
+| 9  | Ethan Mitchell     | 9\. Maple Lane Assembly, Deposit, NY |        |       | .00    |    |
+| 10 | Leah Miller        | 1\. First A/G, Waynesburg, PA        |        | -10   | -10    |    |
+| 11 | Thomas Clinton     | 5\. Smithtown, NY                    |        | -5    | -5     |    |
 

--- a/_pages/history/2017/tournaments/missouri-classic.md
+++ b/_pages/history/2017/tournaments/missouri-classic.md
@@ -12,7 +12,7 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## A League
+## A Division
 
 ### Teams
 
@@ -76,10 +76,11 @@ menubar_toc_static:
 | **\*32** | Emily McKinley      | Sioux Falls (Sioux Falls First)                      | 0     |       |    |    |
 | **\*32** | Romario Rodriguez   | Sioux Falls (Sioux Falls First)                      | 0     |       |    |    |
 
+## Experience Division
 
-## Experience
+### Preliminaries
 
-### Teams
+#### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points*
 
@@ -93,7 +94,7 @@ menubar_toc_static:
 | 5.1 | Central Exp (Central AG)              | 1 / 5 | 315   | 45    | 1  | 24 |
 | 6.0 | The Oaks XP (The Oaks Fellowship)     | 1 / 5 | 235   | 33.6  |    | 16 |
 
-### Individuals
+#### Individuals
 
 *Ties broken by Average Points then Total Quiz Outs*
 
@@ -122,4 +123,66 @@ menubar_toc_static:
 | **\*19** | Abigail Jones       | Central Exp (Central AG)              | 0     |      |    |    |
 | 20       | Isaac Jenkins       | Therefore (James River)               | -5    | -.8  |    |    |
 | 21       | Jason Bartholomew   | The Oaks XP (The Oaks Fellowship)     | -15   | -2.5 |    | 1  |
+
+### Blue
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                     | W/L   | Total | Avg  | QO | Qs |
+|----:|-----------------------------------|-------|------:|-----:|---:|---:|
+| 1.0 | Central Exp (Central AG)          | 2 / 0 | 205   | 68.3 | 1  | 13 |
+| 2.0 | Therefore (James River)           | 1 / 1 | 235   | 78.3 | 1  | 18 |
+| 3.0 | The Oaks XP (The Oaks Fellowship) | 0 / 2 | 60    | 20   |    | 6  |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #  | Quizzer             | Team / Church                     | Total | Avg  | QO | Qs |
+|---:|---------------------|-----------------------------------|------:|-----:|---:|---:|
+| 1  | Lexi Parry          | Central Exp (Central AG)          | 165   | 82.5 | 1  | 9  |
+| 2  | Lewis Groh          | Therefore (James River)           | 90    | 45   | 1  | 6  |
+| 3  | Emma Gapasin        | Therefore (James River)           | 90    | 45   |    | 6  |
+| 4  | Josiah Tonsing      | Therefore (James River)           | 50    | 25   |    | 4  |
+| 5  | Natalie Bartholomew | The Oaks XP (The Oaks Fellowship) | 45    | 22.5 |    | 4  |
+| 6  | Mikayla Butler      | Central Exp (Central AG)          | 30    | 15   |    | 3  |
+| 7  | Isaac Jenkins       | Therefore (James River)           | 20    | 10   |    | 1  |
+| 8  | Jason Bartholomew   | The Oaks XP (The Oaks Fellowship) | 15    | 7.5  |    | 2  |
+| 9  | Trinity Phelps      | Central Exp (Central AG)          | 10    | 5    |    | 1  |
+| 10 | Abigail Jones       | Central Exp (Central AG)          | 0     |      |    |    |
+| 11 | Micah Tonsing       | Therefore (James River)           | -15   | -7.5 |    | 1  |
+
+### Red
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                         | W/L   | Total | Avg   | QO | Qs |
+|----:|---------------------------------------|-------|------:|------:|---:|---:|
+| 1.0 | Sisters of Faith (Life 360)           | 3 / 0 | 520   | 173.3 | 5  | 29 |
+| 2.0 | Trinity Chosen (Trinity Cedar Hill)   | 2 / 1 | 395   | 131.7 | 2  | 26 |
+| 3.0 | Mark My Words (James River)           | 1 / 2 | 375   | 125   | 1  | 21 |
+| 4.0 | Trinity Redeemed (Trinity Cedar Hill) | 0 / 3 | 445   | 148.3 | 3  | 25 |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #  | Quizzer          | Team / Church                         | Total | Avg  | QO | Qs |
+|---:|------------------|---------------------------------------|------:|-----:|---:|---:|
+| 1  | Madison Claunch  | Trinity Redeemed (Trinity Cedar Hill) | 345   | 115  | 3  | 15 |
+| 2  | Riley Breig      | Sisters of Faith (Life 360)           | 290   | 96.7 | 3  | 15 |
+| 3  | Kaitlyn Ramsey   | Sisters of Faith (Life 360)           | 230   | 76.7 | 2  | 14 |
+| 4  | Kaiya Braswell   | Mark My Words (James River)           | 165   | 55   | 1  | 10 |
+| 5  | Isaac Davenport  | Trinity Chosen (Trinity Cedar Hill)   | 150   | 50   | 1  | 8  |
+| 6  | Juliet Amadi     | Trinity Chosen (Trinity Cedar Hill)   | 145   | 48.3 | 1  | 9  |
+| 7  | Naomi McNaughton | Mark My Words (James River)           | 140   | 46.7 |    | 7  |
+| 8  | Joseph Hames     | Trinity Chosen (Trinity Cedar Hill)   | 100   | 33.3 |    | 9  |
+| 9  | Natalie Nailor   | Trinity Redeemed (Trinity Cedar Hill) | 80    | 26.7 |    | 8  |
+| 10 | Danielle Aubrey  | Mark My Words (James River)           | 70    | 23.3 |    | 4  |
+| 11 | Frida Ouedraogo  | Trinity Redeemed (Trinity Cedar Hill) | 20    | 6.7  |    | 2  |
+| 12 | Leah Enke        | Mark My Words (James River)           | 0     |      |    |    |
 

--- a/_pages/history/2017/tournaments/river-classic.md
+++ b/_pages/history/2017/tournaments/river-classic.md
@@ -206,3 +206,58 @@ menubar_toc_static:
 | 14       | Jackson Woodward    | Central-Springfield, MO (Central A/G)              | 0     |      |    | 33%  |
 | **\*14** | Joseph Bogan        | Final Greetings (James River Church)               | 0     |      |    |      |
 
+## Competitor
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                   | W/L   | Total | Avg   | QO | Q%  |
+|----:|-------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Sisters of Faith (Life 360)                     | 9 / 0 | 1730  | 192.2 | 15 | 87% |
+| 2.0 | No Longer Infants (Open Bible Christian Center) | 7 / 2 | 1555  | 172.8 | 9  | 91% |
+| 3.0 | Bite and Devour (James River Church)            | 6 / 3 | 1655  | 183.9 | 13 | 89% |
+| 3.0 | Therefore (James River Church)                  | 6 / 3 | 1420  | 157.8 | 8  | 93% |
+| 3.0 | Mark My Words (James River Church)              | 6 / 3 | 1380  | 153.3 | 6  | 86% |
+| 4.0 | Fruit (James River Church)                      | 5 / 4 | 1610  | 178.9 | 12 | 89% |
+| 5.0 | Flesh and Blood (Bethel Assembly of God)        | 3 / 6 | 600   | 66.7  | 2  | 74% |
+| 6.0 | Calvary Church (David) (Calvary Church)         | 2 / 7 | 820   | 91.1  | 4  | 82% |
+| 7.0 | Building Others Up (Bethel Assembly of God)     | 1 / 8 | 820   | 91.1  | 4  | 83% |
+| 8.0 | Lexington (Sharon) (Lexington First Assembly)   | 0 / 9 | 180   | 20    |    | 59% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                                   | Total | Avg   | QO | Q%   |
+|---------:|----------------------|-------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Kyli Ladd            | No Longer Infants (Open Bible Christian Center) | 1100  | 122.2 | 8  | 98%  |
+| 2        | Josiah Tonsing       | Therefore (James River Church)                  | 1015  | 112.8 | 7  | 93%  |
+| 3        | Riley Breig          | Sisters of Faith (Life 360)                     | 905   | 100.6 | 8  | 92%  |
+| 4        | Abby Dasal           | Fruit (James River Church)                      | 885   | 98.3  | 8  | 92%  |
+| 5        | Kaitlyn Ramsey       | Sisters of Faith (Life 360)                     | 825   | 91.7  | 7  | 83%  |
+| 6        | Micah Tonsing        | Bite and Devour (James River Church)            | 800   | 88.9  | 8  | 92%  |
+| 7        | Truman Griessel      | Bite and Devour (James River Church)            | 795   | 88.3  | 5  | 85%  |
+| 8        | Julianna Torbett     | Mark My Words (James River Church)              | 725   | 80.6  | 4  | 89%  |
+| 9        | Matida MaKoni        | Calvary Church (David) (Calvary Church)         | 605   | 67.2  | 4  | 80%  |
+| 10       | Jonathan Dasal       | Fruit (James River Church)                      | 510   | 56.7  | 4  | 87%  |
+| 11       | Gracee Langstaff     | Building Others Up (Bethel Assembly of God)     | 370   | 41.1  | 2  | 89%  |
+| 12       | Cate Wilhelm         | Building Others Up (Bethel Assembly of God)     | 360   | 40    | 2  | 85%  |
+| 13       | Kaiya Braswell       | Mark My Words (James River Church)              | 360   | 40    | 1  | 92%  |
+| 14       | Hadli Langstaff      | Flesh and Blood (Bethel Assembly of God)        | 315   | 35    | 2  | 72%  |
+| 15       | Lewis Groh           | Therefore (James River Church)                  | 295   | 32.8  | 1  | 92%  |
+| **\*15** | Conor McDaniel       | Mark My Words (James River Church)              | 295   | 32.8  | 1  | 80%  |
+| 16       | Hope Veal            | No Longer Infants (Open Bible Christian Center) | 280   | 31.1  |    | 88%  |
+| 17       | Amber Ragains        | Flesh and Blood (Bethel Assembly of God)        | 245   | 27.2  |    | 81%  |
+| 18       | Tamoghna Mallampalli | Calvary Church (David) (Calvary Church)         | 215   | 23.9  |    | 87%  |
+| **\*18** | Danielle Aubry       | Fruit (James River Church)                      | 215   | 23.9  |    | 87%  |
+| 19       | Anna Veal            | No Longer Infants (Open Bible Christian Center) | 175   | 19.4  | 1  | 79%  |
+| 20       | Nell Davis           | Lexington (Sharon) (Lexington First Assembly)   | 140   | 15.6  |    | 83%  |
+| 21       | Brent Battalgia      | Therefore (James River Church)                  | 110   | 12.2  |    | 91%  |
+| 22       | Isaac Jenkins        | Bite and Devour (James River Church)            | 60    | 6.7   |    | 100% |
+| 23       | Jayda Butts          | Building Others Up (Bethel Assembly of God)     | 50    | 5.6   |    | 67%  |
+| 24       | James Ragains        | Building Others Up (Bethel Assembly of God)     | 40    | 4.4   |    | 67%  |
+| **\*24** | Andrea Devole        | Lexington (Sharon) (Lexington First Assembly)   | 40    | 4.4   |    | 50%  |
+| 25       | Ryan Cottingham      | Flesh and Blood (Bethel Assembly of God)        | 25    | 2.8   |    | 66%  |
+| 26       | Tabor VanDusseldorp  | Flesh and Blood (Bethel Assembly of God)        | 15    | 1.7   |    | 50%  |
+

--- a/_pages/history/2018/tournaments/missouri-classic.md
+++ b/_pages/history/2018/tournaments/missouri-classic.md
@@ -12,7 +12,47 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## Teams
+## Advanced
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                      | W/L   | Total | Avg   | QO | Q%  |
+|----:|----------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Springfield, MO - Life 360 (Life 360)              | 7 / 0 | 1375  | 196.4 | 11 | 82% |
+| 2.0 | Oak Grove, MO - Brookbank (Crown Pointe)           | 5 / 2 | 1225  | 175   | 10 | 72% |
+| 3.1 | Springfield, MO - Sons of Thunder (Evangel Temple) | 3 / 4 | 1025  | 146.4 | 9  | 72% |
+| 4.0 | Houston, TX - Braeswood (Braeswood)                | 3 / 4 | 825   | 117.8 | 6  | 68% |
+| 5.0 | Cedar Hill, TX - Mustard Seeds (Trinity Church)    | 0 / 8 | 445   | 55.6  | 2  | 57% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                                      | Total | Avg  | QO | Q%  |
+|---------:|---------------------|----------------------------------------------------|------:|-----:|---:|----:|
+| 1        | Cameron Ramsey      | Springfield, MO - Life 360 (Life 360)              | 660   | 94.3 | 4  | 86% |
+| 2        | Austin Ramsey       | Springfield, MO - Life 360 (Life 360)              | 640   | 91.4 | 7  | 80% |
+| 3        | Tirzah Brookbank    | Oak Grove, MO - Brookbank (Crown Pointe)           | 535   | 76.4 | 4  | 67% |
+| 4        | Michael Ukonu       | Houston, TX - Braeswood (Braeswood)                | 530   | 75.7 | 5  | 76% |
+| 5        | Josiah Brookbank    | Oak Grove, MO - Brookbank (Crown Pointe)           | 415   | 59.3 | 3  | 81% |
+| 6        | Kara Peters         | Springfield, MO - Sons of Thunder (Evangel Temple) | 395   | 56.4 | 4  | 67% |
+| 7        | Kelise Braithwaite  | Springfield, MO - Sons of Thunder (Evangel Temple) | 345   | 49.3 | 3  | 83% |
+| 8        | Kambria Braithwaite | Springfield, MO - Sons of Thunder (Evangel Temple) | 290   | 41.4 | 2  | 72% |
+| 9        | Rachel Brookbank    | Oak Grove, MO - Brookbank (Crown Pointe)           | 285   | 40.7 | 3  | 70% |
+| 10       | Jose Lopez          | Houston, TX - Braeswood (Braeswood)                | 250   | 35.7 | 1  | 67% |
+| 11       | Josh Barajas        | Cedar Hill, TX - Mustard Seeds (Trinity Church)    | 205   | 25.6 | 2  | 49% |
+| 12       | Madison Claunch     | Cedar Hill, TX - Mustard Seeds (Trinity Church)    | 155   | 19.4 |    | 90% |
+| 13       | Kaitlyn Ramsey      | Springfield, MO - Life 360 (Life 360)              | 80    | 11.4 |    | 75% |
+| 14       | Ethan Pickrell      | Cedar Hill, TX - Mustard Seeds (Trinity Church)    | 85    | 10.6 |    | 56% |
+| 15       | Anyiah Odera        | Houston, TX - Braeswood (Braeswood)                | 30    | 4.3  |    | 54% |
+| **\*15** | William Adu-Gyamfi  | Houston, TX - Braeswood (Braeswood)                | 30    | 4.3  |    | 50% |
+| 16       | Julia Sullivan      | Cedar Hill, TX - Mustard Seeds (Trinity Church)    | 0     |      |    | 50% |
+
+## Middle School
+
+### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points*
 
@@ -25,7 +65,7 @@ menubar_toc_static:
 | 5.0 | Ozark MO - El Equipo (James River Church)                      | 4 / 6 | 985   | 98.5  | 4  | 68% |
 | 6.0 | Springfield, MO - The Unknown (Praise AG )                     | 1 / 9 | 415   | 41.5  |    | 72% |
 
-## Individuals
+### Individuals
 
 *Ties broken by Average Points then Total Quiz Outs*
 

--- a/_pages/history/2019/tournaments/missouri-classic.md
+++ b/_pages/history/2019/tournaments/missouri-classic.md
@@ -114,6 +114,45 @@ menubar_toc_static:
 | **\*13** | Elijah Lee          | Trinity (Trinity Church-Cedar Hill, TX)                                 | 0     |      |    |     |
 | 14       | Kodi Ladd           | Called, Wise, Influential, and Noble (Open Bible Church-Rapid City, SD) | -10   | -2.5 |    |     |
 
+## Challenger
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                      | W/L   | Total | Avg | QO | Q%  |
+|----:|----------------------------------------------------|-------|------:|----:|---:|----:|
+| 1.1 | Princeton (Legacy Church-Princeton, TX)            | 4 / 1 | 505   | 101 | 3  | 80% |
+| 2.0 | Rolla (First Assembly-Rolla, MO)                   | 4 / 1 | 345   | 69  | 2  | 77% |
+| 3.1 | Louisville (First Assembly-Louisville, OH)         | 3 / 2 | 440   | 88  | 4  | 69% |
+| 4.0 | CrossPoint (CrossPoint-Portage, WI)                | 3 / 2 | 255   | 51  | 1  | 83% |
+| 5.0 | Thank God for Us (The Oaks-Red Oak, TX)            | 1 / 4 | 235   | 47  | 3  | 66% |
+| 6.0 | Resolved to Know Something (Bethel-Rapid City, SD) | 0 / 5 | 25    | 5   |    | 54% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                      | Total | Avg | QO | Q%   |
+|---------:|-------------------|----------------------------------------------------|------:|----:|---:|-----:|
+| 1        | Brooke Smith      | Princeton (Legacy Church-Princeton, TX)            | 290   | 58  | 2  | 82%  |
+| 2        | Caleb Cullins     | Louisville (First Assembly-Louisville, OH)         | 285   | 57  | 3  | 67%  |
+| 3        | Gannon Breig      | Rolla (First Assembly-Rolla, MO)                   | 285   | 57  | 2  | 78%  |
+| 4        | Scott Smith       | Thank God for Us (The Oaks-Red Oak, TX)            | 235   | 47  | 3  | 76%  |
+| 5        | Emma Schoessow    | CrossPoint (CrossPoint-Portage, WI)                | 220   | 44  | 1  | 84%  |
+| 6        | Jadyn Prom        | Princeton (Legacy Church-Princeton, TX)            | 205   | 41  | 1  | 83%  |
+| 7        | Bekah Gross       | Louisville (First Assembly-Louisville, OH)         | 155   | 31  | 1  | 74%  |
+| 8        | Riley Breig       | Rolla (First Assembly-Rolla, MO)                   | 60    | 12  |    | 75%  |
+| 9        | Israel Sparling   | CrossPoint (CrossPoint-Portage, WI)                | 35    | 7   |    | 80%  |
+| 10       | Amber Ragains     | Resolved to Know Something (Bethel-Rapid City, SD) | 15    | 3   |    | 100% |
+| 11       | Billy Howard      | Princeton (Legacy Church-Princeton, TX)            | 10    | 2   |    | 60%  |
+| 12       | Gracee Langstaff  | Resolved to Know Something (Bethel-Rapid City, SD) | 5     | 1   |    | 50%  |
+| **\*12** | Lindsay Spire     | Resolved to Know Something (Bethel-Rapid City, SD) | 5     | 1   |    | 44%  |
+| **\*12** | Elyssa Fulfer     | Thank God for Us (The Oaks-Red Oak, TX)            | 5     | 1   |    | 40%  |
+| 13       | Alex Hernandez    | Princeton (Legacy Church-Princeton, TX)            | 0     |     |    |      |
+| **\*13** | Cate Wilhelm      | Resolved to Know Something (Bethel-Rapid City, SD) | 0     |     |    |      |
+| 14       | Jason Bartholomew | Thank God for Us (The Oaks-Red Oak, TX)            | -5    | -1  |    | 43%  |
+
 
 ## Contender
 

--- a/_pages/history/2019/tournaments/windy-city-classic.md
+++ b/_pages/history/2019/tournaments/windy-city-classic.md
@@ -12,7 +12,9 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## Teams
+## Championship
+
+### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points*
 
@@ -34,7 +36,7 @@ menubar_toc_static:
 | 14.0 | Naperville-IL (S) (Calvary Church)            | 3 / 11 | 615   | 43.9  | 1  | 64% |
 | 15.0 | Bellevue-WA #2 (Bellevue Neighborhood Church) | 0 / 14 | 60    | 4.3   |    | 44% |
 
-## Individuals
+### Individuals
 
 *Ties broken by Average Points then Total Quiz Outs*
 
@@ -88,4 +90,35 @@ menubar_toc_static:
 | 40       | Marisa Gephart        | Tucson-AZ (Victory Worship Center)            | -30   | -2.1  |    | 37%  |
 | **\*40** | Aaron Lane            | Germantown-WI (Life church)                   | -30   | -2.1  |    | 25%  |
 | 41       | Ryan Matta            | Bellevue-WA #2 (Bellevue Neighborhood Church) | -50   | -3.6  |    | 12%  |
+
+## Contender
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                       | W/L   | Total | Avg   | QO | Q%  |
+|----:|-----------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Lexington-KY (First Assembly of God)                | 9 / 0 | 1580  | 175.5 | 14 | 86% |
+| 2.0 | Naperville-IL (Calvary Church)                      | 6 / 3 | 1070  | 118.9 | 10 | 80% |
+| 3.0 | Warner Robins-GA #1 (The Assembly at Warner Robins) | 3 / 6 | 335   | 37.2  |    | 81% |
+| 4.0 | Warner Robins-GA #2 (The Assembly at Warner Robins) | 0 / 9 | 45    | 5     |    | 80% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #  | Quizzer           | Team / Church                                       | Total | Avg  | QO | Q%   |
+|---:|-------------------|-----------------------------------------------------|------:|-----:|---:|-----:|
+| 1  | Caleb Song        | Lexington-KY (First Assembly of God)                | 900   | 100  | 8  | 83%  |
+| 2  | Reagan Stevens    | Naperville-IL (Calvary Church)                      | 695   | 77.2 | 7  | 84%  |
+| 3  | Sarah Lin         | Lexington-KY (First Assembly of God)                | 680   | 75.6 | 6  | 89%  |
+| 4  | David Biruduganti | Naperville-IL (Calvary Church)                      | 375   | 41.7 | 3  | 74%  |
+| 5  | Grace Surber      | Warner Robins-GA #1 (The Assembly at Warner Robins) | 205   | 22.8 |    | 84%  |
+| 6  | Ethan Bender      | Warner Robins-GA #1 (The Assembly at Warner Robins) | 105   | 11.7 |    | 80%  |
+| 7  | Sadie Surber      | Warner Robins-GA #2 (The Assembly at Warner Robins) | 50    | 5.6  |    | 100% |
+| 8  | Gavin Booth       | Warner Robins-GA #1 (The Assembly at Warner Robins) | 20    | 2.2  |    | 75%  |
+| 9  | Elija Lawson      | Warner Robins-GA #1 (The Assembly at Warner Robins) | 5     | .6   |    | 66%  |
+| 10 | Gabby Graham      | Warner Robins-GA #2 (The Assembly at Warner Robins) | 0     |      |    |      |
+| 11 | Tommy Antkowiak   | Warner Robins-GA #2 (The Assembly at Warner Robins) | -5    | -.6  |    |      |
 

--- a/_pages/history/2021/nationals.md
+++ b/_pages/history/2021/nationals.md
@@ -16,7 +16,7 @@ menubar_toc_static:
 
 ### Teams
 
-|     | Team / Church                                             | W-L  | Pts  | Avg   | QO  | Q%  | 30s | 20s | 10s |
+|     | Team / Church                                               | W-L  | Pts  | Avg   | QO  | Q%  | 30s | 20s | 10s |
 | --- | ----------------------------------------------------------- | ---- | ---- | ----- | --- | --- | --- | --- | --- |
 | 1   | Calvary Church - J (Naperville, IL)                         | 17-2 | 4030 | 212.1 | 34  | 74% | 37  | 104 | 80  |
 | 2   | Ponraj Family (Deeper Church, Burien, WA)                   | 15-4 | 3880 | 204.2 | 31  | 77% | 35  | 96  | 81  |
@@ -43,183 +43,439 @@ menubar_toc_static:
 
 ### Individuals
 
-| #    | Quizzer              | Team / Church                                             | Pts  | Avg   | QO  | Q%   | 30s | 20s | 10s |
-| ---- | -------------------- | ----------------------------------------------------------- | ---- | ----- | --- | ---- | --- | --- | --- |
-| 1    | Zachary Ponraj       | Ponraj Family (Deeper Church, Burien, WA)                   | 2140 | 112.6 | 16  | 83%  | 33  | 49  | 5   |
-| 2    | Joshua Barajas       | Trinity One (Trinity Church, TX)                            | 2110 | 111.1 | 16  | 81%  | 32  | 53  | 5   |
-| 3    | Samuel Jebaraj       | Warriors of the Faith (Bethel Church, San Jose, CA)         | 1985 | 104.5 | 16  | 78%  | 28  | 49  | 13  |
-| 4    | Shreanna Powell      | Calvary Church - J (Naperville, IL)                         | 1975 | 103.9 | 16  | 82%  | 22  | 57  | 6   |
-| 5    | Nigus Dawit          | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 1955 | 102.9 | 15  | 78%  | 24  | 58  | 4   |
-| 6    | Cameron Ramsey       | Ramsey Family (Springfield, MO)                             | 1745 | 91.8  | 12  | 81%  | 22  | 44  | 16  |
-| 7    | Seth Robertson       | Sharper than Swords (Central Assembly, Houston, PA)         | 1665 | 87.6  | 12  | 76%  | 17  | 55  | 7   |
-| 8    | Sheldon Powell       | Calvary Church - J (Naperville, IL)                         | 1655 | 87.1  | 17  | 80%  | 13  | 38  | 37  |
-| 9    | Camden Haney         | Terrifying Sights (Trinity Church, TX)                      | 1610 | 84.7  | 12  | 71%  | 16  | 60  | 4   |
-| 10   | Toby Hill            | Living Hope (Swedesboro, NJ)                                | 1580 | 83.2  | 10  | 74%  | 20  | 44  | 17  |
-| 11   | Rachel Brookbank     | The Brookbanks (Colorado Springs, CO)                       | 1535 | 80.8  | 10  | 73%  | 17  | 56  | 4   |
-| 12   | Jayden Nimako        | Radiant Life Church (Dublin, OH)                            | 1525 | 80.3  | 10  | 81%  | 20  | 35  | 22  |
-| 13   | Sam Clinston         | Don\`t Run from the Lord (Bellevue Church, Bellevue, WA)    | 1490 | 78.4  | 12  | 73%  | 17  | 47  | 13  |
-| 14   | Shawn Timothy        | Calvary Church - S (Naperville, IL)                         | 1445 | 76.1  | 9   | 71%  | 15  | 56  | 2   |
-| 15   | Alex Jarrell         | Proven Geniuses (Cedar Park, Bothell, WA)                   | 1320 | 69.5  | 10  | 70%  | 17  | 41  | 16  |
-| 16   | Kaitlyn Ramsey       | Ramsey Family (Springfield, MO)                             | 1305 | 68.7  | 15  | 83%  | 1   | 21  | 68  |
-| 17   | Darcie Harr          | Scoffers Gonna Scoff (Journey Life Church, Holt, MI)        | 1305 | 68.7  | 6   | 70%  | 16  | 48  | 8   |
-| 18   | Zane Brown           | Human Rejects (First at Firewheel, Garland, TX)             | 1245 | 65.5  | 13  | 78%  | 6   | 24  | 53  |
-| 19   | Graham Hoffmann      | The New Order (Redeemer Church, Utica, NY)                  | 1180 | 62.1  | 12  | 74%  | 8   | 20  | 53  |
-| 20   | Christian Stevens    | The New Order (Redeemer Church, Utica, NY)                  | 1080 | 56.8  | 9   | 67%  | 4   | 49  | 13  |
-| 21   | Jehosh Jebaraj       | Race Runners (Carolinas Christian Assembly, Charlotte, NC)  | 1025 | 53.9  | 9   | 69%  | 10  | 30  | 28  |
-| 22   | Noah Claunch         | Trinity One (Trinity Church, TX)                            | 1015 | 53.4  | 11  | 78%  | 2   | 14  | 61  |
-| 23   | Hadassah Brookbank   | The Brookbanks (Colorado Springs, CO)                       | 1010 | 53.2  | 8   | 71%  | 7   | 24  | 41  |
-| 24   | Cole Abbott          | Elaborate Hairstyles (New Life Assembly, Sparta, WI)        | 970  | 51.1  | 8   | 67%  | 8   | 29  | 31  |
-| 25   | Joanne Ramesh        | Human Rejects (First at Firewheel, Garland, TX)             | 950  | 50    | 5   | 71%  | 4   | 37  | 20  |
-| 26   | Simeon Ponraj        | Ponraj Family (Deeper Church, Burien, WA)                   | 915  | 48.2  | 10  | 68%  | 2   | 23  | 40  |
-| 27   | Hansel John          | Warriors of the Faith (Bethel Church, San Jose, CA)         | 900  | 47.4  | 7   | 76%  | 2   | 26  | 35  |
-| 28   | Emma Schoessow       | Alive and Active (CrossPoint AG, Portage, WI)               | 895  | 47.1  | 4   | 65%  | 9   | 43  |     |
-| 29   | Logan Webb           | Sharper than Swords (Central Assembly, Houston, PA)         | 870  | 45.8  | 5   | 81%  | 5   | 18  | 36  |
-| 30   | Elaina Ponraj        | Ponraj Family (Deeper Church, Burien, WA)                   | 845  | 44.5  | 5   | 81%  |     | 24  | 36  |
-| 31   | Josiah Brookbank     | The Brookbanks (Colorado Springs, CO)                       | 825  | 43.4  | 8   | 68%  | 4   | 19  | 44  |
-| 32   | Harrison Stevens     | Calvary Church - S (Naperville, IL)                         | 790  | 41.6  | 9   | 77%  |     | 3   | 66  |
-| 33   | Amaya Kocher         | Sharper than Swords (Central Assembly, Houston, PA)         | 775  | 40.8  | 6   | 79%  | 2   | 11  | 48  |
-| 34   | Janelle Nimako       | Radiant Life Church (Dublin, OH)                            | 760  | 40    | 5   | 70%  | 3   | 28  | 23  |
-| 35   | Jonathan Mafe        | Scoffers Gonna Scoff (Journey Life Church, Holt, MI)        | 755  | 39.7  | 8   | 71%  | 1   | 9   | 60  |
-| 36   | Micah DeSanto        | Living Hope (Swedesboro, NJ)                                | 740  | 38.9  | 7   | 71%  | 1   | 9   | 54  |
-| 37   | Emily Thomas         | Race Runners (Carolinas Christian Assembly, Charlotte, NC)  | 715  | 37.6  | 5   | 74%  | 1   | 23  | 29  |
-| 38   | Josi Haugo           | Proven Geniuses (Cedar Park, Bothell, WA)                   | 605  | 31.8  | 4   | 64%  | 6   | 17  | 34  |
-| 39   | Seth Christopher     | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 570  | 30    | 5   | 67%  |     | 12  | 42  |
-| 40   | Elizabeth Godavarthi | Don\`t Run from the Lord (Bellevue Church, Bellevue, WA)    | 445  | 23.4  | 1   | 75%  | 1   | 12  | 24  |
-| 41   | Aaron Hoffmann       | The New Order (Redeemer Church, Utica, NY)                  | 420  | 22.1  | 2   | 68%  | 4   | 11  | 17  |
-| 42   | Joseph Barajas       | Terrifying Sights (Trinity Church, TX)                      | 410  | 21.6  | 4   | 58%  | 1   | 9   | 34  |
-| 43   | Joy Escobar          | Terrifying Sights (Trinity Church, TX)                      | 360  | 18.9  | 3   | 72%  |     | 2   | 34  |
-| 44   | Shaymis Powell       | Calvary Church - J (Naperville, IL)                         | 355  | 18.7  | 1   | 60%  | 2   | 6   | 31  |
-| 45   | Bryce Helgerson      | Elaborate Hairstyles (New Life Assembly, Sparta, WI)        | 350  | 18.4  |     | 86%  |     | 2   | 35  |
-| 46   | Ava Schoessow        | Alive and Active (CrossPoint AG, Portage, WI)               | 305  | 16.1  |     | 70%  |     | 2   | 36  |
-| 47   | Julia Sullivan       | Trinity One (Trinity Church, TX)                            | 265  | 13.9  | 2   | 75%  |     | 7   | 17  |
-| 48   | Lilli Haugo          | Proven Geniuses (Cedar Park, Bothell, WA)                   | 255  | 13.4  | 1   | 70%  |     | 10  | 11  |
-| 49   | Krysle John          | Warriors of the Faith (Bethel Church, San Jose, CA)         | 240  | 12.6  | 1   | 85%  |     | 1   | 22  |
-| 50   | Glory Stevens        | The New Order (Redeemer Church, Utica, NY)                  | 215  | 11.3  |     | 66%  | 2   | 5   | 16  |
-| 50 | Ryan Matta           | Don\`t Run from the Lord (Bellevue Church, Bellevue, WA)    | 215  | 11.3  |     | 57%  |     | 7   | 22  |
-| 51   | Alyssa Ramsey        | Ramsey Family (Springfield, MO)                             | 195  | 10.3  |     | 79%  | 1   | 5   | 9   |
-| 52   | Elijah Lee           | Trinity One (Trinity Church, TX)                            | 145  | 7.6   |     | 92%  |     | 4   | 7   |
-| 53   | Jacob Thomas         | Race Runners (Carolinas Christian Assembly, Charlotte, NC)  | 140  | 7.4   |     | 80%  | 1   | 6   | 1   |
-| 54   | Abel Karthik         | Radiant Life Church (Dublin, OH)                            | 125  | 6.6   |     | 65%  |     | 4   | 9   |
-| 55   | Aulora Sullivan      | Terrifying Sights (Trinity Church, TX)                      | 100  | 5.3   |     | 69%  |     | 4   | 5   |
-| 55 | David Kwabi-Addo     | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 100  | 5.3   |     | 67%  |     | 4   | 6   |
-| 56   | Maddie Clements      | Alive and Active (CrossPoint AG, Portage, WI)               | 65   | 3.4   |     | 100% |     |     | 7   |
-| 57   | Shaylee Powell       | Calvary Church - J (Naperville, IL)                         | 60   | 3.2   |     | 50%  |     | 3   | 6   |
-| 58   | Reagan Stevens       | Calvary Church - S (Naperville, IL)                         | 55   | 2.9   |     | 57%  | 1   | 1   | 2   |
-| 59   | Avinash Poguluri     | Don\`t Run from the Lord (Bellevue Church, Bellevue, WA)    | 50   | 2.6   |     | 100% |     | 2   | 1   |
-| 60   | Cierra Convis        | Scoffers Gonna Scoff (Journey Life Church, Holt, MI)        | 35   | 1.8   |     | 100% |     | 1   | 2   |
-| 61   | Pierce Stevens       | Calvary Church - S (Naperville, IL)                         | 20   | 1.1   |     | 66%  |     | 1   | 1   |
-| 62   | Ndubueze Echefu      | Human Rejects (First at Firewheel, Garland, TX)             | 15   | .8    |     | 66%  |     |     | 2   |
-| 62 | Eric Carty           | Living Hope (Swedesboro, NJ)                                | 15   | .8    |     | 37%  |     |     | 3   |
-| 62 | Jerusha Jebaraj      | Race Runners (Carolinas Christian Assembly, Charlotte, NC)  | 15   | .8    |     | 36%  |     | 2   | 2   |
-| 63   | Madison Claunch      | Trinity One (Trinity Church, TX)                            | 0    |       |     | %    |     |     |     |
-| 63 | Abenezer Mekuria     | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 0    |       |     | %    |     |     |     |
-| 63 | McKinley Stevens     | Calvary Church - S (Naperville, IL)                         | 0    |       |     | %    |     |     |     |
-| 63 | Noah Lee             | Terrifying Sights (Trinity Church, TX)                      | 0    |       |     | %    |     |     |     |
-| 64   | Danny\`El Gonzalez   | Human Rejects (First at Firewheel, Garland, TX)             | \-5  | \-.3  |     | 50%  |     |     | 2   |
-| 64 | Padmini Abothu       | Don\`t Run from the Lord (Bellevue Church, Bellevue, WA)    | \-5  | \-.3  |     | %    |     |     |     |
+| #   | Quizzer              | Team / Church                                               | Pts  | Avg   | QO  | Q%   | 30s | 20s | 10s |
+| --- | -------------------- | ----------------------------------------------------------- | ---- | ----- | --- | ---- | --- | --- | --- |
+| 1   | Zachary Ponraj       | Ponraj Family (Deeper Church, Burien, WA)                   | 2140 | 112.6 | 16  | 83%  | 33  | 49  | 5   |
+| 2   | Joshua Barajas       | Trinity One (Trinity Church, TX)                            | 2110 | 111.1 | 16  | 81%  | 32  | 53  | 5   |
+| 3   | Samuel Jebaraj       | Warriors of the Faith (Bethel Church, San Jose, CA)         | 1985 | 104.5 | 16  | 78%  | 28  | 49  | 13  |
+| 4   | Shreanna Powell      | Calvary Church - J (Naperville, IL)                         | 1975 | 103.9 | 16  | 82%  | 22  | 57  | 6   |
+| 5   | Nigus Dawit          | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 1955 | 102.9 | 15  | 78%  | 24  | 58  | 4   |
+| 6   | Cameron Ramsey       | Ramsey Family (Springfield, MO)                             | 1745 | 91.8  | 12  | 81%  | 22  | 44  | 16  |
+| 7   | Seth Robertson       | Sharper than Swords (Central Assembly, Houston, PA)         | 1665 | 87.6  | 12  | 76%  | 17  | 55  | 7   |
+| 8   | Sheldon Powell       | Calvary Church - J (Naperville, IL)                         | 1655 | 87.1  | 17  | 80%  | 13  | 38  | 37  |
+| 9   | Camden Haney         | Terrifying Sights (Trinity Church, TX)                      | 1610 | 84.7  | 12  | 71%  | 16  | 60  | 4   |
+| 10  | Toby Hill            | Living Hope (Swedesboro, NJ)                                | 1580 | 83.2  | 10  | 74%  | 20  | 44  | 17  |
+| 11  | Rachel Brookbank     | The Brookbanks (Colorado Springs, CO)                       | 1535 | 80.8  | 10  | 73%  | 17  | 56  | 4   |
+| 12  | Jayden Nimako        | Radiant Life Church (Dublin, OH)                            | 1525 | 80.3  | 10  | 81%  | 20  | 35  | 22  |
+| 13  | Sam Clinston         | Don\`t Run from the Lord (Bellevue Church, Bellevue, WA)    | 1490 | 78.4  | 12  | 73%  | 17  | 47  | 13  |
+| 14  | Shawn Timothy        | Calvary Church - S (Naperville, IL)                         | 1445 | 76.1  | 9   | 71%  | 15  | 56  | 2   |
+| 15  | Alex Jarrell         | Proven Geniuses (Cedar Park, Bothell, WA)                   | 1320 | 69.5  | 10  | 70%  | 17  | 41  | 16  |
+| 16  | Kaitlyn Ramsey       | Ramsey Family (Springfield, MO)                             | 1305 | 68.7  | 15  | 83%  | 1   | 21  | 68  |
+| 17  | Darcie Harr          | Scoffers Gonna Scoff (Journey Life Church, Holt, MI)        | 1305 | 68.7  | 6   | 70%  | 16  | 48  | 8   |
+| 18  | Zane Brown           | Human Rejects (First at Firewheel, Garland, TX)             | 1245 | 65.5  | 13  | 78%  | 6   | 24  | 53  |
+| 19  | Graham Hoffmann      | The New Order (Redeemer Church, Utica, NY)                  | 1180 | 62.1  | 12  | 74%  | 8   | 20  | 53  |
+| 20  | Christian Stevens    | The New Order (Redeemer Church, Utica, NY)                  | 1080 | 56.8  | 9   | 67%  | 4   | 49  | 13  |
+| 21  | Jehosh Jebaraj       | Race Runners (Carolinas Christian Assembly, Charlotte, NC)  | 1025 | 53.9  | 9   | 69%  | 10  | 30  | 28  |
+| 22  | Noah Claunch         | Trinity One (Trinity Church, TX)                            | 1015 | 53.4  | 11  | 78%  | 2   | 14  | 61  |
+| 23  | Hadassah Brookbank   | The Brookbanks (Colorado Springs, CO)                       | 1010 | 53.2  | 8   | 71%  | 7   | 24  | 41  |
+| 24  | Cole Abbott          | Elaborate Hairstyles (New Life Assembly, Sparta, WI)        | 970  | 51.1  | 8   | 67%  | 8   | 29  | 31  |
+| 25  | Joanne Ramesh        | Human Rejects (First at Firewheel, Garland, TX)             | 950  | 50    | 5   | 71%  | 4   | 37  | 20  |
+| 26  | Simeon Ponraj        | Ponraj Family (Deeper Church, Burien, WA)                   | 915  | 48.2  | 10  | 68%  | 2   | 23  | 40  |
+| 27  | Hansel John          | Warriors of the Faith (Bethel Church, San Jose, CA)         | 900  | 47.4  | 7   | 76%  | 2   | 26  | 35  |
+| 28  | Emma Schoessow       | Alive and Active (CrossPoint AG, Portage, WI)               | 895  | 47.1  | 4   | 65%  | 9   | 43  |     |
+| 29  | Logan Webb           | Sharper than Swords (Central Assembly, Houston, PA)         | 870  | 45.8  | 5   | 81%  | 5   | 18  | 36  |
+| 30  | Elaina Ponraj        | Ponraj Family (Deeper Church, Burien, WA)                   | 845  | 44.5  | 5   | 81%  |     | 24  | 36  |
+| 31  | Josiah Brookbank     | The Brookbanks (Colorado Springs, CO)                       | 825  | 43.4  | 8   | 68%  | 4   | 19  | 44  |
+| 32  | Harrison Stevens     | Calvary Church - S (Naperville, IL)                         | 790  | 41.6  | 9   | 77%  |     | 3   | 66  |
+| 33  | Amaya Kocher         | Sharper than Swords (Central Assembly, Houston, PA)         | 775  | 40.8  | 6   | 79%  | 2   | 11  | 48  |
+| 34  | Janelle Nimako       | Radiant Life Church (Dublin, OH)                            | 760  | 40    | 5   | 70%  | 3   | 28  | 23  |
+| 35  | Jonathan Mafe        | Scoffers Gonna Scoff (Journey Life Church, Holt, MI)        | 755  | 39.7  | 8   | 71%  | 1   | 9   | 60  |
+| 36  | Micah DeSanto        | Living Hope (Swedesboro, NJ)                                | 740  | 38.9  | 7   | 71%  | 1   | 9   | 54  |
+| 37  | Emily Thomas         | Race Runners (Carolinas Christian Assembly, Charlotte, NC)  | 715  | 37.6  | 5   | 74%  | 1   | 23  | 29  |
+| 38  | Josi Haugo           | Proven Geniuses (Cedar Park, Bothell, WA)                   | 605  | 31.8  | 4   | 64%  | 6   | 17  | 34  |
+| 39  | Seth Christopher     | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 570  | 30    | 5   | 67%  |     | 12  | 42  |
+| 40  | Elizabeth Godavarthi | Don\`t Run from the Lord (Bellevue Church, Bellevue, WA)    | 445  | 23.4  | 1   | 75%  | 1   | 12  | 24  |
+| 41  | Aaron Hoffmann       | The New Order (Redeemer Church, Utica, NY)                  | 420  | 22.1  | 2   | 68%  | 4   | 11  | 17  |
+| 42  | Joseph Barajas       | Terrifying Sights (Trinity Church, TX)                      | 410  | 21.6  | 4   | 58%  | 1   | 9   | 34  |
+| 43  | Joy Escobar          | Terrifying Sights (Trinity Church, TX)                      | 360  | 18.9  | 3   | 72%  |     | 2   | 34  |
+| 44  | Shaymis Powell       | Calvary Church - J (Naperville, IL)                         | 355  | 18.7  | 1   | 60%  | 2   | 6   | 31  |
+| 45  | Bryce Helgerson      | Elaborate Hairstyles (New Life Assembly, Sparta, WI)        | 350  | 18.4  |     | 86%  |     | 2   | 35  |
+| 46  | Ava Schoessow        | Alive and Active (CrossPoint AG, Portage, WI)               | 305  | 16.1  |     | 70%  |     | 2   | 36  |
+| 47  | Julia Sullivan       | Trinity One (Trinity Church, TX)                            | 265  | 13.9  | 2   | 75%  |     | 7   | 17  |
+| 48  | Lilli Haugo          | Proven Geniuses (Cedar Park, Bothell, WA)                   | 255  | 13.4  | 1   | 70%  |     | 10  | 11  |
+| 49  | Krysle John          | Warriors of the Faith (Bethel Church, San Jose, CA)         | 240  | 12.6  | 1   | 85%  |     | 1   | 22  |
+| 50  | Glory Stevens        | The New Order (Redeemer Church, Utica, NY)                  | 215  | 11.3  |     | 66%  | 2   | 5   | 16  |
+| 50  | Ryan Matta           | Don\`t Run from the Lord (Bellevue Church, Bellevue, WA)    | 215  | 11.3  |     | 57%  |     | 7   | 22  |
+| 51  | Alyssa Ramsey        | Ramsey Family (Springfield, MO)                             | 195  | 10.3  |     | 79%  | 1   | 5   | 9   |
+| 52  | Elijah Lee           | Trinity One (Trinity Church, TX)                            | 145  | 7.6   |     | 92%  |     | 4   | 7   |
+| 53  | Jacob Thomas         | Race Runners (Carolinas Christian Assembly, Charlotte, NC)  | 140  | 7.4   |     | 80%  | 1   | 6   | 1   |
+| 54  | Abel Karthik         | Radiant Life Church (Dublin, OH)                            | 125  | 6.6   |     | 65%  |     | 4   | 9   |
+| 55  | Aulora Sullivan      | Terrifying Sights (Trinity Church, TX)                      | 100  | 5.3   |     | 69%  |     | 4   | 5   |
+| 55  | David Kwabi-Addo     | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 100  | 5.3   |     | 67%  |     | 4   | 6   |
+| 56  | Maddie Clements      | Alive and Active (CrossPoint AG, Portage, WI)               | 65   | 3.4   |     | 100% |     |     | 7   |
+| 57  | Shaylee Powell       | Calvary Church - J (Naperville, IL)                         | 60   | 3.2   |     | 50%  |     | 3   | 6   |
+| 58  | Reagan Stevens       | Calvary Church - S (Naperville, IL)                         | 55   | 2.9   |     | 57%  | 1   | 1   | 2   |
+| 59  | Avinash Poguluri     | Don\`t Run from the Lord (Bellevue Church, Bellevue, WA)    | 50   | 2.6   |     | 100% |     | 2   | 1   |
+| 60  | Cierra Convis        | Scoffers Gonna Scoff (Journey Life Church, Holt, MI)        | 35   | 1.8   |     | 100% |     | 1   | 2   |
+| 61  | Pierce Stevens       | Calvary Church - S (Naperville, IL)                         | 20   | 1.1   |     | 66%  |     | 1   | 1   |
+| 62  | Ndubueze Echefu      | Human Rejects (First at Firewheel, Garland, TX)             | 15   | .8    |     | 66%  |     |     | 2   |
+| 62  | Eric Carty           | Living Hope (Swedesboro, NJ)                                | 15   | .8    |     | 37%  |     |     | 3   |
+| 62  | Jerusha Jebaraj      | Race Runners (Carolinas Christian Assembly, Charlotte, NC)  | 15   | .8    |     | 36%  |     | 2   | 2   |
+| 63  | Madison Claunch      | Trinity One (Trinity Church, TX)                            | 0    |       |     | %    |     |     |     |
+| 63  | Abenezer Mekuria     | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 0    |       |     | %    |     |     |     |
+| 63  | McKinley Stevens     | Calvary Church - S (Naperville, IL)                         | 0    |       |     | %    |     |     |     |
+| 63  | Noah Lee             | Terrifying Sights (Trinity Church, TX)                      | 0    |       |     | %    |     |     |     |
+| 64  | Danny\`El Gonzalez   | Human Rejects (First at Firewheel, Garland, TX)             | \-5  | \-.3  |     | 50%  |     |     | 2   |
+| 64  | Padmini Abothu       | Don\`t Run from the Lord (Bellevue Church, Bellevue, WA)    | \-5  | \-.3  |     | %    |     |     |     |
 
 ## Challenger Results
 
 ### Teams
 
-|     | Team / Church                                                              | W-L  | Pts  | Avg   | QO  | Q%  | 30s | 20s | 10s |
-| --- | ------------------------------------------------------------------------ | ---- | ---- | ----- | --- | --- | --- | --- | --- |
-| 1   | Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA)          | 16-2 | 3745 | 208   | 28  | 80% | 35  | 89  | 87  |
-| 2   | Living Water Dolphins (Living Water Bible Church, CA)                  | 16-2 | 3040 | 168.9 | 24  | 81% | 29  | 76  | 53  |
-| 3   | Braeswood Assembly (Houston, TX)                                       | 15-3 | 2840 | 157.8 | 18  | 79% | 28  | 64  | 76  |
-| 4   | Order of Aaron (First Assembly, Lexington, KY)                         | 14-4 | 2560 | 142.2 | 17  | 76% | 11  | 75  | 88  |
+|     | Team / Church                                                         | W-L  | Pts  | Avg   | QO  | Q%  | 30s | 20s | 10s |
+| --- | --------------------------------------------------------------------- | ---- | ---- | ----- | --- | --- | --- | --- | --- |
+| 1   | Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA)         | 16-2 | 3745 | 208   | 28  | 80% | 35  | 89  | 87  |
+| 2   | Living Water Dolphins (Living Water Bible Church, CA)                 | 16-2 | 3040 | 168.9 | 24  | 81% | 29  | 76  | 53  |
+| 3   | Braeswood Assembly (Houston, TX)                                      | 15-3 | 2840 | 157.8 | 18  | 79% | 28  | 64  | 76  |
+| 4   | Order of Aaron (First Assembly, Lexington, KY)                        | 14-4 | 2560 | 142.2 | 17  | 76% | 11  | 75  | 88  |
 | 5   | God\`s Elect From Oklahoma (Mustang, OK)                              | 13-5 | 2305 | 128   | 20  | 74% | 21  | 49  | 73  |
 | 6   | Culmination of the Ages (Covenant Life, Cary, NC)                     | 12-6 | 2250 | 125   | 18  | 76% | 15  | 60  | 69  |
 | 7   | More Than Conquerors (Atlanta Indian Prayer Fellowship, Marietta, GA) | 11-7 | 2550 | 141.7 | 20  | 86% | 15  | 60  | 70  |
 | 8   | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 11-7 | 2255 | 125.3 | 16  | 84% | 27  | 56  | 19  |
-| 9   | Legit Daughters (Open Bible Church, Rapid City, SD)                    | 11-7 | 2090 | 116.1 | 14  | 77% | 25  | 50  | 37  |
-| 10  | Double Edged (Praise Church, Garfield, NJ)                             | 10-8 | 2265 | 125.8 | 20  | 78% | 10  | 61  | 73  |
-| 11  | People are like Grass (Life Church, Germantown, WI)                    | 9-9  | 1605 | 89.2  | 13  | 72% | 1   | 45  | 82  |
+| 9   | Legit Daughters (Open Bible Church, Rapid City, SD)                   | 11-7 | 2090 | 116.1 | 14  | 77% | 25  | 50  | 37  |
+| 10  | Double Edged (Praise Church, Garfield, NJ)                            | 10-8 | 2265 | 125.8 | 20  | 78% | 10  | 61  | 73  |
+| 11  | People are like Grass (Life Church, Germantown, WI)                   | 9-9  | 1605 | 89.2  | 13  | 72% | 1   | 45  | 82  |
 | 12  | Calvary Church (Greensboro, NC)                                       | 8-10 | 1390 | 77.2  | 9   | 68% | 8   | 30  | 88  |
 | 13  | Calvary Assembly of God (Marinette, WI)                               | 7-11 | 2020 | 112.2 | 17  | 71% | 12  | 62  | 64  |
 | 14  | Living Stones (Calvary Assembly, Ozone Park, NY)                      | 6-12 | 985  | 54.7  | 8   | 66% | 3   | 22  | 77  |
-| 15  | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA)           | 4-14 | 1030 | 57.2  | 10  | 69% | 1   | 39  | 41  |
+| 15  | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA)          | 4-14 | 1030 | 57.2  | 10  | 69% | 1   | 39  | 41  |
 | 16  | Prepared to Give an Answer (New Life AG, Frankfort, IN)               | 3-15 | 610  | 33.9  | 3   | 72% |     | 14  | 46  |
-| 17  | First Assembly of God (Louisville, OH)                                 | 3-15 | 340  | 18.9  |     | 59% |     | 6   | 43  |
+| 17  | First Assembly of God (Louisville, OH)                                | 3-15 | 340  | 18.9  |     | 59% |     | 6   | 43  |
 | 18  | Monkey Madness (Sioux Falls First, Sioux Falls, SD)                   | 2-16 | 685  | 38.1  | 6   | 59% | 3   | 15  | 68  |
 | 19  | Imitators (Deeper Church, Burien, WA)                                 | 0-18 | 305  | 16.9  |     | 64% | 1   | 6   | 34  |
-| 20  | Ghost Team (First Assembly, Valentine, NE)                              | 0-0  | 0    |       |     | %   |     |     |     |
+| 20  | Ghost Team (First Assembly, Valentine, NE)                            | 0-0  | 0    |       |     | %   |     |     |     |
 
 ### Individuals
 
-| #  | Quizzer              | Team / Church                                                         | Pts  | Avg   | QO | Q%   | 30s | 20s | 10s |
-|----|----------------------|-----------------------------------------------------------------------|------|-------|----|------|-----|-----|-----|
-| 1  | Gideon Thomas        | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 2120 | 111.6 | 16 | 86%  | 27  | 56  | 1   |
-| 2  | Precious Cyrus-David | Braeswood Assembly (Houston, TX)                                      | 2015 | 106.1 | 13 | 83%  | 28  | 54  | 3   |
-| 3  | Kyli Ladd            | Legit Daughters (Open Bible Church, Rapid City, SD)                   | 1810 | 95.3  | 14 | 77%  | 25  | 46  | 9   |
-| 4  | Elizabeth Li         | Living Water Dolphins (Living Water Bible Church, CA)                 | 1780 | 93.7  | 16 | 82%  | 18  | 48  | 19  |
-| 5  | Shreya Joy           | More Than Conquerors (Atlanta Indian Prayer Fellowship, Marietta, GA) | 1755 | 92.4  | 15 | 85%  | 15  | 46  | 24  |
-| 6  | Samuel Devasahayam   | Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA)         | 1670 | 87.9  | 15 | 85%  | 9   | 48  | 29  |
-| 7  | Ryan Schiebel        | Double Edged (Praise Church, Garfield, NJ)                            | 1600 | 84.2  | 14 | 78%  | 10  | 55  | 17  |
-| 8  | Tabitha Nirmal       | Culmination of the Ages (Covenant Life, Cary, NC)                     | 1545 | 81.3  | 13 | 80%  | 12  | 44  | 28  |
-| 9  | Ronald George        | Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA)         | 1500 | 78.9  | 9  | 75%  | 26  | 37  | 9   |
-| 10 | Janet An             | Living Water Dolphins (Living Water Bible Church, CA)                 | 1260 | 66.3  | 8  | 80%  | 11  | 28  | 34  |
-| 11 | Christian Alapati    | God`s Elect From Oklahoma (Mustang, OK)                               | 1225 | 64.5  | 14 | 81%  | 4   | 22  | 51  |
-| 12 | Hannah Alapati       | God`s Elect From Oklahoma (Mustang, OK)                               | 1080 | 56.8  | 6  | 68%  | 17  | 27  | 22  |
-| 13 | Josiah Laakkonen     | Order of Aaron (First Assembly, Lexington, KY)                        | 1065 | 56.1  | 9  | 73%  |     | 41  | 29  |
-| 14 | Ember Yoder          | Calvary Assembly of God (Marinette, WI)                               | 1060 | 55.8  | 7  | 71%  | 11  | 39  | 10  |
-| 15 | Sarah Lin            | Order of Aaron (First Assembly, Lexington, KY)                        | 1015 | 53.4  | 7  | 82%  | 4   | 28  | 33  |
-| 16 | Camille Lawrence     | Calvary Assembly of God (Marinette, WI)                               | 920  | 48.4  | 10 | 72%  | 1   | 22  | 48  |
-| 17 | Micah Sherry         | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA)          | 910  | 47.9  | 10 | 69%  |     | 34  | 36  |
-| 18 | Andrew Lane          | People are like Grass (Life Church, Germantown, WI)                   | 840  | 44.2  | 8  | 73%  | 1   | 17  | 50  |
-| 19 | Chris Immanuel John  | More Than Conquerors (Atlanta Indian Prayer Fellowship, Marietta, GA) | 795  | 41.8  | 5  | 88%  |     | 14  | 46  |
-| 20 | Anna Lane            | People are like Grass (Life Church, Germantown, WI)                   | 710  | 37.4  | 5  | 68%  |     | 27  | 27  |
-| 21 | Victoria Villegas    | Double Edged (Praise Church, Garfield, NJ)                            | 700  | 36.8  | 6  | 78%  |     | 6   | 56  |
-| 22 | Leslie Cowan         | Culmination of the Ages (Covenant Life, Cary, NC)                     | 670  | 35.3  | 5  | 71%  | 3   | 15  | 38  |
-| 23 | Chidinma Kanu        | Braeswood Assembly (Houston, TX)                                      | 660  | 34.7  | 5  | 76%  |     | 8   | 50  |
-| 24 | Joshua Devasahayam   | Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA)         | 580  | 30.5  | 4  | 80%  |     | 4   | 49  |
-| 25 | Luke Hodge           | Prepared to Give an Answer (New Life AG, Frankfort, IN)               | 580  | 30.5  | 3  | 77%  |     | 14  | 37  |
-| 26 | Aidan Rajesh         | Calvary Church (Greensboro, NC)                                       | 550  | 28.9  | 6  | 63%  | 1   | 8   | 50  |
-| 27 | Savannah Robinson    | Calvary Church (Greensboro, NC)                                       | 525  | 27.6  | 3  | 70%  | 2   | 17  | 28  |
-| 28 | Ariella Grimmond     | Living Stones (Calvary Assembly, Ozone Park, NY)                      | 510  | 26.8  | 2  | 75%  | 2   | 12  | 33  |
-| 29 | Hannah Tinney        | Order of Aaron (First Assembly, Lexington, KY)                        | 485  | 25.5  | 1  | 75%  | 7   | 6   | 26  |
-| 30 | Gabriella Singh      | Living Stones (Calvary Assembly, Ozone Park, NY)                      | 475  | 25    | 6  | 60%  | 1   | 10  | 44  |
-| 31 | Emily McKinley       | Monkey Madness (Sioux Falls First, Sioux Falls, SD)                   | 450  | 23.7  | 5  | 59%  | 3   | 10  | 37  |
-| 32 | Andrew McCollum      | Calvary Church (Greensboro, NC)                                       | 315  | 16.6  |    | 83%  | 5   | 5   | 10  |
-| 32 | Caleb Cullins        | First Assembly of God (Louisville, OH)                                | 315  | 16.6  |    | 58%  |     | 5   | 41  |
-| 33 | Amelia Peterson      | Imitators (Deeper Church, Burien, WA)                                 | 270  | 14.2  |    | 71%  | 1   | 5   | 21  |
-| 34 | Naomi Shtyralo       | Braeswood Assembly (Houston, TX)                                      | 225  | 11.8  |    | 80%  |     | 2   | 22  |
-| 35 | Matthew McKinley     | Monkey Madness (Sioux Falls First, Sioux Falls, SD)                   | 210  | 11.1  | 1  | 56%  |     | 5   | 27  |
-| 36 | Kodi Ladd            | Legit Daughters (Open Bible Church, Rapid City, SD)                   | 160  | 8.4   |    | 78%  |     |     | 21  |
-| 37 | Emmy Hill            | Legit Daughters (Open Bible Church, Rapid City, SD)                   | 120  | 6.3   |    | 73%  |     | 4   | 7   |
-| 38 | Alexis Lucero        | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 85   | 4.5   |    | 90%  |     |     | 9   |
-| 39 | Cheyene Puckett      | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA)          | 70   | 3.7   |    | 75%  |     | 3   | 3   |
-| 40 | Aaron Lane           | People are like Grass (Life Church, Germantown, WI)                   | 60   | 3.2   |    | 86%  |     | 1   | 5   |
-| 40 | Rochelle Sherry      | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA)          | 60   | 3.2   |    | 62%  | 1   | 2   | 2   |
-| 41 | Kora Pardee          | Calvary Assembly of God (Marinette, WI)                               | 50   | 2.6   |    | 64%  |     | 1   | 6   |
-| 42 | Jaelyn Comellas      | Culmination of the Ages (Covenant Life, Cary, NC)                     | 45   | 2.4   |    | 80%  |     | 1   | 3   |
-| 43 | Romario Rodriguez    | Monkey Madness (Sioux Falls First, Sioux Falls, SD)                   | 40   | 2.1   |    | 100% |     |     | 4   |
-| 44 | Jocelyn Squires      | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 35   | 1.8   |    | 71%  |     |     | 5   |
-| 45 | Abigail Mobley       | Imitators (Deeper Church, Burien, WA)                                 | 30   | 1.6   |    | 100% |     |     | 3   |
-| 46 | Victoria Cullins     | First Assembly of God (Louisville, OH)                                | 25   | 1.3   |    | 75%  |     | 1   | 2   |
-| 47 | Alexis Squires       | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 20   | 1.1   |    | 57%  |     |     | 4   |
-| 47 | Benaiah Hodge        | Prepared to Give an Answer (New Life AG, Frankfort, IN)               | 20   | 1.1   |    | 54%  |     |     | 6   |
-| 48 | Kelly Hodge          | Prepared to Give an Answer (New Life AG, Frankfort, IN)               | 15   | .8    |    | 50%  |     |     | 3   |
-| 48 | Quentin Counley      | Imitators (Deeper Church, Burien, WA)                                 | 15   | .8    |    | 48%  |     | 1   | 9   |
-| 49 | Quizzer-3            | Double Edged (Praise Church, Garfield, NJ)                            | 0    |       |    | %    |     |     |     |
-| 49 | Michael Ukonu        | Braeswood Assembly (Houston, TX)                                      | 0    |       |    | %    |     |     |     |
-| 49 | Brandon Ukonu        | Braeswood Assembly (Houston, TX)                                      | 0    |       |    | %    |     |     |     |
-| 49 | Caleb Song           | Order of Aaron (First Assembly, Lexington, KY)                        | 0    |       |    | %    |     |     |     |
-| 49 | Aaron Lin            | Order of Aaron (First Assembly, Lexington, KY)                        | 0    |       |    | %    |     |     |     |
-| 49 | Quizzer-3            | God`s Elect From Oklahoma (Mustang, OK)                               | 0    |       |    | %    |     |     |     |
-| 49 | Brittney Gauldin     | Calvary Church (Greensboro, NC)                                       | 0    |       |    | %    |     |     |     |
-| 49 | Robson Yoder         | Calvary Assembly of God (Marinette, WI)                               | 0    |       |    | %    |     |     |     |
-| 49 | Inky                 | Ghost Team (1st Assembly, Valentine, NE)                              | 0    |       |    | %    |     |     |     |
-| 49 | Blinky               | Ghost Team (1st Assembly, Valentine, NE)                              | 0    |       |    | %    |     |     |     |
-| 49 | Pinky                | Ghost Team (1st Assembly, Valentine, NE)                              | 0    |       |    | %    |     |     |     |
-| 49 | Clyde                | Ghost Team (1st Assembly, Valentine, NE)                              | 0    |       |    | %    |     |     |     |
-| 50 | Sasha Mobley         | Imitators (Deeper Church, Burien, WA)                                 | -5   | -.3   |    | 50%  |     |     | 1   |
-| 50 | Brandon Ukonu        | Braeswood Assembly (Houston, TX)                                      | -5   | -.3   |    | %    |     |     |     |
-| 51 | Jonathan Shtyrkalo   | Braeswood Assembly (Houston, TX)                                      | -10  | -.5   |    | 25%  |     |     | 1   |
+| #   | Quizzer              | Team / Church                                                         | Pts  | Avg   | QO  | Q%   | 30s | 20s | 10s |
+| --- | -------------------- | --------------------------------------------------------------------- | ---- | ----- | --- | ---- | --- | --- | --- |
+| 1   | Gideon Thomas        | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 2120 | 111.6 | 16  | 86%  | 27  | 56  | 1   |
+| 2   | Precious Cyrus-David | Braeswood Assembly (Houston, TX)                                      | 2015 | 106.1 | 13  | 83%  | 28  | 54  | 3   |
+| 3   | Kyli Ladd            | Legit Daughters (Open Bible Church, Rapid City, SD)                   | 1810 | 95.3  | 14  | 77%  | 25  | 46  | 9   |
+| 4   | Elizabeth Li         | Living Water Dolphins (Living Water Bible Church, CA)                 | 1780 | 93.7  | 16  | 82%  | 18  | 48  | 19  |
+| 5   | Shreya Joy           | More Than Conquerors (Atlanta Indian Prayer Fellowship, Marietta, GA) | 1755 | 92.4  | 15  | 85%  | 15  | 46  | 24  |
+| 6   | Samuel Devasahayam   | Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA)         | 1670 | 87.9  | 15  | 85%  | 9   | 48  | 29  |
+| 7   | Ryan Schiebel        | Double Edged (Praise Church, Garfield, NJ)                            | 1600 | 84.2  | 14  | 78%  | 10  | 55  | 17  |
+| 8   | Tabitha Nirmal       | Culmination of the Ages (Covenant Life, Cary, NC)                     | 1545 | 81.3  | 13  | 80%  | 12  | 44  | 28  |
+| 9   | Ronald George        | Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA)         | 1500 | 78.9  | 9   | 75%  | 26  | 37  | 9   |
+| 10  | Janet An             | Living Water Dolphins (Living Water Bible Church, CA)                 | 1260 | 66.3  | 8   | 80%  | 11  | 28  | 34  |
+| 11  | Christian Alapati    | God`s Elect From Oklahoma (Mustang, OK)                               | 1225 | 64.5  | 14  | 81%  | 4   | 22  | 51  |
+| 12  | Hannah Alapati       | God`s Elect From Oklahoma (Mustang, OK)                               | 1080 | 56.8  | 6   | 68%  | 17  | 27  | 22  |
+| 13  | Josiah Laakkonen     | Order of Aaron (First Assembly, Lexington, KY)                        | 1065 | 56.1  | 9   | 73%  |     | 41  | 29  |
+| 14  | Ember Yoder          | Calvary Assembly of God (Marinette, WI)                               | 1060 | 55.8  | 7   | 71%  | 11  | 39  | 10  |
+| 15  | Sarah Lin            | Order of Aaron (First Assembly, Lexington, KY)                        | 1015 | 53.4  | 7   | 82%  | 4   | 28  | 33  |
+| 16  | Camille Lawrence     | Calvary Assembly of God (Marinette, WI)                               | 920  | 48.4  | 10  | 72%  | 1   | 22  | 48  |
+| 17  | Micah Sherry         | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA)          | 910  | 47.9  | 10  | 69%  |     | 34  | 36  |
+| 18  | Andrew Lane          | People are like Grass (Life Church, Germantown, WI)                   | 840  | 44.2  | 8   | 73%  | 1   | 17  | 50  |
+| 19  | Chris Immanuel John  | More Than Conquerors (Atlanta Indian Prayer Fellowship, Marietta, GA) | 795  | 41.8  | 5   | 88%  |     | 14  | 46  |
+| 20  | Anna Lane            | People are like Grass (Life Church, Germantown, WI)                   | 710  | 37.4  | 5   | 68%  |     | 27  | 27  |
+| 21  | Victoria Villegas    | Double Edged (Praise Church, Garfield, NJ)                            | 700  | 36.8  | 6   | 78%  |     | 6   | 56  |
+| 22  | Leslie Cowan         | Culmination of the Ages (Covenant Life, Cary, NC)                     | 670  | 35.3  | 5   | 71%  | 3   | 15  | 38  |
+| 23  | Chidinma Kanu        | Braeswood Assembly (Houston, TX)                                      | 660  | 34.7  | 5   | 76%  |     | 8   | 50  |
+| 24  | Joshua Devasahayam   | Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA)         | 580  | 30.5  | 4   | 80%  |     | 4   | 49  |
+| 25  | Luke Hodge           | Prepared to Give an Answer (New Life AG, Frankfort, IN)               | 580  | 30.5  | 3   | 77%  |     | 14  | 37  |
+| 26  | Aidan Rajesh         | Calvary Church (Greensboro, NC)                                       | 550  | 28.9  | 6   | 63%  | 1   | 8   | 50  |
+| 27  | Savannah Robinson    | Calvary Church (Greensboro, NC)                                       | 525  | 27.6  | 3   | 70%  | 2   | 17  | 28  |
+| 28  | Ariella Grimmond     | Living Stones (Calvary Assembly, Ozone Park, NY)                      | 510  | 26.8  | 2   | 75%  | 2   | 12  | 33  |
+| 29  | Hannah Tinney        | Order of Aaron (First Assembly, Lexington, KY)                        | 485  | 25.5  | 1   | 75%  | 7   | 6   | 26  |
+| 30  | Gabriella Singh      | Living Stones (Calvary Assembly, Ozone Park, NY)                      | 475  | 25    | 6   | 60%  | 1   | 10  | 44  |
+| 31  | Emily McKinley       | Monkey Madness (Sioux Falls First, Sioux Falls, SD)                   | 450  | 23.7  | 5   | 59%  | 3   | 10  | 37  |
+| 32  | Andrew McCollum      | Calvary Church (Greensboro, NC)                                       | 315  | 16.6  |     | 83%  | 5   | 5   | 10  |
+| 32  | Caleb Cullins        | First Assembly of God (Louisville, OH)                                | 315  | 16.6  |     | 58%  |     | 5   | 41  |
+| 33  | Amelia Peterson      | Imitators (Deeper Church, Burien, WA)                                 | 270  | 14.2  |     | 71%  | 1   | 5   | 21  |
+| 34  | Naomi Shtyralo       | Braeswood Assembly (Houston, TX)                                      | 225  | 11.8  |     | 80%  |     | 2   | 22  |
+| 35  | Matthew McKinley     | Monkey Madness (Sioux Falls First, Sioux Falls, SD)                   | 210  | 11.1  | 1   | 56%  |     | 5   | 27  |
+| 36  | Kodi Ladd            | Legit Daughters (Open Bible Church, Rapid City, SD)                   | 160  | 8.4   |     | 78%  |     |     | 21  |
+| 37  | Emmy Hill            | Legit Daughters (Open Bible Church, Rapid City, SD)                   | 120  | 6.3   |     | 73%  |     | 4   | 7   |
+| 38  | Alexis Lucero        | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 85   | 4.5   |     | 90%  |     |     | 9   |
+| 39  | Cheyene Puckett      | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA)          | 70   | 3.7   |     | 75%  |     | 3   | 3   |
+| 40  | Aaron Lane           | People are like Grass (Life Church, Germantown, WI)                   | 60   | 3.2   |     | 86%  |     | 1   | 5   |
+| 40  | Rochelle Sherry      | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA)          | 60   | 3.2   |     | 62%  | 1   | 2   | 2   |
+| 41  | Kora Pardee          | Calvary Assembly of God (Marinette, WI)                               | 50   | 2.6   |     | 64%  |     | 1   | 6   |
+| 42  | Jaelyn Comellas      | Culmination of the Ages (Covenant Life, Cary, NC)                     | 45   | 2.4   |     | 80%  |     | 1   | 3   |
+| 43  | Romario Rodriguez    | Monkey Madness (Sioux Falls First, Sioux Falls, SD)                   | 40   | 2.1   |     | 100% |     |     | 4   |
+| 44  | Jocelyn Squires      | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 35   | 1.8   |     | 71%  |     |     | 5   |
+| 45  | Abigail Mobley       | Imitators (Deeper Church, Burien, WA)                                 | 30   | 1.6   |     | 100% |     |     | 3   |
+| 46  | Victoria Cullins     | First Assembly of God (Louisville, OH)                                | 25   | 1.3   |     | 75%  |     | 1   | 2   |
+| 47  | Alexis Squires       | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 20   | 1.1   |     | 57%  |     |     | 4   |
+| 47  | Benaiah Hodge        | Prepared to Give an Answer (New Life AG, Frankfort, IN)               | 20   | 1.1   |     | 54%  |     |     | 6   |
+| 48  | Kelly Hodge          | Prepared to Give an Answer (New Life AG, Frankfort, IN)               | 15   | .8    |     | 50%  |     |     | 3   |
+| 48  | Quentin Counley      | Imitators (Deeper Church, Burien, WA)                                 | 15   | .8    |     | 48%  |     | 1   | 9   |
+| 49  | Quizzer-3            | Double Edged (Praise Church, Garfield, NJ)                            | 0    |       |     | %    |     |     |     |
+| 49  | Michael Ukonu        | Braeswood Assembly (Houston, TX)                                      | 0    |       |     | %    |     |     |     |
+| 49  | Brandon Ukonu        | Braeswood Assembly (Houston, TX)                                      | 0    |       |     | %    |     |     |     |
+| 49  | Caleb Song           | Order of Aaron (First Assembly, Lexington, KY)                        | 0    |       |     | %    |     |     |     |
+| 49  | Aaron Lin            | Order of Aaron (First Assembly, Lexington, KY)                        | 0    |       |     | %    |     |     |     |
+| 49  | Quizzer-3            | God`s Elect From Oklahoma (Mustang, OK)                               | 0    |       |     | %    |     |     |     |
+| 49  | Brittney Gauldin     | Calvary Church (Greensboro, NC)                                       | 0    |       |     | %    |     |     |     |
+| 49  | Robson Yoder         | Calvary Assembly of God (Marinette, WI)                               | 0    |       |     | %    |     |     |     |
+| 49  | Inky                 | Ghost Team (1st Assembly, Valentine, NE)                              | 0    |       |     | %    |     |     |     |
+| 49  | Blinky               | Ghost Team (1st Assembly, Valentine, NE)                              | 0    |       |     | %    |     |     |     |
+| 49  | Pinky                | Ghost Team (1st Assembly, Valentine, NE)                              | 0    |       |     | %    |     |     |     |
+| 49  | Clyde                | Ghost Team (1st Assembly, Valentine, NE)                              | 0    |       |     | %    |     |     |     |
+| 50  | Sasha Mobley         | Imitators (Deeper Church, Burien, WA)                                 | -5   | -.3   |     | 50%  |     |     | 1   |
+| 50  | Brandon Ukonu        | Braeswood Assembly (Houston, TX)                                      | -5   | -.3   |     | %    |     |     |     |
+| 51  | Jonathan Shtyrkalo   | Braeswood Assembly (Houston, TX)                                      | -10  | -.5   |     | 25%  |     |     | 1   |
 
 
+## Preliminary Results
+
+### Group A
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                        | W/L   | Total | Avg   | QO | Q%  |
+|----:|------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Calvary Church - J (Naperville, IL)                  | 7 / 0 | 1880  | 268.5 | 14 | 80% |
+| 2.1 | Elaborate Hairstyles (New Life Assembly, Sparta, WI) | 5 / 2 | 715   | 102.1 | 5  | 78% |
+| 3.0 | Warriors of the Faith (Bethel Church, San Jose, CA)  | 5 / 2 | 1265  | 180.7 | 10 | 76% |
+| 4.1 | Culmination of the Ages (Covenant Life, Cary, NC)    | 4 / 3 | 880   | 125.7 | 7  | 78% |
+| 5.0 | Terrifying Sights (Trinity Church, TX)               | 4 / 3 | 865   | 123.6 | 6  | 68% |
+| 6.0 | People are like Grass (Life Church, Germantown, WI)  | 2 / 5 | 720   | 102.8 | 5  | 72% |
+| 7.0 | Imitators (Deeper Church, Burien, WA)                | 1 / 6 | 135   | 19.3  | 1  | 68% |
+| 8.0 | First Assembly of God (Louisville, OH)               | 0 / 7 | -55   | -7.9  |    | 30% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer          | Team / Church                                        | Total | Avg   | QO | Q%   |
+|---------:|------------------|------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Shreanna Powell  | Calvary Church - J (Naperville, IL)                  | 890   | 127.1 | 7  | 85%  |
+| 2        | Samuel Jebaraj   | Warriors of the Faith (Bethel Church, San Jose, CA)  | 765   | 109.3 | 6  | 80%  |
+| 3        | Sheldon Powell   | Calvary Church - J (Naperville, IL)                  | 675   | 96.4  | 7  | 87%  |
+| 4        | Tabitha Nirmal   | Culmination of the Ages (Covenant Life, Cary, NC)    | 565   | 80.7  | 5  | 74%  |
+| 5        | Hansel John      | Warriors of the Faith (Bethel Church, San Jose, CA)  | 465   | 66.4  | 4  | 81%  |
+| 6        | Cole Abbott      | Elaborate Hairstyles (New Life Assembly, Sparta, WI) | 460   | 65.7  | 3  | 69%  |
+| 7        | Anna Lane        | People are like Grass (Life Church, Germantown, WI)  | 430   | 61.4  | 2  | 78%  |
+| 8        | Camden Haney     | Terrifying Sights (Trinity Church, TX)               | 380   | 54.3  | 2  | 68%  |
+| 9        | Leslie Cowan     | Culmination of the Ages (Covenant Life, Cary, NC)    | 305   | 43.6  | 2  | 84%  |
+| 10       | Joseph Barajas   | Terrifying Sights (Trinity Church, TX)               | 270   | 38.6  | 2  | 62%  |
+| 11       | Andrew Lane      | People are like Grass (Life Church, Germantown, WI)  | 260   | 37.1  | 3  | 65%  |
+| 12       | Bryce Helgerson  | Elaborate Hairstyles (New Life Assembly, Sparta, WI) | 255   | 36.4  | 2  | 89%  |
+| 13       | Joy Escobar      | Terrifying Sights (Trinity Church, TX)               | 225   | 32.1  | 2  | 81%  |
+| 14       | Shaymis Powell   | Calvary Church - J (Naperville, IL)                  | 225   | 32.1  |    | 61%  |
+| 15       | Amelia Peterson  | Imitators (Deeper Church, Burien, WA)                | 105   | 15    | 1  | 72%  |
+| 16       | Shaylee Powell   | Calvary Church - J (Naperville, IL)                  | 90    | 12.9  |    | 82%  |
+| 17       | Quentin Counley  | Imitators (Deeper Church, Burien, WA)                | 35    | 5     |    | 67%  |
+| **\*17** | Krysle John      | Warriors of the Faith (Bethel Church, San Jose, CA)  | 35    | 5     |    | 54%  |
+| 18       | Aaron Lane       | People are like Grass (Life Church, Germantown, WI)  | 30    | 4.3   |    | 100% |
+| 19       | Jaelyn Comellas  | Culmination of the Ages (Covenant Life, Cary, NC)    | 10    | 1.4   |    | 99%  |
+| **\*19** | Caleb Cullins    | First Assembly of God (Louisville, OH)               | 10    | 1.4   |    | 38%  |
+| 20       | Noah Lee         | Terrifying Sights (Trinity Church, TX)               | 0     |       |    |      |
+| **\*20** | Sasha Mobley     | Imitators (Deeper Church, Burien, WA)                | 0     |       |    |      |
+| 21       | Abigail Mobley   | Imitators (Deeper Church, Burien, WA)                | -5    | -.7   |    |      |
+| 22       | Aulora Sullivan  | Terrifying Sights (Trinity Church, TX)               | -10   | -1.4  |    |      |
+| 23       | Victoria Cullins | First Assembly of God (Louisville, OH)               | -65   | -9.3  |    |      |
+
+### Group B
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                         | W/L   | Total | Avg   | QO | Q%  |
+|----:|-----------------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Sharper than Swords (Central Assembly, Houston, PA)                   | 7 / 0 | 1655  | 236.4 | 12 | 85% |
+| 2.0 | Ponraj Family (Deeper Church, Burien, WA)                             | 6 / 1 | 1910  | 272.8 | 16 | 87% |
+| 3.0 | Race Runners (Carolinas Christian Assembly, Charlotte, NC)            | 5 / 2 | 980   | 140   | 8  | 78% |
+| 4.0 | Human Rejects (First at Firewheel, Garland, TX)                       | 4 / 3 | 1105  | 157.8 | 9  | 80% |
+| 5.0 | Calvary Assembly of God (Marinette, WI)                               | 3 / 4 | 680   | 97.1  | 3  | 81% |
+| 6.0 | More Than Conquerors (Atlanta Indian Prayer Fellowship, Marietta, GA) | 2 / 5 | 850   | 121.4 | 6  | 85% |
+| 7.0 | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 1 / 6 | 830   | 118.6 | 6  | 84% |
+| 8.0 | Living Stones (Calvary Assembly, Ozone Park, NY)                      | 0 / 7 | 325   | 46.4  | 3  | 62% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                                                         | Total | Avg   | QO | Q%  |
+|---------:|---------------------|-----------------------------------------------------------------------|------:|------:|---:|----:|
+| 1        | Zachary Ponraj      | Ponraj Family (Deeper Church, Burien, WA)                             | 940   | 134.3 | 6  | 97% |
+| 2        | Gideon Thomas       | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 825   | 117.9 | 6  | 87% |
+| 3        | Seth Robertson      | Sharper than Swords (Central Assembly, Houston, PA)                   | 800   | 114.3 | 6  | 87% |
+| 4        | Shreya Joy          | More Than Conquerors (Atlanta Indian Prayer Fellowship, Marietta, GA) | 575   | 82.1  | 4  | 86% |
+| 5        | Simeon Ponraj       | Ponraj Family (Deeper Church, Burien, WA)                             | 555   | 79.3  | 6  | 78% |
+| 6        | Zane Brown          | Human Rejects (First at Firewheel, Garland, TX)                       | 545   | 77.9  | 5  | 80% |
+| 7        | Joanne Ramesh       | Human Rejects (First at Firewheel, Garland, TX)                       | 540   | 77.1  | 4  | 83% |
+| 8        | Amaya Kocher        | Sharper than Swords (Central Assembly, Houston, PA)                   | 465   | 66.4  | 4  | 86% |
+| 9        | Jehosh Jebaraj      | Race Runners (Carolinas Christian Assembly, Charlotte, NC)            | 460   | 65.7  | 4  | 72% |
+| 10       | Elaina Ponraj       | Ponraj Family (Deeper Church, Burien, WA)                             | 425   | 60.7  | 4  | 87% |
+| 11       | Emily Thomas        | Race Runners (Carolinas Christian Assembly, Charlotte, NC)            | 415   | 59.3  | 4  | 93% |
+| 12       | Logan Webb          | Sharper than Swords (Central Assembly, Houston, PA)                   | 390   | 55.7  | 2  | 81% |
+| 13       | Ember Yoder         | Calvary Assembly of God (Marinette, WI)                               | 365   | 52.1  | 1  | 73% |
+| 14       | Camille Lawrence    | Calvary Assembly of God (Marinette, WI)                               | 310   | 44.3  | 2  | 92% |
+| 15       | Chris Immanuel John | More Than Conquerors (Atlanta Indian Prayer Fellowship, Marietta, GA) | 275   | 39.3  | 2  | 84% |
+| 16       | Ariella Grimmond    | Living Stones (Calvary Assembly, Ozone Park, NY)                      | 170   | 24.3  | 1  | 70% |
+| 17       | Gabriella Singh     | Living Stones (Calvary Assembly, Ozone Park, NY)                      | 160   | 22.9  | 2  | 55% |
+| 18       | Jacob Thomas        | Race Runners (Carolinas Christian Assembly, Charlotte, NC)            | 95    | 13.6  |    | 62% |
+| 19       | Danny\'El Gonzalez  | Human Rejects (First at Firewheel, Garland, TX)                       | 20    | 2.9   |    | 60% |
+| 20       | Jocelyn Squires     | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 10    | 1.4   |    | 99% |
+| **\*20** | Jerusha Jebaraj     | Race Runners (Carolinas Christian Assembly, Charlotte, NC)            | 10    | 1.4   |    | 66% |
+| 21       | Kora Pardee         | Calvary Assembly of God (Marinette, WI)                               | 5     | .7    |    | 50% |
+| 22       | Alexis Lucero       | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | 0     |       |    | 50% |
+| **\*22** | Ndubueze Echefu     | Human Rejects (First at Firewheel, Garland, TX)                       | 0     |       |    |     |
+| **\*22** | Robson Yoder        | Calvary Assembly of God (Marinette, WI)                               | 0     |       |    |     |
+| 23       | Alexis Squires      | Gideon and the Girls (Lakeview Church, Indianapolis, IN)              | -5    | -.7   |    |     |
 
 
+### Group C
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                               | W/L   | Total | Avg   | QO | Q%  |
+|----:|-------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | The Brookbanks (Colorado Springs, CO)                       | 7 / 0 | 1315  | 187.8 | 13 | 72% |
+| 2.1 | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 5 / 2 | 1125  | 160.7 | 7  | 79% |
+| 3.0 | Don\'t Run from the Lord (Bellevue Church, Bellevue, WA)    | 5 / 2 | 915   | 130.7 | 6  | 75% |
+| 4.0 | Alive and Active (CrossPoint AG, Portage, WI)               | 4 / 3 | 840   | 120   | 4  | 75% |
+| 5.1 | Double Edged (Praise Church, Garfield, NJ)                  | 3 / 4 | 870   | 124.3 | 8  | 76% |
+| 6.0 | Braeswood Assembly (Houston, TX)                            | 3 / 4 | 850   | 121.4 | 6  | 71% |
+| 7.0 | Calvary Church (Greensboro, NC)                             | 1 / 6 | 280   | 40    | 1  | 56% |
+| 8.0 | Monkey Madness (Sioux Falls First, Sioux Falls, SD)         | 0 / 7 | 240   | 34.3  | 3  | 56% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                                               | Total | Avg   | QO | Q%   |
+|---------:|----------------------|-------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Nigus Dawit          | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 835   | 119.3 | 7  | 81%  |
+| 2        | Sam Clinston         | Don\'t Run from the Lord (Bellevue Church, Bellevue, WA)    | 725   | 103.6 | 6  | 85%  |
+| 3        | Precious Cyrus-David | Braeswood Assembly (Houston, TX)                            | 645   | 92.1  | 4  | 74%  |
+| 4        | Emma Schoessow       | Alive and Active (CrossPoint AG, Portage, WI)               | 645   | 92.1  | 3  | 85%  |
+| 5        | Ryan Schiebel        | Double Edged (Praise Church, Garfield, NJ)                  | 520   | 74.3  | 5  | 74%  |
+| 6        | Josiah Brookbank     | The Brookbanks (Colorado Springs, CO)                       | 510   | 72.9  | 6  | 79%  |
+| 7        | Rachel Brookbank     | The Brookbanks (Colorado Springs, CO)                       | 475   | 67.9  | 4  | 65%  |
+| 8        | Victoria Villegas    | Double Edged (Praise Church, Garfield, NJ)                  | 355   | 50.7  | 3  | 78%  |
+| 9        | Hadassah Brookbank   | The Brookbanks (Colorado Springs, CO)                       | 340   | 48.6  | 3  | 70%  |
+| 10       | Emily McKinley       | Monkey Madness (Sioux Falls First, Sioux Falls, SD)         | 275   | 39.3  | 3  | 70%  |
+| 11       | Chidinma Kanu        | Braeswood Assembly (Houston, TX)                            | 210   | 30    | 2  | 75%  |
+| 12       | Seth Christopher     | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 205   | 29.3  |    | 72%  |
+| 13       | Ava Schoessow        | Alive and Active (CrossPoint AG, Portage, WI)               | 200   | 28.6  | 1  | 67%  |
+| 14       | Aidan Rajesh         | Calvary Church (Greensboro, NC)                             | 130   | 18.6  | 1  | 50%  |
+| 15       | Ryan Matta           | Don\'t Run from the Lord (Bellevue Church, Bellevue, WA)    | 95    | 13.6  |    | 71%  |
+| 16       | David Kwabi-Addo     | Fury of the Flames (Word of Life Assembly, Springfield, VA) | 90    | 12.9  |    | 100% |
+| **\*16** | Savannah Robinson    | Calvary Church (Greensboro, NC)                             | 90    | 12.9  |    | 62%  |
+| **\*16** | Elizabeth Godavarthi | Don\'t Run from the Lord (Bellevue Church, Bellevue, WA)    | 90    | 12.9  |    | 55%  |
+| 17       | Andrew McCollum      | Calvary Church (Greensboro, NC)                             | 65    | 9.3   |    | 61%  |
+| 18       | Naomi Shtyralo       | Braeswood Assembly (Houston, TX)                            | 25    | 3.6   |    | 54%  |
+| 19       | Padmini Abothu       | Don\'t Run from the Lord (Bellevue Church, Bellevue, WA)    | 20    | 2.9   |    | 100% |
+| 20       | Jonathan Shtyrkalo   | Braeswood Assembly (Houston, TX)                            | 10    | 1.4   |    | 99%  |
+| 21       | Avinash Poguluri     | Don\'t Run from the Lord (Bellevue Church, Bellevue, WA)    | 0     |       |    |      |
+| **\*21** | Quizzer-3            | Double Edged (Praise Church, Garfield, NJ)                  | 0     |       |    |      |
+| **\*21** | Michael Ukonu        | Braeswood Assembly (Houston, TX)                            | 0     |       |    |      |
+| **\*21** | Brandon Ukonu        | Braeswood Assembly (Houston, TX)                            | 0     |       |    |      |
+| **\*21** | Brittney Gauldin     | Calvary Church (Greensboro, NC)                             | 0     |       |    |      |
+| 22       | Romario Rodriguez    | Monkey Madness (Sioux Falls First, Sioux Falls, SD)         | -5    | -.7   |    | 33%  |
+| **\*22** | Maddie Clements      | Alive and Active (CrossPoint AG, Portage, WI)               | -5    | -.7   |    |      |
+| **\*22** | Brandon Ukonu        | Braeswood Assembly (Houston, TX)                            | -5    | -.7   |    |      |
+| **\*22** | Abenezer Mekuria     | Fury of the Flames (Word of Life Assembly, Springfield, VA) | -5    | -.7   |    |      |
+| 23       | Matthew McKinley     | Monkey Madness (Sioux Falls First, Sioux Falls, SD)         | -30   | -4.3  |    | 27%  |
+
+
+### Group D
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                | W/L   | Total | Avg   | QO | Q%  |
+|----:|--------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.1 | The New Order (Redeemer Church, Utica, NY)                   | 6 / 1 | 1435  | 205   | 10 | 76% |
+| 2.0 | Radiant Life Church (Dublin, OH)                             | 6 / 1 | 1040  | 148.6 | 6  | 82% |
+| 3.0 | Proven Geniuses (Cedar Park, Bothell, WA)                    | 5 / 2 | 1040  | 148.6 | 8  | 73% |
+| 4.0 | Calvary Church - S (Naperville, IL)                          | 4 / 3 | 905   | 129.3 | 7  | 73% |
+| 5.1 | Living Water Dolphins (Living Water Bible Church, CA)        | 3 / 4 | 1040  | 148.6 | 9  | 83% |
+| 6.0 | Legit Daughters (Open Bible Church, Rapid City, SD)          | 3 / 4 | 695   | 99.3  | 5  | 76% |
+| 7.0 | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA) | 1 / 6 | 395   | 56.4  | 4  | 69% |
+| 8.0 | Prepared to Give an Answer (New Life AG, Frankfort, IN)      | 0 / 7 | 225   | 32.1  | 1  | 75% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                                | Total | Avg  | QO | Q%   |
+|---------:|-------------------|--------------------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Kyli Ladd         | Legit Daughters (Open Bible Church, Rapid City, SD)          | 655   | 93.6 | 5  | 82%  |
+| 2        | Jayden Nimako     | Radiant Life Church (Dublin, OH)                             | 640   | 91.4 | 5  | 84%  |
+| 3        | Shawn Timothy     | Calvary Church - S (Naperville, IL)                          | 565   | 80.7 | 4  | 72%  |
+| 4        | Elizabeth Li      | Living Water Dolphins (Living Water Bible Church, CA)        | 545   | 77.9 | 5  | 75%  |
+| 5        | Christian Stevens | The New Order (Redeemer Church, Utica, NY)                   | 505   | 72.1 | 4  | 70%  |
+| 6        | Janet An          | Living Water Dolphins (Living Water Bible Church, CA)        | 495   | 70.7 | 4  | 93%  |
+| 7        | Josi Haugo        | Proven Geniuses (Cedar Park, Bothell, WA)                    | 485   | 69.3 | 4  | 83%  |
+| 8        | Graham Hoffmann   | The New Order (Redeemer Church, Utica, NY)                   | 445   | 63.6 | 5  | 74%  |
+| 9        | Alex Jarrell      | Proven Geniuses (Cedar Park, Bothell, WA)                    | 425   | 60.7 | 4  | 66%  |
+| 10       | Micah Sherry      | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA) | 315   | 45   | 4  | 66%  |
+| 11       | Harrison Stevens  | Calvary Church - S (Naperville, IL)                          | 285   | 40.7 | 3  | 76%  |
+| 12       | Glory Stevens     | The New Order (Redeemer Church, Utica, NY)                   | 255   | 36.4 | 1  | 95%  |
+| 13       | Janelle Nimako    | Radiant Life Church (Dublin, OH)                             | 240   | 34.3 | 1  | 68%  |
+| 14       | Aaron Hoffmann    | The New Order (Redeemer Church, Utica, NY)                   | 235   | 33.6 |    | 75%  |
+| 15       | Luke Hodge        | Prepared to Give an Answer (New Life AG, Frankfort, IN)      | 200   | 28.6 | 1  | 75%  |
+| 16       | Abel Karthik      | Radiant Life Church (Dublin, OH)                             | 160   | 22.9 |    | 100% |
+| 17       | Lilli Haugo       | Proven Geniuses (Cedar Park, Bothell, WA)                    | 130   | 18.6 |    | 69%  |
+| 18       | Reagan Stevens    | Calvary Church - S (Naperville, IL)                          | 80    | 11.4 |    | 86%  |
+| 19       | Cheyene Puckett   | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA) | 70    | 10   |    | 100% |
+| 20       | Kodi Ladd         | Legit Daughters (Open Bible Church, Rapid City, SD)          | 40    | 5.7  |    | 71%  |
+| 21       | Kelly Hodge       | Prepared to Give an Answer (New Life AG, Frankfort, IN)      | 30    | 4.3  |    | 100% |
+| 22       | Rochelle Sherry   | Holy, Blameless and Pure (Kinport Assembly, Cherry Tree, PA) | 10    | 1.4  |    | 66%  |
+| 23       | Emmy Hill         | Legit Daughters (Open Bible Church, Rapid City, SD)          | 0     |      |    | 40%  |
+| **\*23** | McKinley Stevens  | Calvary Church - S (Naperville, IL)                          | 0     |      |    |      |
+| 24       | Benaiah Hodge     | Prepared to Give an Answer (New Life AG, Frankfort, IN)      | -5    | -.7  |    |      |
+| 25       | Pierce Stevens    | Calvary Church - S (Naperville, IL)                          | -20   | -2.9 |    |      |
+
+
+### Group E
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                   | W/L   | Total | Avg   | QO | Q%  |
+|----:|-----------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.1 | 5 Trinity One (Trinity Church, TX)                              | 4 / 2 | 1245  | 207.5 | 11 | 80% |
+| 2.0 | 7 Ramsey Family (Springfield, MO)                               | 4 / 2 | 1110  | 185   | 8  | 79% |
+| 3.0 | 3 Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA) | 3 / 3 | 880   | 146.6 | 8  | 70% |
+| 4.0 | 6 Scoffers Gonna Scoff (Journey Life Church, Holt, MI)          | 3 / 3 | 860   | 143.3 | 7  | 78% |
+| 5.0 | 13 Living Hope (Swedesboro, NJ)                                 | 3 / 3 | 775   | 129.1 | 6  | 75% |
+| 6.0 | 9 Order of Aaron (First Assembly, Lexington, KY)                | 3 / 3 | 660   | 110   | 7  | 71% |
+| 7.0 | 14 God\'s Elect From Oklahoma (Mustang, OK)                     | 1 / 5 | 415   | 69.2  | 2  | 67% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                                                   | Total | Avg   | QO | Q%  |
+|---------:|--------------------|-----------------------------------------------------------------|------:|------:|---:|----:|
+| 1        | Joshua Barajas     | 5 Trinity One (Trinity Church, TX)                              | 660   | 110   | 5  | 76% |
+| 2        | Toby Hill          | 13 Living Hope (Swedesboro, NJ)                                 | 610   | 101.7 | 5  | 81% |
+| **\*2**  | Cameron Ramsey     | 7 Ramsey Family (Springfield, MO)                               | 610   | 101.7 | 5  | 76% |
+| 3        | Jonathan Mafe      | 6 Scoffers Gonna Scoff (Journey Life Church, Holt, MI)          | 445   | 74.2  | 5  | 82% |
+| 4        | Ronald George      | 3 Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA) | 445   | 74.2  | 4  | 71% |
+| 5        | Noah Claunch       | 5 Trinity One (Trinity Church, TX)                              | 430   | 71.7  | 5  | 85% |
+| 6        | Josiah Laakkonen   | 9 Order of Aaron (First Assembly, Lexington, KY)                | 410   | 68.3  | 5  | 76% |
+| 7        | Darcie Harr        | 6 Scoffers Gonna Scoff (Journey Life Church, Holt, MI)          | 405   | 67.5  | 2  | 72% |
+| 8        | Kaitlyn Ramsey     | 7 Ramsey Family (Springfield, MO)                               | 390   | 65    | 3  | 86% |
+| 9        | Samuel Devasahayam | 3 Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA) | 380   | 63.3  | 4  | 71% |
+| 10       | Christian Alapati  | 14 God\'s Elect From Oklahoma (Mustang, OK)                     | 250   | 41.7  | 2  | 68% |
+| 11       | Sarah Lin          | 9 Order of Aaron (First Assembly, Lexington, KY)                | 235   | 39.2  | 2  | 82% |
+| 12       | Hannah Alapati     | 14 God\'s Elect From Oklahoma (Mustang, OK)                     | 170   | 28.3  |    | 67% |
+| 13       | Micah DeSanto      | 13 Living Hope (Swedesboro, NJ)                                 | 160   | 26.7  | 1  | 68% |
+| 14       | Julia Sullivan     | 5 Trinity One (Trinity Church, TX)                              | 125   | 20.8  | 1  | 89% |
+| 15       | Alyssa Ramsey      | 7 Ramsey Family (Springfield, MO)                               | 110   | 18.3  |    | 75% |
+| 16       | Joshua Devasahayam | 3 Strangers in a Foreign Country (Atlanta Tamil - Norcross, GA) | 55    | 9.2   |    | 64% |
+| 17       | Elijah Lee         | 5 Trinity One (Trinity Church, TX)                              | 30    | 5     |    | 60% |
+| 18       | Cierra Convis      | 6 Scoffers Gonna Scoff (Journey Life Church, Holt, MI)          | 10    | 1.7   |    | 99% |
+| **\*18** | Caleb Song         | 9 Order of Aaron (First Assembly, Lexington, KY)                | 10    | 1.7   |    | 66% |
+| 19       | Eric Carty         | 13 Living Hope (Swedesboro, NJ)                                 | 5     | .8    |    | 50% |
+| **\*19** | Hannah Tinney      | 9 Order of Aaron (First Assembly, Lexington, KY)                | 5     | .8    |    | 36% |
+| 20       | Madison Claunch    | 5 Trinity One (Trinity Church, TX)                              | 0     |       |    |     |
+| **\*20** | Quizzer-3          | 14 God\'s Elect From Oklahoma (Mustang, OK)                     | 0     |       |    |     |
+| **\*20** | Aaron Lin          | 9 Order of Aaron (First Assembly, Lexington, KY)                | 0     |       |    |     |
 
 ## Special Events
 

--- a/_pages/history/2022/tournaments/mid-winter-classic.md
+++ b/_pages/history/2022/tournaments/mid-winter-classic.md
@@ -12,9 +12,11 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## A-League
+## A League
 
-### Teams
+### Preliminaries
+
+#### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points*
 
@@ -28,7 +30,7 @@ menubar_toc_static:
 | 6.0 | Germantown #1 (Germantown-WI-Life Church)       | 1 / 5 | 340   | 56.7  | 1  | 79% |
 | 7.0 | Sioux Falls (Sioux Falls-SD-Sioux Falls First)  | 0 / 6 | 175   | 29.2  | 1  | 55% |
 
-### Individuals
+#### Individuals
 
 *Ties broken by Average Points then Total Quiz Outs*
 
@@ -57,10 +59,9 @@ menubar_toc_static:
 | 17       | Miriam Clements  | Birds of the Air (Portage-WI-CrossPoint AG)     | -5    | -.8  |    | 40% |
 | 18       | Anna Reece       | Flowers of the Field (Portage-WI-CrossPoint AG) | -10   | -1.7 |    |     |
 
+### Upper
 
-## A-Upper
-
-### Teams
+#### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points*
 
@@ -71,7 +72,7 @@ menubar_toc_static:
 | 3.0 | YpsiAG (Ypsilanti-MI-AG)                        | 2 / 1 | 410   | 136.6 | 3  | 88% |
 | 4.0 | Sparta A (Sparta-WI-New Life AG)                | 0 / 3 | 100   | 33.3  | 1  | 53% |
 
-### Individuals
+#### Individuals
 
 *Ties broken by Average Points then Total Quiz Outs*
 
@@ -91,8 +92,35 @@ menubar_toc_static:
 | **\*11** | Robson Yoder    | YpsiAG (Ypsilanti-MI-AG)                        | 0     |      |    |      |
 | **\*11** | Gannon Breig    | Springfield #1 (Springfield-MO-Hope Church)     | 0     |      |    |      |
 
+### Lower
 
-## XP-Middle School
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                  | W/L   | Total | Avg  | QO | Q%  |
+|----:|------------------------------------------------|-------|------:|-----:|---:|----:|
+| 1.0 | Birds of the Air (Portage-WI-CrossPoint AG)    | 1 / 1 | 115   | 57.5 | 1  | 71% |
+| 2.0 | Sioux Falls (Sioux Falls-SD-Sioux Falls First) | 1 / 1 | 90    | 45   |    | 60% |
+| 3.0 | Germantown #1 (Germantown-WI-Life Church)      | 1 / 1 | 70    | 35   |    | 67% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #       | Quizzer          | Team / Church                                  | Total | Avg  | QO | Q%   |
+|--------:|------------------|------------------------------------------------|------:|-----:|---:|-----:|
+| 1       | Maddie Clements  | Birds of the Air (Portage-WI-CrossPoint AG)    | 110   | 55   | 1  | 80%  |
+| 2       | Brooks Anderson  | Sioux Falls (Sioux Falls-SD-Sioux Falls First) | 105   | 52.5 |    | 86%  |
+| 3       | Aaron Lane       | Germantown #1 (Germantown-WI-Life Church)      | 50    | 25   |    | 100% |
+| 4       | Andrew Lane      | Germantown #1 (Germantown-WI-Life Church)      | 20    | 10   |    | 50%  |
+| 5       | Miriam Clements  | Birds of the Air (Portage-WI-CrossPoint AG)    | 5     | 2.5  |    | 50%  |
+| 6       | Brenna Schoessow | Birds of the Air (Portage-WI-CrossPoint AG)    | 0     |      |    | 50%  |
+| **\*6** | Merisa Rodriguez | Sioux Falls (Sioux Falls-SD-Sioux Falls First) | 0     |      |    |      |
+| **\*6** | Brianna McKinley | Sioux Falls (Sioux Falls-SD-Sioux Falls First) | 0     |      |    |      |
+| 7       | Emily McKinley   | Sioux Falls (Sioux Falls-SD-Sioux Falls First) | -15   | -7.5 |    | 37%  |
+
+## XP vs. Middle School
 
 ### Teams
 
@@ -127,8 +155,47 @@ menubar_toc_static:
 | 12       | Sophia Curtis      | Sparta XP (Sparta-WI-New Life AG)                       | 25    | 8.3   |    | 100% |
 | 13       | Malaika Evans      | Our Way is Yahweh (Orange City-IA-New Hope Evangelical) | 0     |       |    |      |
 
+## Middle School (Saturday)
 
-## XP-Saturday
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                           | W/L   | Total | Avg | QO | Q%  |
+|----:|---------------------------------------------------------|-------|------:|----:|---:|----:|
+| 1.1 | Our Way is Yahweh (Orange City-IA-New Hope Evangelical) | 4 / 1 | 635   | 127 | 5  | 80% |
+| 2.0 | Marinette #1 (Marinette-WI-Calvary Church AG)           | 4 / 1 | 920   | 184 | 8  | 85% |
+| 3.1 | Truth Be Told (Orange City-IA-New Hope Evangelical)     | 3 / 2 | 320   | 64  | 1  | 86% |
+| 4.0 | Sparta B (Sparta-WI-New Life AG)                        | 3 / 2 | 765   | 153 | 6  | 75% |
+| 5.0 | 10,000 Reasons (Orange City-IA-New Hope Evangelical)    | 1 / 4 | 210   | 42  | 1  | 90% |
+| 6.0 | The Knights (Orange City-IA-New Hope Evangelical)       | 0 / 5 | 25    | 5   |    | 57% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer          | Team / Church                                           | Total | Avg | QO | Q%   |
+|---------:|------------------|---------------------------------------------------------|------:|----:|---:|-----:|
+| 1        | Sawyer Curtis    | Sparta B (Sparta-WI-New Life AG)                        | 605   | 121 | 5  | 83%  |
+| 2        | Kora Pardee      | Marinette #1 (Marinette-WI-Calvary Church AG)           | 545   | 109 | 4  | 82%  |
+| 3        | Zoe Thornton     | Marinette #1 (Marinette-WI-Calvary Church AG)           | 375   | 75  | 4  | 88%  |
+| 4        | Ziva Murphy      | Our Way is Yahweh (Orange City-IA-New Hope Evangelical) | 320   | 64  | 3  | 86%  |
+| 5        | Jessie Murphy    | Our Way is Yahweh (Orange City-IA-New Hope Evangelical) | 295   | 59  | 2  | 75%  |
+| 6        | Ruth Varpness    | 10,000 Reasons (Orange City-IA-New Hope Evangelical)    | 210   | 42  | 1  | 90%  |
+| 7        | Sam Erwin        | Truth Be Told (Orange City-IA-New Hope Evangelical)     | 165   | 33  | 1  | 79%  |
+| 8        | Isaac Helgerson  | Sparta B (Sparta-WI-New Life AG)                        | 110   | 22  | 1  | 61%  |
+| 9        | Lily Varpness    | Truth Be Told (Orange City-IA-New Hope Evangelical)     | 85    | 17  |    | 89%  |
+| 10       | Hannah Hulstein  | Truth Be Told (Orange City-IA-New Hope Evangelical)     | 70    | 14  |    | 100% |
+| 11       | Elijah Helgerson | Sparta B (Sparta-WI-New Life AG)                        | 50    | 10  |    | 75%  |
+| 12       | Malaika Evans    | Our Way is Yahweh (Orange City-IA-New Hope Evangelical) | 20    | 4   |    | 75%  |
+| **\*12** | Elijah Delong    | The Knights (Orange City-IA-New Hope Evangelical)       | 20    | 4   |    | 60%  |
+| 13       | Max Koenig       | The Knights (Orange City-IA-New Hope Evangelical)       | 5     | 1   |    | 50%  |
+| 14       | Will Evans       | The Knights (Orange City-IA-New Hope Evangelical)       | 0     |     |    |      |
+| **\*14** | Amelia Brossard  | 10,000 Reasons (Orange City-IA-New Hope Evangelical)    | 0     |     |    |      |
+| **\*14** | Maya Brown       | 10,000 Reasons (Orange City-IA-New Hope Evangelical)    | 0     |     |    |      |
+
+
+## XP (Saturday)
 
 ### Teams
 
@@ -160,3 +227,40 @@ menubar_toc_static:
 | **\*9** | Haydee Heersink    | Peacemakers (Orange City-IA-New Hope Evangelical)     | 20    | 3.3   |    | 99%  |
 | 10      | Samuel Heersink    | Beckett SAMwich (Orange City-IA-New Hope Evangelical) | 0     |       |    |      |
 
+## Adult
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                      | W/L   | Total | Avg   | QO | Q%  |
+|----:|--------------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Sioux Falls (Sioux Falls-SD-Sioux Falls First)                     | 4 / 0 | 745   | 186.2 | 4  | 97% |
+| 2.0 | Coaches of Children in the Market Place (Portage-WI-CrossPoint AG) | 3 / 1 | 465   | 116.2 | 4  | 81% |
+| 3.0 | Parents of Children in the Market Place (Portage-WI-CrossPoint AG) | 2 / 2 | 165   | 41.2  | 1  | 64% |
+| 4.0 | Calvary Church #4 (Marinette-WI-Calvary Church AG)                 | 1 / 3 | 40    | 10    |    | 57% |
+| 5.0 | Calvary Church #3 (Marinette-WI-Calvary Church AG)                 | 0 / 4 | 75    | 18.7  |    | 62% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                                                      | Total | Avg  | QO | Q%   |
+|---------:|--------------------|--------------------------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Laura Rodrigez     | Sioux Falls (Sioux Falls-SD-Sioux Falls First)                     | 560   | 140  | 4  | 100% |
+| 2        | Don Batty          | Coaches of Children in the Market Place (Portage-WI-CrossPoint AG) | 355   | 88.8 | 4  | 83%  |
+| 3        | Terry Schoessow    | Parents of Children in the Market Place (Portage-WI-CrossPoint AG) | 165   | 41.3 | 1  | 86%  |
+| 4        | Brianna McKinley   | Sioux Falls (Sioux Falls-SD-Sioux Falls First)                     | 135   | 33.8 |    | 92%  |
+| 5        | Warren Hazard      | Coaches of Children in the Market Place (Portage-WI-CrossPoint AG) | 110   | 27.5 |    | 77%  |
+| 6        | Lisa Pardee        | Calvary Church #3 (Marinette-WI-Calvary Church AG)                 | 95    | 23.8 |    | 75%  |
+| 7        | Merisa Rodrigez    | Sioux Falls (Sioux Falls-SD-Sioux Falls First)                     | 50    | 12.5 |    | 100% |
+| 8        | Christine Clements | Parents of Children in the Market Place (Portage-WI-CrossPoint AG) | 35    | 8.8  |    | 57%  |
+| 9        | Jesse Yoder        | Calvary Church #4 (Marinette-WI-Calvary Church AG)                 | 30    | 7.5  |    | 60%  |
+| 10       | Gary Mertz         | Calvary Church #4 (Marinette-WI-Calvary Church AG)                 | 10    | 2.5  |    | 50%  |
+| 11       | Kaden Dargatz      | Sioux Falls (Sioux Falls-SD-Sioux Falls First)                     | 0     |      |    |      |
+| **\*11** | Brooks Anderson    | Sioux Falls (Sioux Falls-SD-Sioux Falls First)                     | 0     |      |    |      |
+| **\*11** | Cheri Kjetland     | Sioux Falls (Sioux Falls-SD-Sioux Falls First)                     | 0     |      |    |      |
+| **\*11** | Emily McKinley     | Sioux Falls (Sioux Falls-SD-Sioux Falls First)                     | 0     |      |    |      |
+| **\*11** | Laurie Day         | Calvary Church #4 (Marinette-WI-Calvary Church AG)                 | 0     |      |    |      |
+| 12       | Jon Rakowski       | Calvary Church #3 (Marinette-WI-Calvary Church AG)                 | -20   | -5   |    | 25%  |
+| 13       | John Clements      | Parents of Children in the Market Place (Portage-WI-CrossPoint AG) | -35   | -8.8 |    |      |

--- a/_pages/history/2023/tournaments/bluegrass-classic.md
+++ b/_pages/history/2023/tournaments/bluegrass-classic.md
@@ -105,6 +105,36 @@ menubar_toc_static:
 | **\*20** | Quizzer-3           | Night and Day (Lighthouse Assembly of God)                    | 0     |       |    |      |
 | 21       | Luci Mjos           | Flaming Fire (King\'s Way Assembly of God)                    | -5    | -.7   |    |      |
 
+## XP Top 4
+
+### Teams
+
+*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
+
+| # | Team / Church                                                 | W/L   | W%  | Total | Avg   | QO | Q%  | Rnds |
+|--:|---------------------------------------------------------------|-------|----:|------:|------:|---:|----:|-----:|
+| 1 | Eternal Destruction (Lighthouse Assembly of God)              | 2 / 1 | 67% | 465   | 155   | 3  | 86% | 3    |
+| 2 | Oasis Community Church (Ithaca, MI) (Oasis Community Church)  | 2 / 1 | 67% | 640   | 213.3 | 6  | 97% | 3    |
+| 3 | Murderers at Heart (Lighthouse Assembly of God)               | 1 / 2 | 33% | 520   | 173.3 | 5  | 88% | 3    |
+| 4 | The Approved Messengers (Radiant Life Church Assembly of God) | 1 / 2 | 33% | 610   | 203.3 | 3  | 97% | 3    |
+
+### Individuals
+
+*Ties broken by Average Points then by Total Quiz Outs*
+
+| #  | Quizzer             | Team / Church                                                 | Total | Avg   | QO | Q%   |
+|---:|---------------------|---------------------------------------------------------------|------:|------:|---:|-----:|
+| 1  | Nathan Nimako       | The Approved Messengers (Radiant Life Church Assembly of God) | 405   | 135   | 3  | 100% |
+| 2  | Colton Markwell     | Oasis Community Church (Ithaca, MI) (Oasis Community Church)  | 335   | 111.7 | 3  | 94%  |
+| 3  | Will Wood           | Oasis Community Church (Ithaca, MI) (Oasis Community Church)  | 305   | 101.7 | 3  | 100% |
+| 4  | Joelle Powell       | Murderers at Heart (Lighthouse Assembly of God)               | 290   | 96.7  | 3  | 94%  |
+| 5  | Elizabeth Powell    | Eternal Destruction (Lighthouse Assembly of God)              | 285   | 95    | 2  | 82%  |
+| 6  | Jeremy Zadina       | Murderers at Heart (Lighthouse Assembly of God)               | 230   | 76.7  | 2  | 82%  |
+| 7  | Tabitha Barney      | Eternal Destruction (Lighthouse Assembly of God)              | 180   | 60    | 1  | 92%  |
+| 8  | Aseda Essandoh      | The Approved Messengers (Radiant Life Church Assembly of God) | 125   | 41.7  |    | 91%  |
+| 9  | Konyinsola Sofowora | The Approved Messengers (Radiant Life Church Assembly of God) | 80    | 26.7  |    | 100% |
+| 10 | Oye Essandoh        | The Approved Messengers (Radiant Life Church Assembly of God) | 0     |       |    |      |
+
 ## XP Lower 4
 
 ### Teams

--- a/_pages/jbq/2010/nationals.md
+++ b/_pages/jbq/2010/nationals.md
@@ -716,6 +716,44 @@ menubar_toc_static:
 | 23 | Andrea Little        | Grace Assembly of God | Grace A/G (New Whiteland, IN)                |       | .00   |    |
 | 24 | Vincent Hall-Shipley | New Life C.L.A.Y.     | New Life Church (Billings, MT)               | -20   | -4    |    |
 
+### Cherry
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                      | Church                                  | W/L | Total | Avg    |
+|--:|---------------------------|-----------------------------------------|-----|------:|-------:|
+| 1 | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | 4/0 | 750   | 187.50 |
+| 2 | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 3/1 | 705   | 176.25 |
+| 3 | Light                     | World Harvest (Roswell, GA)             | 2/2 | 535   | 133.75 |
+| 4 | Wild Things               | Glad Tidings Church (Hanford, CA)       | 1/3 | 400   | 100.00 |
+| 5 | God's Victory Kids        | Victory A/G (Universal City, TX)        | 0/4 | 230   | 57.50  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer             | Team                      | Church                                  | Total | Avg    | QO |
+|---:|---------------------|---------------------------|-----------------------------------------|------:|-------:|---:|
+| 1  | Weslee Kate Green   | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 400   | 100.00 | 2  |
+| 2  | Mary Frances Harris | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | 300   | 75.00  | 1  |
+| 3  | Robert Brock        | Wild Things               | Glad Tidings Church (Hanford, CA)       | 250   | 62.50  | 1  |
+| 4  | Brittany Steinberg  | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | 250   | 62.50  |    |
+| 5  | Daniel Ferreira     | Light                     | World Harvest (Roswell, GA)             | 230   | 57.50  |    |
+| 6  | Dayna Burns         | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 180   | 45.00  | 1  |
+| 7  | Cody Goodwyn        | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | 175   | 43.75  | 2  |
+| 8  | Grace Artis         | Light                     | World Harvest (Roswell, GA)             | 155   | 38.75  | 1  |
+| 9  | Trent Stafford      | Wild Things               | Glad Tidings Church (Hanford, CA)       | 150   | 37.50  | 2  |
+| 10 | Cristian Huix       | Light                     | World Harvest (Roswell, GA)             | 150   | 37.50  | 1  |
+| 11 | Nathan Green        | Lifepointe Miners         | Lifepointe Church (Prescott Valley, AZ) | 125   | 31.25  |    |
+| 12 | Zach Wylie          | God's Victory Kids        | Victory A/G (Universal City, TX)        | 90    | 22.50  |    |
+| 13 | Noah Harris         | God's Victory Kids        | Victory A/G (Universal City, TX)        | 85    | 21.25  |    |
+| 14 | Paul Russell, Jr.   | God's Victory Kids        | Victory A/G (Universal City, TX)        | 40    | 10.00  |    |
+| 15 | Jakob Schweizerhoff | God's Victory Kids        | Victory A/G (Universal City, TX)        | 20    | 5.00   |    |
+| 16 | Rudy Narvaez        | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | 15    | 3.75   |    |
+| 17 | Micah Rodriguez     | Awesome Bible Competitors | Victory A/G (Universal City, TX)        | 10    | 2.50   |    |
+| 18 | Kasie Narvaez       | God's Victory Kids        | Victory A/G (Universal City, TX)        | -5    | -1.25  |    |
 
 ### Cream
 
@@ -932,6 +970,46 @@ menubar_toc_static:
 | 23 | Darcie Harr                   | Greater Lansing   | 1st A/G (East Lansing, MI)         |       | .00    |    |
 | 23 | Sara Gaither                  | Ashland           | 1st A/G (Ashland, AL)              |       | .00    |    |
 
+### Lime
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                | Church                      | W/L | Total | Avg    |
+|--:|---------------------|-----------------------------|-----|------:|-------:|
+| 1 | Bible Worms         | 1st A/G (Dumas,TX)          | 3/1 | 695   | 173.75 |
+| 2 | Lebanon Swordsmen   | 1st A/G (Lebanon, MO)       | 3/1 | 625   | 156.25 |
+| 3 | Phoenix First Frogs | 1st A/G (Phoenix, AZ)       | 2/2 | 555   | 138.75 |
+| 4 | Quiztastic Four     | Tiffany Fellowship (KC, MO) | 1/3 | 430   | 107.50 |
+| 5 | Cordova             | 1st A/G (Cordova, TN)       | 1/3 | 305   | 76.25  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                | Church                      | Total | Avg    | QO |
+|---:|-------------------|---------------------|-----------------------------|------:|-------:|---:|
+| 1  | Chris Collins     | Lebanon Swordsmen   | 1st A/G (Lebanon, MO)       | 430   | 107.50 | 2  |
+| 2  | Maggie Akins      | Bible Worms         | 1st A/G (Dumas,TX)          | 370   | 92.50  | 1  |
+| 3  | Connor Ferguson   | Quiztastic Four     | Tiffany Fellowship (KC, MO) | 220   | 55.00  | 1  |
+| 4  | Bethany Lane      | Phoenix First Frogs | 1st A/G (Phoenix, AZ)       | 210   | 52.50  |    |
+| 5  | Sarah Lane        | Phoenix First Frogs | 1st A/G (Phoenix, AZ)       | 205   | 51.25  | 1  |
+| 6  | Nicholas Clemens  | Bible Worms         | 1st A/G (Dumas,TX)          | 175   | 43.75  | 1  |
+| 7  | Daniel Deppe      | Cordova             | 1st A/G (Cordova, TN)       | 150   | 37.50  | 1  |
+| 8  | James Lane        | Phoenix First Frogs | 1st A/G (Phoenix, AZ)       | 140   | 35.00  | 1  |
+| 9  | Dugan Akins       | Bible Worms         | 1st A/G (Dumas,TX)          | 120   | 30.00  |    |
+| 9  | Jared Deppe       | Cordova             | 1st A/G (Cordova, TN)       | 120   | 30.00  |    |
+| 10 | Tyler Lake        | Quiztastic Four     | Tiffany Fellowship (KC, MO) | 100   | 25.00  |    |
+| 11 | Jordan Birmingham | Quiztastic Four     | Tiffany Fellowship (KC, MO) | 95    | 23.75  | 1  |
+| 12 | Cody Collins      | Lebanon Swordsmen   | 1st A/G (Lebanon, MO)       | 80    | 20.00  | 1  |
+| 13 | Isaac Reading     | Lebanon Swordsmen   | 1st A/G (Lebanon, MO)       | 60    | 15.00  |    |
+| 14 | Nicole Bradberry  | Cordova             | 1st A/G (Cordova, TN)       | 35    | 8.75   |    |
+| 14 | Emily Rogers      | Lebanon Swordsmen   | 1st A/G (Lebanon, MO)       | 35    | 8.75   |    |
+| 15 | Ashli Sauer       | Bible Worms         | 1st A/G (Dumas,TX)          | 30    | 7.50   |    |
+| 16 | Alisa Rosen       | Lebanon Swordsmen   | 1st A/G (Lebanon, MO)       | 20    | 5.00   |    |
+| 17 | Brendan Ferguson  | Quiztastic Four     | Tiffany Fellowship (KC, MO) | 15    | 3.75   |    |
+| 18 | Abbigail Vaughan  | Cordova             | 1st A/G (Cordova, TN)       | 10    | 2.50   |    |
 
 ### Orange
 
@@ -1152,6 +1230,45 @@ menubar_toc_static:
 | 22 | Michael Webb         | The Giant Smarties          | Bethel Temple A/G (Huntington, WV) |       | .00    |    |
 | 22 | Laura Henderson      | Harrison Thrashers          | Faith A/G (Harrison, AR)           |       | .00    |    |
 
+### Teal
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                   | Church                        | W/L | Total | Avg    |
+|--:|------------------------|-------------------------------|-----|------:|-------:|
+| 1 | Status Update          | 1st A/G (Fargo, ND)           | 3/1 | 750   | 187.50 |
+| 2 | Justified Gems         | Evangel (Columbus, MS)        | 3/1 | 710   | 177.50 |
+| 3 | Westgate Chapel A Team | Westgate Chapel (Edmonds, WA) | 3/1 | 690   | 172.50 |
+| 4 | Get Smart              | 1st A/G (Des Moines, IA)      | 1/3 | 515   | 128.75 |
+| 5 | IAG Seals              | International A/G (Mesa, AZ)  | 0/4 | 130   | 32.50  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                   | Church                        | Total | Avg   | QO |
+|---:|-------------------|------------------------|-------------------------------|------:|------:|---:|
+| 1  | Trent Hashimoto   | Westgate Chapel A Team | Westgate Chapel (Edmonds, WA) | 350   | 87.50 | 2  |
+| 2  | Carson Nix        | Status Update          | 1st A/G (Fargo, ND)           | 295   | 73.75 | 1  |
+| 3  | Garrett Miyaoka   | Westgate Chapel A Team | Westgate Chapel (Edmonds, WA) | 250   | 62.50 |    |
+| 4  | Micah Marchand    | Status Update          | 1st A/G (Fargo, ND)           | 245   | 61.25 | 1  |
+| 5  | Aaron Marchand    | Status Update          | 1st A/G (Fargo, ND)           | 210   | 52.50 | 2  |
+| 6  | Cameron Wilcox    | Justified Gems         | Evangel (Columbus, MS)        | 190   | 47.50 |    |
+| 7  | Noah Ridgway      | Get Smart              | 1st A/G (Des Moines, IA)      | 180   | 45.00 | 1  |
+| 8  | Sophia Ridgway    | Get Smart              | 1st A/G (Des Moines, IA)      | 170   | 42.50 |    |
+| 9  | Emilee Wilcox     | Justified Gems         | Evangel (Columbus, MS)        | 165   | 41.25 |    |
+| 10 | Amelia Dixon      | Get Smart              | 1st A/G (Des Moines, IA)      | 145   | 36.25 | 1  |
+| 11 | Caleb Brewer      | Justified Gems         | Evangel (Columbus, MS)        | 130   | 32.50 | 2  |
+| 12 | Kathryn Mackey    | Justified Gems         | Evangel (Columbus, MS)        | 125   | 31.25 |    |
+| 13 | Billy Brewer      | Justified Gems         | Evangel (Columbus, MS)        | 100   | 25.00 | 1  |
+| 14 | Ashley Theesfeld  | IAG Seals              | International A/G (Mesa, AZ)  | 90    | 22.50 |    |
+| 15 | Nicholas Tveit    | Westgate Chapel A Team | Westgate Chapel (Edmonds, WA) | 60    | 15.00 |    |
+| 16 | Madyson Theesfeld | IAG Seals              | International A/G (Mesa, AZ)  | 40    | 10.00 |    |
+| 17 | Isabelle Smith    | Westgate Chapel A Team | Westgate Chapel (Edmonds, WA) | 30    | 7.50  |    |
+| 18 | Lola Phillips     | Get Smart              | 1st A/G (Des Moines, IA)      | 20    | 5.00  |    |
+| 19 | Justin Cheriyan   | IAG Seals              | International A/G (Mesa, AZ)  |       | .00   |    |
 
 ### White
 

--- a/_pages/jbq/2011/districts/arkansas.md
+++ b/_pages/jbq/2011/districts/arkansas.md
@@ -83,6 +83,41 @@ menubar_toc_static:
 | 12 | Gabby Ahne        | North Little Rock 1st | (North Little Rock) | 10    | 3.33   |    |
 | 13 | Ethan Davis       | Van Buren             | (Van Buren)         | 5     | 1.67   |    |
 
+### Bronze Division
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by AVERAGE)*
+
+| # | Team             | Church         | W/L | Total | Avg    |
+|--:|------------------|----------------|-----|------:|-------:|
+| 1 | Texarkana Faith  | (Texarkana)    | 3/1 | 675   | 168.75 |
+| 2 | Texarkana 1st    | (Texarkana)    | 2/2 | 370   | 92.50  |
+| 3 | Searcy 1st       | (Searcy)       | 2/2 | 335   | 83.75  |
+| 4 | Russellville 1st | (Russellville) | 2/2 | 320   | 80.00  |
+| 5 | Fordyce          | (Fordyce )     | 1/3 | 240   | 60.00  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by AVERAGE)*
+
+| #  | Quizzer          | Team             | Church         | Total | Avg    | QO |
+|---:|------------------|------------------|----------------|------:|-------:|---:|
+| 1  | Sarah McDonald   | Texarkana Faith  | (Texarkana)    | 520   | 130.00 | 2  |
+| 2  | Gracie Sisemore  | Texarkana 1st    | (Texarkana)    | 340   | 85.00  | 3  |
+| 3  | MiKayla Shaw     | Searcy 1st       | (Searcy)       | 280   | 70.00  | 4  |
+| 4  | Caden Lemley     | Russellville 1st | (Russellville) | 180   | 45.00  | 1  |
+| 5  | Kristopher Duran | Russellville 1st | (Russellville) | 120   | 30.00  | 1  |
+| 6  | Ian Hendryx      | Fordyce          | (Fordyce )     | 110   | 27.50  |    |
+| 7  | Lexie Lansdell   | Texarkana Faith  | (Texarkana)    | 100   | 25.00  | 1  |
+| 8  | Aubrey Hornaday  | Fordyce          | (Fordyce )     | 90    | 22.50  |    |
+| 9  | Sydney Sheek     | Texarkana Faith  | (Texarkana)    | 55    | 13.75  | 1  |
+| 10 | Ashley Coker     | Searcy 1st       | (Searcy)       | 45    | 11.25  |    |
+| 11 | Luke Hendryx     | Fordyce          | (Fordyce )     | 40    | 10.00  |    |
+| 12 | Rilyn Poage      | Texarkana 1st    | (Texarkana)    | 30    | 7.50   |    |
+| 13 | Seth West        | Searcy 1st       | (Searcy)       | 20    | 5.00   |    |
+| 13 | Carter Lemley    | Russellville 1st | (Russellville) | 20    | 5.00   |    |
+
 ### Blue Division
 
 #### Teams
@@ -123,6 +158,54 @@ menubar_toc_static:
 | 15 | Jack Berryhill    | Benton 1st          | (Benton)       | 15    | 3.00   |    |
 | 16 | Ethan Davis       | Van Buren           | (Van Buren)    | 5     | 1.00   |    |
 | 16 | Seth West         | Searcy 1st          | (Searcy)       | 5     | 1.00   |    |
+
+### Red Division
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by AVERAGE)*
+
+| # | Team                  | Church              | W/L | Total | Avg    |
+|--:|-----------------------|---------------------|-----|------:|-------:|
+| 1 | McArthur Green        | (Jacksonville)      | 6/0 | 1020  | 170.00 |
+| 2 | Jonesboro 1st         | (Jonesboro)         | 4/2 | 930   | 155.00 |
+| 3 | Harrison Faith        | (Harrison)          | 4/2 | 805   | 134.17 |
+| 4 | North Little Rock 1st | (North Little Rock) | 3/3 | 875   | 145.83 |
+| 5 | Texarkana Faith       | (Texarkana)         | 3/3 | 715   | 119.17 |
+| 6 | Fordyce               | (Fordyce )          | 1/5 | 265   | 44.17  |
+| 7 | Russellville 1st      | (Russellville)      | 0/6 | 335   | 55.83  |
+
+#### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by AVERAGE)*
+
+| #  | Quizzer            | Team                  | Church              | Total | Avg    | QO |
+|---:|--------------------|-----------------------|---------------------|------:|-------:|---:|
+| 1  | David Rubottom     | Jonesboro 1st         | (Jonesboro)         | 760   | 126.67 | 4  |
+| 2  | Sarah McDonald     | Texarkana Faith       | (Texarkana)         | 500   | 83.33  | 1  |
+| 3  | Madison Shaw       | McArthur Green        | (Jacksonville)      | 490   | 81.67  | 2  |
+| 4  | Kamryn Bradshaw    | Harrison Faith        | (Harrison)          | 400   | 66.67  | 1  |
+| 5  | Grant Wilson       | North Little Rock 1st | (North Little Rock) | 375   | 62.50  | 1  |
+| 6  | Morgan Liles       | North Little Rock 1st | (North Little Rock) | 335   | 55.83  | 4  |
+| 7  | Jordan Henley      | Harrison Faith        | (Harrison)          | 320   | 53.33  | 4  |
+| 8  | Garrett Richardson | McArthur Green        | (Jacksonville)      | 315   | 52.50  | 4  |
+| 9  | Kristopher Duran   | Russellville 1st      | (Russellville)      | 195   | 32.50  | 2  |
+| 10 | Nick Shipley       | Jonesboro 1st         | (Jonesboro)         | 170   | 28.33  |    |
+| 11 | Lexie Lansdell     | Texarkana Faith       | (Texarkana)         | 160   | 26.67  |    |
+| 12 | Grayson Young      | McArthur Green        | (Jacksonville)      | 130   | 21.67  | 1  |
+| 13 | Jacob Blackburn    | North Little Rock 1st | (North Little Rock) | 125   | 20.83  |    |
+| 14 | Caden Lemley       | Russellville 1st      | (Russellville)      | 115   | 19.17  | 1  |
+| 15 | Luke Hendryx       | Fordyce               | (Fordyce )          | 105   | 17.50  |    |
+| 16 | Ian Hendryx        | Fordyce               | (Fordyce )          | 85    | 14.17  |    |
+| 17 | Aubrey Hornaday    | Fordyce               | (Fordyce )          | 75    | 12.50  |    |
+| 18 | Caleb Whitener     | McArthur Green        | (Jacksonville)      | 70    | 11.67  |    |
+| 19 | Sadie Smith        | Harrison Faith        | (Harrison)          | 55    | 9.17   |    |
+| 19 | Sydney Sheek       | Texarkana Faith       | (Texarkana)         | 55    | 9.17   |    |
+| 20 | Andrew Dippel      | North Little Rock 1st | (North Little Rock) | 40    | 6.67   |    |
+| 21 | Eli Wilson         | Harrison Faith        | (Harrison)          | 30    | 5.00   |    |
+| 22 | Carter Lemley      | Russellville 1st      | (Russellville)      | 25    | 4.17   |    |
+| 23 | James Lindner      | McArthur Green        | (Jacksonville)      | 15    | 2.50   |    |
+| 24 | Allie Turner       | Fordyce               | (Fordyce )          | 5     | .83    |    |
 
 ## 3rd and 4th Grade
 

--- a/_pages/jbq/2014/districts/southern-missouri.md
+++ b/_pages/jbq/2014/districts/southern-missouri.md
@@ -167,6 +167,93 @@ menubar_toc_static:
 | 14 | Abigail Cooke     | That One Team           | Pebble Creek Assembly | -5    | -0.83  |    |
 
 
+## A Discoverer
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                                    | Church                      | W/L | Total | Avg    |
+|--:|-----------------------------------------|-----------------------------|-----|------:|-------:|
+| 1 | God Girls                               | Grace Community Church      | 5/1 | 1005  | 167.50 |
+| 2 | Quizzin Quotin Cardinals-Blazing Swords | West County Assembly of God | 5/1 | 845   | 140.83 |
+| 3 | Faith Warriors                          | Faith Community Church      | 2/4 | 575   | 95.83  |
+| 4 | NHF Heaven's Hitters                    | New Hope Fellowship: Fenton | 0/6 | 330   | 55.00  |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer           | Team                                    | Church                      | Total | Avg    | QO |
+|---:|-------------------|-----------------------------------------|-----------------------------|------:|-------:|---:|
+| 1  | Emily Pruitt      | God Girls                               | Grace Community Church      | 770   | 128.33 | 5  |
+| 2  | Adelaide Newfield | Faith Warriors                          | Faith Community Church      | 555   | 92.50  | 5  |
+| 3  | Kate Stoner       | Quizzin Quotin Cardinals-Blazing Swords | West County Assembly of God | 550   | 91.67  | 3  |
+| 4  | Logan Barnes      | NHF Heaven's Hitters                    | New Hope Fellowship: Fenton | 225   | 37.50  | 2  |
+| 5  | Jacob Stoner      | Quizzin Quotin Cardinals-Blazing Swords | West County Assembly of God | 210   | 35.00  | 1  |
+| 6  | Kyleigh Gibbs     | God Girls                               | Grace Community Church      | 200   | 33.33  | 1  |
+| 7  | Meredith Spratt   | NHF Heaven's Hitters                    | New Hope Fellowship: Fenton | 105   | 17.50  |    |
+| 8  | Nate Vast-Binder  | Quizzin Quotin Cardinals-Blazing Swords | West County Assembly of God | 85    | 14.17  |    |
+| 9  | Autumn Morgan     | God Girls                               | Grace Community Church      | 35    | 5.83   |    |
+| 10 | Liam Holt         | Faith Warriors                          | Faith Community Church      | 20    | 3.33   |    |
+| 11 | B Quizzer         | Quizzin Quotin Cardinals-Blazing Swords | West County Assembly of God |       | .00    |    |
+| 11 | B Quizzer         | God Girls                               | Grace Community Church      |       | .00    |    |
+| 11 | A Quizzer         | Quizzin Quotin Cardinals-Blazing Swords | West County Assembly of God |       | .00    |    |
+| 11 | A Quizzer         | Faith Warriors                          | Faith Community Church      |       | .00    |    |
+| 11 | B Quizzer         | Faith Warriors                          | Faith Community Church      |       | .00    |    |
+| 11 | A Quizzer         | God Girls                               | Grace Community Church      |       | .00    |    |
+| 11 | Grace Parks       | God Girls                               | Grace Community Church      |       | .00    |    |
+| 11 | A Quizzer         | NHF Heaven's Hitters                    | New Hope Fellowship: Fenton |       | .00    |    |
+| 11 | B Quizzer         | NHF Heaven's Hitters                    | New Hope Fellowship: Fenton |       | .00    |    |
+
+
+## B Master
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+| # | Team                  | Church             | W/L | Total | Avg    |
+|--:|-----------------------|--------------------|-----|------:|-------:|
+| 1 | James River Church    | James River Church | 4/2 | 740   | 123.33 |
+| 2 | Lightning Buzzers     | Evangel Assembly   | 4/2 | 860   | 143.33 |
+| 3 | Brighton Quiz Masters | Brighton Assembly  | 3/3 | 850   | 141.67 |
+| 4 | Cha Cha Cheetahs      | Central Assembly   | 1/5 | 465   | 77.50  |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+| #  | Quizzer          | Team                  | Church             | Total | Avg    | QO |
+|---:|------------------|-----------------------|--------------------|------:|-------:|---:|
+| 1  | Brooks Bilton    | Lightning Buzzers     | Evangel Assembly   | 690   | 115.00 | 4  |
+| 2  | Kalyn Cerce      | Brighton Quiz Masters | Brighton Assembly  | 525   | 87.50  | 4  |
+| 3  | Elli Woodward    | Cha Cha Cheetahs      | Central Assembly   | 265   | 44.17  | 2  |
+| 4  | Chuck Myers      | James River Church    | James River Church | 260   | 43.33  |    |
+| 5  | Mercy Germany    | James River Church    | James River Church | 215   | 35.83  |    |
+| 6  | Hannah Plake     | Cha Cha Cheetahs      | Central Assembly   | 170   | 28.33  |    |
+| 7  | Rebekah Burks    | James River Church    | James River Church | 165   | 27.50  |    |
+| 8  | Jonathan Crispin | Lightning Buzzers     | Evangel Assembly   | 140   | 23.33  | 1  |
+| 9  | Brad Cooper      | Brighton Quiz Masters | Brighton Assembly  | 125   | 20.83  |    |
+| 10 | Weston Schubert  | Brighton Quiz Masters | Brighton Assembly  | 120   | 20.00  |    |
+| 11 | Tristen Bough    | James River Church    | James River Church | 90    | 15.00  |    |
+| 12 | Lance Ramirez    | Brighton Quiz Masters | Brighton Assembly  | 80    | 13.33  |    |
+| 13 | Madison Tucker   | Cha Cha Cheetahs      | Central Assembly   | 30    | 5.00   |    |
+| 14 | Julia Garman     | Lightning Buzzers     | Evangel Assembly   | 20    | 3.33   |    |
+| 15 | Peyton Bough     | James River Church    | James River Church | 10    | 1.67   |    |
+| 15 | Eliot Wagner     | Lightning Buzzers     | Evangel Assembly   | 10    | 1.67   |    |
+| 16 | A Quizzer        | Lightning Buzzers     | Evangel Assembly   |       | .00    |    |
+| 16 | Noelle Germany   | James River Church    | James River Church |       | .00    |    |
+| 16 | Jack Wiebe       | Brighton Quiz Masters | Brighton Assembly  |       | .00    |    |
+| 16 | A Quizzer        | Brighton Quiz Masters | Brighton Assembly  |       | .00    |    |
+| 16 | B Quizzer        | Brighton Quiz Masters | Brighton Assembly  |       | .00    |    |
+| 16 | Drew Cooper      | Brighton Quiz Masters | Brighton Assembly  |       | .00    |    |
+| 16 | B Quizzer        | Lightning Buzzers     | Evangel Assembly   |       | .00    |    |
+| 16 | Rileigh Jamison  | James River Church    | James River Church |       | .00    |    |
+| 16 | A Quizzer        | Cha Cha Cheetahs      | Central Assembly   |       | .00    |    |
+| 16 | B Quizzer        | Cha Cha Cheetahs      | Central Assembly   |       | .00    |    |
+
+
 ## B Achiever
 
 ### Teams

--- a/_pages/jbq/2015/other/arkansas-districts-qualifying.md
+++ b/_pages/jbq/2015/other/arkansas-districts-qualifying.md
@@ -99,6 +99,59 @@ menubar_toc_static:
 | 17 | Caleb Brummett    | NEWSONG JBQ  | Newsong Church     | 15    | 3.00   |    |
 | 18 | Mikayla Owens     | Bible Ninjas | Bella Vista        | 10    | 2.00   |    |
 
+## North Central Area - 2nd & Under
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by AVERAGE)*
+
+| # | Team             | Church   | W/L | Total | Avg    |
+|--:|------------------|----------|-----|------:|-------:|
+| 1 | Team - TS        | McArthur | 3/0 | 480   | 160.00 |
+| 2 | Team - CH        | McArthur | 2/1 | 165   | 55.00  |
+| 3 | Thunder Bolts    | New Life | 1/2 | 145   | 48.33  |
+| 4 | Lightening Bolts | New LIfe | 0/3 | 55    | 18.33  |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by AVERAGE)*
+
+| # | Quizzer          | Team             | Church   | Total | Avg   | QO |
+|--:|------------------|------------------|----------|------:|------:|---:|
+| 1 | Elijah Yates     | Team - TS        | McArthur | 255   | 85.00 | 3  |
+| 2 | Nicholas Souden  | Team - TS        | McArthur | 210   | 70.00 | 2  |
+| 3 | Nathan Dickerson | Thunder Bolts    | New Life | 130   | 43.33 | 1  |
+| 4 | Aubrey Brandon   | Team - CH        | McArthur | 120   | 40.00 |    |
+| 5 | Sara Swain       | Team - TS        | McArthur | 70    | 23.33 |    |
+| 6 | Jacob Eckart     | Lightening Bolts | New LIfe | 60    | 20.00 |    |
+| 7 | ReeceAnn Folsom  | Team - CH        | McArthur | 45    | 15.00 |    |
+| 8 | Cloe Graves      | Thunder Bolts    | New Life | 15    | 5.00  |    |
+
+## North Central Area - 3rd & 4th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by AVERAGE)*
+
+| # | Team           | Church   | W/L | Total | Avg    |
+|--:|----------------|----------|-----|------:|-------:|
+| 1 | McArthur       | McArthur | 2/0 | 260   | 130.00 |
+| 2 | BOLTS          | New Life | 1/1 | 200   | 100.00 |
+| 3 | Bethel Bombers | Bethel   | 0/2 | 120   | 60.00  |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by AVERAGE)*
+
+| # | Quizzer          | Team           | Church   | Total | Avg   | QO |
+|--:|------------------|----------------|----------|------:|------:|---:|
+| 1 | Nevaeh Yates     | McArthur       | McArthur | 155   | 77.50 | 1  |
+| 2 | Peyton Dickerson | BOLTS          | New Life | 145   | 72.50 | 1  |
+| 3 | Colton Rosenbaum | Bethel Bombers | Bethel   | 125   | 62.50 |    |
+| 4 | Kylee Morris     | McArthur       | McArthur | 45    | 22.50 |    |
+| 5 | Allison Donley   | McArthur       | McArthur | 40    | 20.00 |    |
+| 6 | Savanna Stevens  | McArthur       | McArthur | 20    | 10.00 |    |
+| 7 | Kristina Phipps  | BOLTS          | New Life | 10    | 5.00  |    |
 
 ## North Central Area - 5th & 6th Grade
 

--- a/_pages/jbq/2016/other/arkansas-districts-qualifying.md
+++ b/_pages/jbq/2016/other/arkansas-districts-qualifying.md
@@ -57,6 +57,57 @@ menubar_toc_static:
 | 20 | Ella Lovell          | Bella Vista The Jesus League K-2 | Bella Vista        | 20    | 3.33   |    |
 | 21 | Isaiah Mata          | Trinity Believers K-2            | Trinity Fellowship | 15    | 2.50   |    |
 
+## North Central Area - 2nd & Under
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by AVERAGE)*
+
+| # | Team      | Church        | W/L | Total | Avg   |
+|--:|-----------|---------------|-----|------:|------:|
+| 1 | McArthur  | McArthur      | 2/0 | 195   | 97.50 |
+| 2 | New Life  | New Life      | 1/1 | 90    | 45.00 |
+| 3 | Buzz Hogs | River of Life | 0/2 | 40    | 20.00 |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by AVERAGE)*
+
+| # | Quizzer         | Team      | Church        | Total | Avg   | QO |
+|--:|-----------------|-----------|---------------|------:|------:|---:|
+| 1 | Elijah Yates    | McArthur  | McArthur      | 105   | 52.50 | 1  |
+| 2 | Skyla Cope      | New Life  | New Life      | 60    | 30.00 |    |
+| 2 | ReeceAnn Folsom | McArthur  | McArthur      | 60    | 30.00 |    |
+| 3 | Josiah Minick   | Buzz Hogs | River of Life | 40    | 20.00 |    |
+| 4 | Neaeh Watson    | New Life  | New Life      | 30    | 15.00 |    |
+| 4 | Alexa Harvey    | McArthur  | McArthur      | 30    | 15.00 |    |
+
+## North Central Area - 3rd & 4th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by AVERAGE)*
+
+| # | Team           | Church          | W/L | Total | Avg    |
+|--:|----------------|-----------------|-----|------:|-------:|
+| 1 | Bethel Bombers | Bethel Assembly | 2/0 | 320   | 160.00 |
+| 2 | New Life       | New Life        | 1/1 | 190   | 95.00  |
+| 3 | Mcarthur       | McArthur        | 0/2 | 190   | 95.00  |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by AVERAGE)*
+
+| # | Quizzer          | Team           | Church          | Total | Avg    | QO |
+|--:|------------------|----------------|-----------------|------:|-------:|---:|
+| 1 | Colton Rosenbaum | Bethel Bombers | Bethel Assembly | 280   | 140.00 | 2  |
+| 2 | Jacob Eckart     | New Life       | New Life        | 120   | 60.00  |    |
+| 3 | Hannah Harvey    | Mcarthur       | McArthur        | 100   | 50.00  | 1  |
+| 4 | Sara Swain       | Mcarthur       | McArthur        | 95    | 47.50  |    |
+| 5 | Nathan Dickerson | New Life       | New Life        | 70    | 35.00  |    |
+| 6 | Bradley Sims     | Bethel Bombers | Bethel Assembly | 30    | 15.00  |    |
+| 7 | Carter Higgins   | Mcarthur       | McArthur        | 10    | 5.00   |    |
+| 7 | Addyson Herbert  | Bethel Bombers | Bethel Assembly | 10    | 5.00   |    |
 
 ## North Central Area - 5th & 6th Grade
 
@@ -89,6 +140,37 @@ menubar_toc_static:
 | 10 | Madelyn Brandon  | G Force    | McArthur      | 20    | 6.67   |    |
 | 11 | Kristana Phipps  | New Life   | New Life      | 5     | 1.67   |    |
 
+## Northwest Area - 3rd & 4th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by AVERAGE)*
+
+| # | Team                         | Church             | W/L | Total | Avg    |
+|--:|------------------------------|--------------------|-----|------:|-------:|
+| 1 | Rogers 1st 3-4               | Rogers 1st         | 3/0 | 795   | 265.00 |
+| 2 | Harrison Faith 3-4           | Harrison Faith     | 2/1 | 540   | 180.00 |
+| 3 | Bella Vista Bible Ninjas 3-4 | Bella Vista        | 1/2 | 460   | 153.33 |
+| 4 | Trinity Truth Followers 3-4  | Trinity Fellowship | 0/3 | 100   | 33.33  |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by AVERAGE)*
+
+| #  | Quizzer          | Team                         | Church             | Total | Avg    | QO |
+|---:|------------------|------------------------------|--------------------|------:|-------:|---:|
+| 1  | Jayden Reed      | Rogers 1st 3-4               | Rogers 1st         | 360   | 120.00 | 2  |
+| 2  | Hannah Cheney    | Rogers 1st 3-4               | Rogers 1st         | 345   | 115.00 | 3  |
+| 3  | Kadence Still    | Harrison Faith 3-4           | Harrison Faith     | 230   | 76.67  | 1  |
+| 4  | Caleb Cunningham | Bella Vista Bible Ninjas 3-4 | Bella Vista        | 220   | 73.33  | 1  |
+| 5  | Lucas Paul       | Harrison Faith 3-4           | Harrison Faith     | 210   | 70.00  |    |
+| 6  | Norah Rustad     | Bella Vista Bible Ninjas 3-4 | Bella Vista        | 195   | 65.00  | 1  |
+| 7  | Kaedon Roberts   | Harrison Faith 3-4           | Harrison Faith     | 100   | 33.33  | 1  |
+| 8  | Landon Manweiler | Rogers 1st 3-4               | Rogers 1st         | 90    | 30.00  | 1  |
+| 9  | Hayden Kellhofer | Trinity Truth Followers 3-4  | Trinity Fellowship | 70    | 23.33  |    |
+| 10 | Maddie Lovell    | Bella Vista Bible Ninjas 3-4 | Bella Vista        | 45    | 15.00  |    |
+| 11 | Bella Bruton     | Trinity Truth Followers 3-4  | Trinity Fellowship | 20    | 6.67   |    |
+| 12 | Noah Hernandez   | Trinity Truth Followers 3-4  | Trinity Fellowship | 10    | 3.33   |    |
 
 ## Northwest Area - 5th & 6th Grade
 

--- a/_pages/jbq/2017/districts/southern-missouri.md
+++ b/_pages/jbq/2017/districts/southern-missouri.md
@@ -80,6 +80,44 @@ menubar_toc_static:
 | **\*30** | Jeremiah Koenig   | Blazing Swords of God (West County AG, Chesterfield) | 0     |       |    |      |
 | **\*30** | Dominic Hasty     | Blazing Swords of God (West County AG, Chesterfield) | 0     |       |    |      |
 
+## A Master Playoffs
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                      | W/L   | Total | Avg   | QO | Q%  |
+|----:|------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Double Edged Swords (Central )     | 4 / 0 | 685   | 171.2 | 3  | 85% |
+| 2.0 | Fried Pickles (Life360 Church)     | 2 / 2 | 685   | 171.2 | 5  | 82% |
+| 2.0 | Shock Diamonds (Central)           | 2 / 2 | 610   | 152.5 | 3  | 81% |
+| 2.0 | Bible Ninjas (Crown Pointe Church) | 2 / 2 | 560   | 140   | 2  | 70% |
+| 3.0 | Giant Slayers (De Soto 1st AG)     | 0 / 4 | 410   | 102.5 | 2  | 81% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer          | Team / Church                      | Total | Avg   | QO | Q%   |
+|---------:|------------------|------------------------------------|------:|------:|---:|-----:|
+| 1        | Josiah Brookbank | Bible Ninjas (Crown Pointe Church) | 415   | 103.8 | 2  | 73%  |
+| 2        | Shekinah Phelps  | Double Edged Swords (Central )     | 405   | 101.3 | 3  | 88%  |
+| 3        | Hannah Plake     | Shock Diamonds (Central)           | 405   | 101.3 | 2  | 94%  |
+| 4        | Kaitlyn Ramsey   | Fried Pickles (Life360 Church)     | 305   | 76.3  | 2  | 69%  |
+| 5        | Grace Wright     | Giant Slayers (De Soto 1st AG)     | 260   | 65    | 1  | 82%  |
+| 6        | Alyssa Ramsey    | Fried Pickles (Life360 Church)     | 210   | 52.5  | 2  | 90%  |
+| 7        | Abigail Jones    | Double Edged Swords (Central )     | 205   | 51.3  |    | 75%  |
+| 8        | Elli Woodward    | Shock Diamonds (Central)           | 150   | 37.5  | 1  | 75%  |
+| 9        | Catie Wolfe      | Fried Pickles (Life360 Church)     | 130   | 32.5  | 1  | 92%  |
+| 10       | Kennedy Shores   | Giant Slayers (De Soto 1st AG)     | 125   | 31.3  | 1  | 81%  |
+| 11       | Casen Gray       | Bible Ninjas (Crown Pointe Church) | 125   | 31.3  |    | 75%  |
+| 12       | Bethany Plake    | Shock Diamonds (Central)           | 55    | 13.8  |    | 70%  |
+| 13       | Sarah Jones      | Double Edged Swords (Central )     | 40    | 10    |    | 100% |
+| **\*13** | McKenna Black    | Fried Pickles (Life360 Church)     | 40    | 10    |    | 100% |
+| 14       | Andrew Le        | Double Edged Swords (Central )     | 35    | 8.8   |    | 80%  |
+| 15       | Hailey Nichol    | Giant Slayers (De Soto 1st AG)     | 25    | 6.3   |    | 66%  |
+| 16       | Gabe Diebold     | Bible Ninjas (Crown Pointe Church) | 20    | 5     |    | 43%  |
+| 17       | Rylee Honea      | Giant Slayers (De Soto 1st AG)     | 0     |       |    |      |
 
 ## A Achiever Playoffs
 
@@ -198,6 +236,76 @@ menubar_toc_static:
 | **\*34** | Kaelynn Fry       | Mighty Minions (Life360 Church)                            | 0     |       |    |      |
 | **\*34** | Isabel Nichol     | Giant Slayers (De Soto 1st AG)                             | 0     |       |    |      |
 | 35       | Gideon Koenig     | The Superstars (West County AG, Chesterfield)              | -10   | -.9   |    |      |
+
+## B Master Playoffs
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                              | W/L   | Total | Avg   | QO | Q%  |
+|----:|------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Deep Fried Twinkies (Brighton AG)                          | 3 / 0 | 555   | 184.9 | 1  | 92% |
+| 2.0 | Team-Central (Central)                                     | 2 / 1 | 395   | 131.6 | 3  | 77% |
+| 3.0 | Giant Slayers (De Soto 1st AG)                             | 1 / 2 | 290   | 96.6  | 2  | 77% |
+| 4.0 | The Lightning Ninja Quizzers (West County AG, Chesterfiel) | 0 / 3 | 295   | 98.3  |    | 70% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer         | Team / Church                                              | Total | Avg  | QO | Q%   |
+|---------:|-----------------|------------------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Shirah Ramaji   | The Lightning Ninja Quizzers (West County AG, Chesterfiel) | 255   | 85   |    | 72%  |
+| 2        | Tyler Woodham   | Deep Fried Twinkies (Brighton AG)                          | 220   | 73.3 |    | 100% |
+| 3        | Anna Le         | Team-Central (Central)                                     | 180   | 60   | 1  | 76%  |
+| 4        | Eliana Phelps   | Team-Central (Central)                                     | 160   | 53.3 | 2  | 81%  |
+| 5        | Chase Steward   | Giant Slayers (De Soto 1st AG)                             | 155   | 51.7 | 1  | 65%  |
+| 6        | Jason Cerce     | Deep Fried Twinkies (Brighton AG)                          | 150   | 50   | 1  | 86%  |
+| 7        | Joshua Vennum   | Deep Fried Twinkies (Brighton AG)                          | 150   | 50   |    | 100% |
+| 8        | Bryce Wright    | Giant Slayers (De Soto 1st AG)                             | 115   | 38.3 | 1  | 92%  |
+| 9        | C.C.Myers       | Team-Central (Central)                                     | 65    | 21.7 |    | 75%  |
+| 10       | Isaac Elliott   | The Lightning Ninja Quizzers (West County AG, Chesterfiel) | 40    | 13.3 |    | 67%  |
+| 11       | Trevor Tucker   | Deep Fried Twinkies (Brighton AG)                          | 25    | 8.3  |    | 75%  |
+| 12       | Brian Honea     | Giant Slayers (De Soto 1st AG)                             | 20    | 6.7  |    | 100% |
+| 13       | David Miller    | Deep Fried Twinkies (Brighton AG)                          | 10    | 3.3  |    | 99%  |
+| 14       | Aahana Shrestha | The Lightning Ninja Quizzers (West County AG, Chesterfiel) | 0     |      |    |      |
+| **\*14** | Isabel Nichol   | Giant Slayers (De Soto 1st AG)                             | 0     |      |    |      |
+| 15       | J.J. myers      | Team-Central (Central)                                     | -10   | -3.3 |    |      |
+
+## B Achiever Playoffs
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                 | W/L   | Total | Avg   | QO | Q%   |
+|----:|-----------------------------------------------|-------|------:|------:|---:|-----:|
+| 1.0 | Followers of Jesus Christ (West County AG)    | 2 / 1 | 345   | 115   |    | 83%  |
+| 1.0 | Royal Quizzers (Crown Pointe Church)          | 2 / 1 | 305   | 101.6 | 1  | 76%  |
+| 1.0 | Pebble Creek (Pebble Creek AG)                | 2 / 1 | 300   | 100   | 1  | 79%  |
+| 2.0 | The Superstars (West County AG, Chesterfield) | 0 / 3 | 300   | 100   | 3  | 100% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                 | Total | Avg  | QO | Q%   |
+|---------:|-------------------|-----------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Josh Pedapudi     | The Superstars (West County AG, Chesterfield) | 270   | 90   | 3  | 100% |
+| 2        | Diego Botana      | Pebble Creek (Pebble Creek AG)                | 210   | 70   | 1  | 80%  |
+| 3        | Haddie Brookbank  | Royal Quizzers (Crown Pointe Church)          | 190   | 63.3 | 1  | 85%  |
+| 4        | Shawn Ramaji      | Followers of Jesus Christ (West County AG)    | 155   | 51.7 |    | 100% |
+| 5        | Jonathan Benedict | Followers of Jesus Christ (West County AG)    | 140   | 46.7 |    | 72%  |
+| 6        | Isaiah Johnson    | Pebble Creek (Pebble Creek AG)                | 90    | 30   |    | 79%  |
+| 7        | Savanna Barber    | Royal Quizzers (Crown Pointe Church)          | 65    | 21.7 |    | 87%  |
+| 8        | Andrew Green      | Followers of Jesus Christ (West County AG)    | 50    | 16.7 |    | 100% |
+| 9        | George Hoelzel    | Royal Quizzers (Crown Pointe Church)          | 35    | 11.7 |    | 55%  |
+| 10       | Eliana Nelapati   | The Superstars (West County AG, Chesterfield) | 30    | 10   |    | 100% |
+| 11       | Cadence Chiles    | Royal Quizzers (Crown Pointe Church)          | 15    | 5    |    | 66%  |
+| 12       | Halle Korth       | Pebble Creek (Pebble Creek AG)                | 0     |      |    |      |
+| **\*12** | Gideon Koenig     | The Superstars (West County AG, Chesterfield) | 0     |      |    |      |
+| **\*12** | Isaac Koenig      | The Superstars (West County AG, Chesterfield) | 0     |      |    |      |
 
 
 ## B Searcher Playoffs

--- a/_pages/jbq/2017/other/arkansas-districts-qualifying.md
+++ b/_pages/jbq/2017/other/arkansas-districts-qualifying.md
@@ -42,6 +42,81 @@ menubar_toc_static:
 | **\*4** | Skyla Moody     | The Ridge (The Ridge)  | 0     |     |    |      |
 | 5       | William Phipps  | The Ridge (The Ridge)  | -5    | -5  |    | 50%  |
 
+## North Central Area - 3rd & 4th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church            | W/L   | Total | Avg   | QO | Q%  |
+|----:|--------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Bethel AG (Bethel AG)    | 3 / 0 | 390   | 130   |    | 71% |
+| 2.0 | The Stand (McArthur AG)  | 2 / 1 | 445   | 148.3 | 2  | 91% |
+| 3.0 | The Ridge (The Ridge)    | 1 / 2 | 225   | 75    | 2  | 84% |
+| 4.0 | Troys Team (McArthur AG) | 0 / 3 | 80    | 26.7  |    | 78% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer          | Team / Church            | Total | Avg  | QO | Q%   |
+|---------:|------------------|--------------------------|------:|-----:|---:|-----:|
+| 1        | Nathan Dickerson | The Ridge (The Ridge)    | 225   | 75   | 2  | 84%  |
+| 2        | Hannah Harvey    | The Stand (McArthur AG)  | 195   | 65   | 2  | 84%  |
+| 3        | Cloe Graves      | Bethel AG (Bethel AG)    | 195   | 65   |    | 67%  |
+| 4        | Sara Swain       | The Stand (McArthur AG)  | 180   | 60   |    | 100% |
+| 5        | Colten Rosenbaum | Bethel AG (Bethel AG)    | 110   | 36.7 |    | 57%  |
+| 6        | Kaitlyn Mogish   | Bethel AG (Bethel AG)    | 85    | 28.3 |    | 100% |
+| 7        | Addison Walters  | Troys Team (McArthur AG) | 45    | 15   |    | 80%  |
+| 8        | Aubrey Branden   | The Stand (McArthur AG)  | 40    | 13.3 |    | 100% |
+| 9        | Justin Hairston  | Troys Team (McArthur AG) | 35    | 11.7 |    | 75%  |
+| 10       | Evie Harrin      | The Stand (McArthur AG)  | 30    | 10   |    | 100% |
+| 11       | Jamia Smith      | Troys Team (McArthur AG) | 0     |      |    |      |
+| **\*11** | Scout Bateman    | Troys Team (McArthur AG) | 0     |      |    |      |
+| **\*11** | Tashla Hite      | Troys Team (McArthur AG) | 0     |      |    |      |
+| **\*11** | Aiden Scissell   | Troys Team (McArthur AG) | 0     |      |    |      |
+| **\*11** | Addyson Herbert  | Bethel AG (Bethel AG)    | 0     |      |    |      |
+| **\*11** | Mikaela Herbert  | Bethel AG (Bethel AG)    | 0     |      |    |      |
+| **\*11** | Jacob Eckart     | The Ridge (The Ridge)    | 0     |      |    |      |
+| **\*11** | Alexis Phipps    | The Ridge (The Ridge)    | 0     |      |    |      |
+
+## North Central Area - 5th & 6th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church             | W/L   | Total | Avg   | QO | Q%   |
+|----:|---------------------------|-------|------:|------:|---:|-----:|
+| 1.0 | Minions (McArthur AG)     | 3 / 0 | 685   | 228.3 | 3  | 92%  |
+| 2.0 | Buzz Hogs (River of Life) | 2 / 1 | 480   | 159.9 | 5  | 100% |
+| 3.0 | The Ridge 6th (The Ridge) | 1 / 2 | 280   | 93.3  | 1  | 90%  |
+| 4.0 | The Ridge 5th (The Ridge) | 0 / 3 | 130   | 43.3  |    | 100% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #       | Quizzer            | Team / Church             | Total | Avg   | QO | Q%   |
+|--------:|--------------------|---------------------------|------:|------:|---:|-----:|
+| 1       | Madelyn Brandon    | Minions (McArthur AG)     | 305   | 101.7 | 1  | 93%  |
+| 2       | Kamelia Skinner    | Minions (McArthur AG)     | 280   | 93.3  | 1  | 93%  |
+| 3       | Lauryn Jackson     | Buzz Hogs (River of Life) | 270   | 90    | 2  | 100% |
+| 4       | Peyton Dickerson   | The Ridge 6th (The Ridge) | 240   | 80    | 1  | 87%  |
+| 5       | Josiah Minick      | Buzz Hogs (River of Life) | 210   | 70    | 3  | 100% |
+| 6       | Savanna Stephens   | Minions (McArthur AG)     | 100   | 33.3  | 1  | 91%  |
+| 7       | Kristina Phipps    | The Ridge 6th (The Ridge) | 40    | 13.3  |    | 100% |
+| 8       | Kierra Huntley     | The Ridge 6th (The Ridge) | 0     |       |    |      |
+| **\*8** | Isabella Keaton    | The Ridge 6th (The Ridge) | 0     |       |    |      |
+| **\*8** | AnnaGrace Scallion | The Ridge 5th (The Ridge) | 0     |       |    |      |
+| **\*8** | Katie Henderson    | The Ridge 5th (The Ridge) | 0     |       |    |      |
+| **\*8** | Sunshine Moody     | The Ridge 5th (The Ridge) | 0     |       |    |      |
+| **\*8** | Braydon May        | The Ridge 5th (The Ridge) | 0     |       |    |      |
+| **\*8** | Brendon May        | The Ridge 5th (The Ridge) | 0     |       |    |      |
+| **\*8** | Kyler Cox          | The Ridge 5th (The Ridge) | 0     |       |    |      |
+| **\*8** | Lakin Skinner      | Minions (McArthur AG)     | 0     |       |    |      |
+| **\*8** | Jordan Hairston    | Minions (McArthur AG)     | 0     |       |    |      |
+| **\*8** | Nicholas Seigrist  | Buzz Hogs (River of Life) | 0     |       |    |      |
 
 ## Northwest Area - 2nd & Under
 
@@ -78,6 +153,79 @@ menubar_toc_static:
 | **\*9** | Ashleigh Griffin   | Harrison Faith K-2 Green (Faith) | 0     |      |    |    |
 | **\*9** | Adalee Roberts     | Harrison Faith K-2 Green (Faith) | 0     |      |    |    |
 | **\*9** | Empty Chair        | Harrison Faith K-2 Green (Faith) | 0     |      |    |    |
+
+## Northwest Area - 3rd & 4th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                   | W/L   | Total | Avg  | QO | Q% |
+|----:|---------------------------------|-------|------:|-----:|---:|---:|
+| 1.0 | Faith Harrison 3-4 Blue (Faith) | 1 / 0 | 100   | 99.9 |    |    |
+| 2.0 | Bella Vista 3-4 Blue (BVAG)     | 0 / 1 | 85    | 84.9 |    |    |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #       | Quizzer              | Team / Church                   | Total | Avg | QO | Q% |
+|--------:|----------------------|---------------------------------|------:|----:|---:|---:|
+| 1       | Zechariah Cunningham | Bella Vista 3-4 Blue (BVAG)     | 65    | 65  |    |    |
+| 2       | Kadence Still        | Faith Harrison 3-4 Blue (Faith) | 50    | 50  |    |    |
+| 3       | Lucas Paul           | Faith Harrison 3-4 Blue (Faith) | 45    | 45  |    |    |
+| 4       | Caleb Cunningham     | Bella Vista 3-4 Blue (BVAG)     | 40    | 40  |    |    |
+| 5       | Lillian Fairchild    | Faith Harrison 3-4 Blue (Faith) | 10    | 10  |    |    |
+| 6       | Trinity Henley       | Faith Harrison 3-4 Blue (Faith) | 0     |     |    |    |
+| **\*6** | Sarah Houston        | Faith Harrison 3-4 Blue (Faith) | 0     |     |    |    |
+| **\*6** | Kaedon Roberts       | Faith Harrison 3-4 Blue (Faith) | 0     |     |    |    |
+| **\*6** | Adam Bailey          | Faith Harrison 3-4 Blue (Faith) | 0     |     |    |    |
+| **\*6** | Avianna Rochier      | Bella Vista 3-4 Blue (BVAG)     | 0     |     |    |    |
+| 7       | Addison Williams     | Faith Harrison 3-4 Blue (Faith) | -5    | -5  |    |    |
+| **\*7** | Ian Cunningham       | Bella Vista 3-4 Blue (BVAG)     | -5    | -5  |    |    |
+| 8       | Zander Rochier       | Bella Vista 3-4 Blue (BVAG)     | -10   | -10 |    |    |
+
+## Northwest Area - 5th & 6th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                       | W/L   | Total | Avg   | QO | Q% |
+|----:|-------------------------------------|-------|------:|------:|---:|---:|
+| 1.0 | Rogers 5-6 (RFAG)                   | 4 / 0 | 1225  | 306.2 | 10 |    |
+| 2.0 | Faith Harrison 5-6 Blue (Faith)     | 3 / 1 | 625   | 156.2 | 2  |    |
+| 3.0 | BVAG 5-6 Incredible Quizzers (BVAG) | 2 / 2 | 345   | 86.2  |    |    |
+| 4.0 | Trinity Fellowship 5-6 (TF)         | 1 / 3 | 215   | 53.7  |    |    |
+| 5.0 | Newsong 5-6 (Newsong)               | 0 / 4 | 35    | 8.7   |    |    |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                       | Total | Avg   | QO | Q% |
+|---------:|--------------------|-------------------------------------|------:|------:|---:|---:|
+| 1        | Zachary Bernardini | Rogers 5-6 (RFAG)                   | 510   | 127.5 | 4  |    |
+| 2        | Hannah Cheney      | Rogers 5-6 (RFAG)                   | 460   | 115   | 3  |    |
+| 3        | Shaylee Ward       | Faith Harrison 5-6 Blue (Faith)     | 310   | 77.5  | 1  |    |
+| 4        | Landon Manweiler   | Rogers 5-6 (RFAG)                   | 255   | 63.8  | 3  |    |
+| 5        | Arabella Rochier   | BVAG 5-6 Incredible Quizzers (BVAG) | 220   | 55    |    |    |
+| 6        | Winston Fairchild  | Faith Harrison 5-6 Blue (Faith)     | 145   | 36.3  |    |    |
+| 7        | Bella Stewart      | Trinity Fellowship 5-6 (TF)         | 135   | 33.8  |    |    |
+| 8        | Mekayla Henley     | Faith Harrison 5-6 Blue (Faith)     | 100   | 25    | 1  |    |
+| 9        | Josiah Lewis       | BVAG 5-6 Incredible Quizzers (BVAG) | 95    | 23.8  |    |    |
+| 10       | Rachel Gregg       | Trinity Fellowship 5-6 (TF)         | 80    | 20    |    |    |
+| 11       | Juli Bailey        | Faith Harrison 5-6 Blue (Faith)     | 50    | 12.5  |    |    |
+| 12       | Colton Brummett    | Newsong 5-6 (Newsong)               | 35    | 8.8   |    |    |
+| 13       | Zayin Rochier      | BVAG 5-6 Incredible Quizzers (BVAG) | 30    | 7.5   |    |    |
+| 14       | Kyli Badgewell     | Faith Harrison 5-6 Blue (Faith)     | 20    | 5     |    |    |
+| **\*14** | Devin Ferguson     | Newsong 5-6 (Newsong)               | 20    | 5     |    |    |
+| 15       | EmptyChair         | BVAG 5-6 Incredible Quizzers (BVAG) | 0     |       |    |    |
+| **\*15** | Kalin Badgewell    | Faith Harrison 5-6 Blue (Faith)     | 0     |       |    |    |
+| **\*15** | Empty Chair        | Newsong 5-6 (Newsong)               | 0     |       |    |    |
+| **\*15** | Tielyr Boysen      | Rogers 5-6 (RFAG)                   | 0     |       |    |    |
+| **\*15** | Silvestre Trujillo | Trinity Fellowship 5-6 (TF)         | 0     |       |    |    |
+| 16       | Caleb Brummett     | Newsong 5-6 (Newsong)               | -20   | -5    |    |    |
 
 
 ## South Central Area - 2nd & Under
@@ -121,4 +269,90 @@ menubar_toc_static:
 | **\*14** | Matthew Boren      | First NLR - Life Savers ()    | 10    | 2.5  |    |    |
 | 15       | Addisyn McCullough | First NLR - Laffy Taffy ()    | 0     |      |    |    |
 | 16       | Noah Turner        | First NLR - Laffy Taffy ()    | -5    | -1.3 |    |    |
+
+
+## South Central Area - 3rd & 4th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church               | W/L   | Total | Avg   | QO | Q% |
+|----:|-----------------------------|-------|------:|------:|---:|---:|
+| 1.0 | First NLR - The A List ()   | 4 / 0 | 680   | 170   | 4  |    |
+| 2.0 | First NLR - Master B's ()   | 3 / 1 | 520   | 130   | 4  |    |
+| 3.0 | Benton First (3rd & 4th) () | 2 / 2 | 595   | 148.7 | 3  |    |
+| 4.0 | The Assembly (3rd & 4th) () | 1 / 3 | 215   | 53.7  |    |    |
+| 5.0 | Unlimited (3rd & 4th) ()    | 0 / 4 | 75    | 18.7  |    |    |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church               | Total | Avg   | QO | Q% |
+|---------:|-------------------|-----------------------------|------:|------:|---:|---:|
+| 1        | Alex Eckart       | First NLR - The A List ()   | 525   | 131.3 | 3  |    |
+| 2        | LaMaria Hall      | First NLR - Master B's ()   | 260   | 65    | 2  |    |
+| 3        | Kailey McCullough | First NLR - Master B's ()   | 255   | 63.8  | 2  |    |
+| 4        | Jose Perez        | Benton First (3rd & 4th) () | 215   | 53.8  | 1  |    |
+| 5        | Keeli Jackson     | Benton First (3rd & 4th) () | 205   | 51.3  | 1  |    |
+| 6        | David Morris      | Benton First (3rd & 4th) () | 145   | 36.3  | 1  |    |
+| 7        | Crevan Moore      | First NLR - The A List ()   | 140   | 35    | 1  |    |
+| 8        | Silas Ford        | The Assembly (3rd & 4th) () | 90    | 22.5  |    |    |
+| 9        | Solomon Ford      | The Assembly (3rd & 4th) () | 85    | 21.3  |    |    |
+| 10       | Serrinna John     | Unlimited (3rd & 4th) ()    | 50    | 12.5  |    |    |
+| 11       | Brandon Wilhelm   | The Assembly (3rd & 4th) () | 40    | 10    |    |    |
+| 12       | Samuel John       | Unlimited (3rd & 4th) ()    | 30    | 7.5   |    |    |
+| 13       | Lorelei Davis     | Benton First (3rd & 4th) () | 20    | 5     |    |    |
+| 14       | Garrett Dorsey    | First NLR - The A List ()   | 15    | 3.8   |    |    |
+| 15       | Lillie Johnson    | Benton First (3rd & 4th) () | 10    | 2.5   |    |    |
+| **\*15** | Makeda Toombs     | First NLR - Master B's ()   | 10    | 2.5   |    |    |
+| 16       | Lulu Davis        | Benton First (3rd & 4th) () | 0     |       |    |    |
+| **\*16** | Serenity Hampton  | First NLR - The A List ()   | 0     |       |    |    |
+| **\*16** | Nicole Sharps     | First NLR - Master B's ()   | 0     |       |    |    |
+| 17       | Harmony Leavins   | Unlimited (3rd & 4th) ()    | -5    | -1.3  |    |    |
+| **\*17** | Hope Weaver       | First NLR - Master B's ()   | -5    | -1.3  |    |    |
+
+## South Central Area - 5th & 6th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                | W/L   | Total | Avg   | QO | Q% |
+|----:|------------------------------|-------|------:|------:|---:|---:|
+| 1.0 | Unlimited (5th & 6th) ()     | 4 / 0 | 680   | 170   | 3  |    |
+| 2.0 | Benton First (5th & 6th) ()  | 3 / 1 | 630   | 157.5 | 3  |    |
+| 3.0 | First NLR - A (5th & 6th) () | 2 / 2 | 690   | 172.5 | 3  |    |
+| 4.0 | First NLR - B (5th & 6th) () | 1 / 3 | 200   | 50    |    |    |
+| 5.0 | The Assembly (5th & 6th) ()  | 0 / 4 | 135   | 33.7  |    |    |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer          | Team / Church                | Total | Avg   | QO | Q% |
+|---------:|------------------|------------------------------|------:|------:|---:|---:|
+| 1        | Anna Jordan      | Unlimited (5th & 6th) ()     | 565   | 141.3 | 3  |    |
+| 2        | Christian Lu     | First NLR - A (5th & 6th) () | 310   | 77.5  |    |    |
+| 3        | Elizabeth Hall   | First NLR - A (5th & 6th) () | 250   | 62.5  | 3  |    |
+| 4        | Tyler Kelly      | Benton First (5th & 6th) ()  | 215   | 53.8  | 1  |    |
+| 5        | Abby Roden       | First NLR - B (5th & 6th) () | 200   | 50    |    |    |
+| 6        | Noah Sanders     | Benton First (5th & 6th) ()  | 195   | 48.8  | 2  |    |
+| 7        | Michakela Irving | Benton First (5th & 6th) ()  | 140   | 35    |    |    |
+| 8        | Katie Harper     | First NLR - A (5th & 6th) () | 120   | 30    |    |    |
+| 9        | Mikey Griffin    | The Assembly (5th & 6th) ()  | 90    | 22.5  |    |    |
+| 10       | Tabitha Leavins  | Unlimited (5th & 6th) ()     | 65    | 16.3  |    |    |
+| 11       | McKenzie Estorga | The Assembly (5th & 6th) ()  | 35    | 8.8   |    |    |
+| 12       | Caden Sanders    | Benton First (5th & 6th) ()  | 30    | 7.5   |    |    |
+| **\*12** | Olivia Moore     | Benton First (5th & 6th) ()  | 30    | 7.5   |    |    |
+| **\*12** | Abigail Leavins  | Unlimited (5th & 6th) ()     | 30    | 7.5   |    |    |
+| 13       | Chloe Leavins    | Unlimited (5th & 6th) ()     | 20    | 5     |    |    |
+| 14       | Andrew Greenwell | Benton First (5th & 6th) ()  | 10    | 2.5   |    |    |
+| **\*14** | Riley Huskey     | Benton First (5th & 6th) ()  | 10    | 2.5   |    |    |
+| **\*14** | Grant Lewis      | First NLR - A (5th & 6th) () | 10    | 2.5   |    |    |
+| **\*14** | Telese Mason     | The Assembly (5th & 6th) ()  | 10    | 2.5   |    |    |
+| 15       | Andee Earnest    | Benton First (5th & 6th) ()  | 0     |       |    |    |
+| **\*15** | Larisssa Puckett | First NLR - B (5th & 6th) () | 0     |       |    |    |
+| **\*15** | Bethany Turner   | First NLR - B (5th & 6th) () | 0     |       |    |    |
 

--- a/_pages/jbq/2018/districts/north-texas.md
+++ b/_pages/jbq/2018/districts/north-texas.md
@@ -77,10 +77,11 @@ menubar_toc_static:
 | **\*33** | Abigail Koch       | Guardians of the Gospel (First @ Firewheel) | 0     |       |    |     |
 | 34       | Judith Ramesh      | Guardians of the Gospel (First @ Firewheel) | -10   | -1.4  |    |     |
 
+## Beginner
 
-## Beginner - Emerald
+### Emerald
 
-### Teams
+#### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points*
 
@@ -93,7 +94,7 @@ menubar_toc_static:
 | 5.0 | Iron Force (The Oaks Church)                    | 1 / 3 | 180   | 45    | 1  | 78% |
 | 6.0 | Genesis (Little Elm - The Crossing)             | 0 / 4 | 90    | 22.5  |    | 82% |
 
-### Individuals
+#### Individuals
 
 *Ties broken by Average Points then Total Quiz Outs*
 
@@ -124,10 +125,90 @@ menubar_toc_static:
 | **\*18** | Talom Ima         | Genesis (Little Elm - The Crossing)             | 0     |      |    |      |
 | 19       | Trinaty Blocker   | Iron Force (The Oaks Church)                    | -5    | -1.3 |    | 25%  |
 
+### Pearl
 
-## Beginner - Sapphire
+#### Teams
 
-### Teams
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                            | W/L   | Total | Avg   | QO | Q%  |
+|----:|------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Lion Warriors (The Oaks Church)          | 3 / 1 | 540   | 135   | 5  | 95% |
+| 2.0 | Transform (First @ Firewheel)            | 3 / 1 | 515   | 128.7 | 4  | 83% |
+| 3.0 | God\'s Knights (Dripping Springs UMC)    | 3 / 1 | 340   | 85    | 2  | 86% |
+| 4.0 | Quiz Kids (Freedom Church)               | 2 / 2 | 385   | 96.2  | 3  | 85% |
+| 5.0 | Victorious Bible Lions (The Oaks Church) | 1 / 3 | 65    | 16.2  |    | 69% |
+| 6.0 | Starburst (Casa View)                    | 0 / 4 | 100   | 25    |    | 75% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer         | Team / Church                            | Total | Avg  | QO | Q%   |
+|---------:|-----------------|------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Michael Schmude | Lion Warriors (The Oaks Church)          | 275   | 68.8 | 3  | 96%  |
+| 2        | Joel Maddox     | Lion Warriors (The Oaks Church)          | 260   | 65   | 2  | 94%  |
+| 3        | Emmett Taylor   | God\'s Knights (Dripping Springs UMC)    | 220   | 55   | 2  | 90%  |
+| 4        | Simon Solomon   | Transform (First @ Firewheel)            | 210   | 52.5 | 2  | 81%  |
+| 5        | Ian Ciruelos    | Quiz Kids (Freedom Church)               | 175   | 43.8 | 2  | 82%  |
+| 6        | Seth Thomas     | Quiz Kids (Freedom Church)               | 160   | 40   | 1  | 85%  |
+| 7        | Nathan Moges    | Transform (First @ Firewheel)            | 145   | 36.3 | 1  | 91%  |
+| 8        | Alex Lopez      | Transform (First @ Firewheel)            | 135   | 33.8 | 1  | 82%  |
+| 9        | Micah Marroquin | Victorious Bible Lions (The Oaks Church) | 70    | 17.5 |    | 87%  |
+| **\*9**  | Charlotte Smith | God\'s Knights (Dripping Springs UMC)    | 70    | 17.5 |    | 75%  |
+| **\*9**  | Jayden Esparza  | Starburst (Casa View)                    | 70    | 17.5 |    | 69%  |
+| 10       | James Moreland  | Quiz Kids (Freedom Church)               | 50    | 12.5 |    | 100% |
+| **\*10** | Jaya Gastineau  | God\'s Knights (Dripping Springs UMC)    | 50    | 12.5 |    | 86%  |
+| 11       | Chizaram Echefu | Transform (First @ Firewheel)            | 30    | 7.5  |    | 100% |
+| **\*11** | Camila Romero   | Starburst (Casa View)                    | 30    | 7.5  |    | 100% |
+| 12       | Gabriel Schmude | Victorious Bible Lions (The Oaks Church) | 15    | 3.8  |    | 66%  |
+| 13       | Lawson Haynes   | Lion Warriors (The Oaks Church)          | 10    | 2.5  |    | 99%  |
+| 14       | Addie Osborn    | Quiz Kids (Freedom Church)               | 0     |      |    |      |
+| **\*14** | Chinasa Ayozie  | Transform (First @ Firewheel)            | 0     |      |    |      |
+| **\*14** | Jackson Robson  | Lion Warriors (The Oaks Church)          | 0     |      |    |      |
+| 15       | Jonny Janssens  | Victorious Bible Lions (The Oaks Church) | -20   | -5   |    |      |
+
+
+### Ruby
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                     | W/L   | Total | Avg | QO | Q%   |
+|----:|-----------------------------------|-------|------:|----:|---:|-----:|
+| 1.0 | Rhema (Little Elm - The Crossing) | 4 / 0 | 580   | 145 | 3  | 84%  |
+| 2.0 | LifeKids (LIFEchurch )            | 4 / 1 | 545   | 109 | 5  | 80%  |
+| 3.0 | Gospel Gladiators (Hope Church)   | 1 / 3 | 260   | 65  | 1  | 79%  |
+| 4.0 | ProjecT 4:12 (The Oaks Church)    | 0 / 5 | 170   | 34  |    | 100% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer          | Team / Church                     | Total | Avg  | QO | Q%   |
+|---------:|------------------|-----------------------------------|------:|-----:|---:|-----:|
+| 1        | Eli Miller       | Rhema (Little Elm - The Crossing) | 230   | 57.5 | 3  | 85%  |
+| 2        | Jeremiah Webb    | LifeKids (LIFEchurch )            | 265   | 53   | 2  | 79%  |
+| 3        | Michael Gillelan | Gospel Gladiators (Hope Church)   | 210   | 52.5 | 1  | 80%  |
+| 4        | Ryland Sawyer    | LifeKids (LIFEchurch )            | 235   | 47   | 3  | 79%  |
+| 5        | David Kadari     | Rhema (Little Elm - The Crossing) | 180   | 45   |    | 83%  |
+| 6        | Harrison Miller  | Rhema (Little Elm - The Crossing) | 95    | 23.8 |    | 79%  |
+| 7        | Abigail Corder   | Rhema (Little Elm - The Crossing) | 75    | 18.8 |    | 89%  |
+| 8        | Sydney Haynes    | ProjecT 4:12 (The Oaks Church)    | 80    | 16   |    | 100% |
+| 9        | Marcos Marroquin | ProjecT 4:12 (The Oaks Church)    | 70    | 14   |    | 100% |
+| 10       | Sarah Johnson    | Gospel Gladiators (Hope Church)   | 30    | 7.5  |    | 67%  |
+| 11       | Mylie Dobson     | LifeKids (LIFEchurch )            | 35    | 7    |    | 80%  |
+| 12       | Karrington Allen | ProjecT 4:12 (The Oaks Church)    | 20    | 4    |    | 100% |
+| 13       | Sarah Bryant     | Gospel Gladiators (Hope Church)   | 10    | 2.5  |    | 99%  |
+| **\*13** | Kayden Spurgeon  | Gospel Gladiators (Hope Church)   | 10    | 2.5  |    | 99%  |
+| 14       | Andre Dobson     | LifeKids (LIFEchurch )            | 10    | 2    |    | 99%  |
+| 15       | Ethan Janssens   | ProjecT 4:12 (The Oaks Church)    | 0     |      |    |      |
+| **\*15** | Xavier McCoy     | Rhema (Little Elm - The Crossing) | 0     |      |    |      |
+
+### Sapphire
+
+#### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points*
 
@@ -140,7 +221,7 @@ menubar_toc_static:
 | 5.0 | Word Warriors - Hope Church (Hope Church)  | 1 / 3 | 150   | 37.5  | 1  | 88% |
 | 6.0 | Word Warriors - Dallas 1st (Dallas 1st AG) | 0 / 4 | 210   | 52.5  |    | 85% |
 
-### Individuals
+#### Individuals
 
 *Ties broken by Average Points then Total Quiz Outs*
 

--- a/_pages/jbq/2018/districts/peninsular-florida.md
+++ b/_pages/jbq/2018/districts/peninsular-florida.md
@@ -402,3 +402,53 @@ menubar_toc_static:
 | **\*12** | Ahnaley Serrano   | Highpoint Quizzers (Highpoint Church)         | 0     |      |    |      |
 | **\*12** | Madison Bowden    | God\'s Superheroes (LIFE Church AG)           | 0     |      |    |      |
 
+
+## Flight X2
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                | W/L   | Total | Avg | QO | Q%   |
+|----:|----------------------------------------------|-------|------:|----:|---:|-----:|
+| 1.0 | Mighty Mighty Christians (LIFE Church AG)    | 5 / 0 | 580   | 116 | 2  | 91%  |
+| 2.0 | Trinity 1X (Trinity AG)                      | 4 / 1 | 370   | 74  | 4  | 82%  |
+| 3.0 | Buzz Lightkids (Christian Life Center)       | 3 / 2 | 380   | 76  | 2  | 83%  |
+| 4.0 | Angels Army (Faith AG Orlando)               | 2 / 3 | 320   | 64  | 2  | 73%  |
+| 5.0 | Bible Girl\'s (City Church)                  | 1 / 4 | 240   | 48  |    | 82%  |
+| 6.0 | Trinity TCI X (Trinity Church International) | 0 / 5 | 30    | 6   |    | 100% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                                | Total | Avg | QO | Q%   |
+|---------:|---------------------|----------------------------------------------|------:|----:|---:|-----:|
+| 1        | Jordan Low          | Trinity 1X (Trinity AG)                      | 310   | 62  | 4  | 88%  |
+| 2        | Adalynn Dubois      | Angels Army (Faith AG Orlando)               | 245   | 49  | 2  | 96%  |
+| **\*2**  | Brayden Gracelien   | Buzz Lightkids (Christian Life Center)       | 245   | 49  | 2  | 89%  |
+| 3        | Gabe Thompson       | Mighty Mighty Christians (LIFE Church AG)    | 240   | 48  | 2  | 86%  |
+| 4        | Kaden Johnson       | Mighty Mighty Christians (LIFE Church AG)    | 200   | 40  |    | 91%  |
+| 5        | Alysa Cosat         | Bible Girl\'s (City Church)                  | 145   | 29  |    | 94%  |
+| 6        | Kirra Perry         | Mighty Mighty Christians (LIFE Church AG)    | 110   | 22  |    | 100% |
+| 7        | Gunner Padgett      | Trinity 1X (Trinity AG)                      | 75    | 15  |    | 89%  |
+| **\*7**  | Sebastian Jules     | Buzz Lightkids (Christian Life Center)       | 75    | 15  |    | 75%  |
+| 8        | Ella Tyminski       | Bible Girl\'s (City Church)                  | 70    | 14  |    | 80%  |
+| 9        | Zoe Dubois          | Angels Army (Faith AG Orlando)               | 65    | 13  |    | 87%  |
+| 10       | Pleasant Okoh       | Buzz Lightkids (Christian Life Center)       | 60    | 12  |    | 78%  |
+| 11       | Molly Saligan       | Trinity TCI X (Trinity Church International) | 30    | 6   |    | 100% |
+| **\*11** | Sydney Osorto       | Mighty Mighty Christians (LIFE Church AG)    | 30    | 6   |    | 100% |
+| **\*11** | Madi Stewart        | Bible Girl\'s (City Church)                  | 30    | 6   |    | 100% |
+| 12       | Lydia Marrero       | Angels Army (Faith AG Orlando)               | 10    | 2   |    | 37%  |
+| 13       | Makenzie Hayes      | Bible Girl\'s (City Church)                  | 5     | 1   |    | 50%  |
+| 14       | Omarie Jordan       | Trinity TCI X (Trinity Church International) | 0     |     |    |      |
+| **\*14** | Eliana Sam          | Trinity 1X (Trinity AG)                      | 0     |     |    |      |
+| **\*14** | Sheliana Sam        | Trinity 1X (Trinity AG)                      | 0     |     |    |      |
+| **\*14** | Isabella Longstreet | Mighty Mighty Christians (LIFE Church AG)    | 0     |     |    |      |
+| **\*14** | David Okoh          | Buzz Lightkids (Christian Life Center)       | 0     |     |    |      |
+| **\*14** | Kenzie Wayte        | Bible Girl\'s (City Church)                  | 0     |     |    |      |
+| **\*14** | Charlie Gomez       | Angels Army (Faith AG Orlando)               | 0     |     |    |      |
+| 15       | Nicholas Low        | Trinity 1X (Trinity AG)                      | -5    | -1  |    |      |
+| 16       | Sadie Padgett       | Trinity 1X (Trinity AG)                      | -10   | -2  |    |      |
+| **\*16** | Mari Rivera         | Bible Girl\'s (City Church)                  | -10   | -2  |    |      |
+

--- a/_pages/jbq/2018/districts/southern-missouri.md
+++ b/_pages/jbq/2018/districts/southern-missouri.md
@@ -56,6 +56,39 @@ menubar_toc_static:
 | **\*16** | Joshua Rogers   | Buzzing Bible Kids (Lebanon 1st AG)      | 0     |       |    |      |
 | 17       | Brady Williams  | Jedi Quizzers (Life 360 Church )         | -15   | -3.8  |    | 25%  |
 
+## A Achiever
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                       | W/L   | Total | Avg   | QO | Q%  |
+|----:|-------------------------------------|-------|------:|------:|---:|----:|
+| 1.1 | Bible Ninjas (Crown Pointe Church)  | 5 / 1 | 1050  | 175   | 9  | 78% |
+| 2.0 | Pebble Creek (Pebble Creek AG)      | 5 / 1 | 925   | 154.1 | 4  | 76% |
+| 3.0 | Slim Jims (Brighton AG)             | 2 / 4 | 615   | 102.5 | 4  | 94% |
+| 4.0 | The Giant Slayers (De Soto 1st AG ) | 0 / 6 | 455   | 75.8  |    | 79% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer         | Team / Church                       | Total | Avg  | QO | Q%   |
+|---------:|-----------------|-------------------------------------|------:|-----:|---:|-----:|
+| 1        | Casen Gray      | Bible Ninjas (Crown Pointe Church)  | 535   | 89.2 | 3  | 73%  |
+| 2        | Antoine Johnson | Pebble Creek (Pebble Creek AG)      | 530   | 88.3 | 4  | 74%  |
+| 3        | George Hoelzel  | Bible Ninjas (Crown Pointe Church)  | 450   | 75   | 6  | 82%  |
+| 4        | Jason Cerce     | Slim Jims (Brighton AG)             | 365   | 60.8 | 4  | 91%  |
+| 5        | Leah Grobe      | The Giant Slayers (De Soto 1st AG ) | 315   | 52.5 |    | 94%  |
+| 6        | Noah Fulton     | Pebble Creek (Pebble Creek AG)      | 275   | 45.8 |    | 78%  |
+| 7        | Grant Price     | Slim Jims (Brighton AG)             | 250   | 41.7 |    | 100% |
+| 8        | Kaiden Shores   | The Giant Slayers (De Soto 1st AG ) | 125   | 20.8 |    | 70%  |
+| 9        | Drew Fite       | Pebble Creek (Pebble Creek AG)      | 120   | 20   |    | 78%  |
+| 10       | Cam Risner      | Bible Ninjas (Crown Pointe Church)  | 65    | 10.8 |    | 86%  |
+| 11       | Isabel Nichol   | The Giant Slayers (De Soto 1st AG ) | 5     | .8   |    | 50%  |
+| 12       | Rylee Honea     | The Giant Slayers (De Soto 1st AG ) | 0     |      |    |      |
+| **\*12** | Josiah Mayfield | Slim Jims (Brighton AG)             | 0     |      |    |      |
+| **\*12** | David Miller    | Slim Jims (Brighton AG)             | 0     |      |    |      |
 
 ## A League
 

--- a/_pages/jbq/2018/other/arkansas-districts-qualifying.md
+++ b/_pages/jbq/2018/other/arkansas-districts-qualifying.md
@@ -12,6 +12,40 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
+## North Central Area - 2nd & Under
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                | W/L   | Total | Avg   | QO | Q%  |
+|----:|------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Quadruple Threat (McArthur ) | 2 / 0 | 225   | 112.4 | 1  | 94% |
+| 2.0 | Bethel Kids (Bethel AG)      | 1 / 1 | 135   | 67.5  | 2  | 74% |
+| 3.0 | Rose Bud (Rose Bud)          | 0 / 2 | 15    | 7.5   |    | 60% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #       | Quizzer             | Team / Church                | Total | Avg  | QO | Q%   |
+|--------:|---------------------|------------------------------|------:|-----:|---:|-----:|
+| 1       | Lexi Shalter        | Quadruple Threat (McArthur ) | 135   | 67.5 | 1  | 90%  |
+| 2       | Kayden Johnson      | Bethel Kids (Bethel AG)      | 130   | 65   | 2  | 86%  |
+| 3       | Addison Cotner      | Quadruple Threat (McArthur ) | 40    | 20   |    | 100% |
+| 4       | Taylinn Cotner      | Quadruple Threat (McArthur ) | 30    | 15   |    | 100% |
+| 5       | Johnathan Hairston  | Quadruple Threat (McArthur ) | 20    | 10   |    | 100% |
+| **\*5** | Timothy Donley      | Bethel Kids (Bethel AG)      | 20    | 10   |    | 99%  |
+| 6       | Naomi Nichols       | Rose Bud (Rose Bud)          | 15    | 7.5  |    | 60%  |
+| 7       | Kayden Moore        | Bethel Kids (Bethel AG)      | 5     | 2.5  |    | 50%  |
+| 8       | Anya Abdullah       | Quadruple Threat (McArthur ) | 0     |      |    |      |
+| **\*8** | Mel Stone           | Quadruple Threat (McArthur ) | 0     |      |    |      |
+| **\*8** | Ty Jacobs           | Quadruple Threat (McArthur ) | 0     |      |    |      |
+| **\*8** | Mikaela Herbert     | Bethel Kids (Bethel AG)      | 0     |      |    |      |
+| **\*8** | Parker Brandstetter | Rose Bud (Rose Bud)          | 0     |      |    |      |
+| **\*8** | Isaac Biniakewitz   | Rose Bud (Rose Bud)          | 0     |      |    |      |
+| 9       | Layne Burton        | Bethel Kids (Bethel AG)      | -20   | -10  |    |      |
+
 ## North Central Area - 3rd & 4th Grade
 
 ### Teams
@@ -44,6 +78,76 @@ menubar_toc_static:
 | 10       | Trinity Terry    | Buzz Hogs (River of Life)     | 10    | 3.3  |    | 50%  |
 | 11       | Casie Kappler    | Jesus Freaks (McArthur )      | 0     |      |    |      |
 | **\*11** | Chloe            | Jesus Freaks (McArthur )      | 0     |      |    |      |
+
+## North Central Area - 5th & 6th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church             | W/L   | Total | Avg   | QO | Q%  |
+|----:|---------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Buzz Hogs (River of Life) | 3 / 0 | 755   | 251.6 | 3  | 89% |
+| 2.0 | Minons ()                 | 2 / 1 | 605   | 201.6 | 4  | 86% |
+| 3.0 | Bethel Kids (Bethel AG)   | 1 / 2 | 230   | 76.6  |    | 65% |
+| 4.0 | Warriors ()               | 0 / 3 | 75    | 25    |    | 83% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer          | Team / Church             | Total | Avg   | QO | Q%   |
+|---------:|------------------|---------------------------|------:|------:|---:|-----:|
+| 1        | Lauryn Jackson   | Buzz Hogs (River of Life) | 305   | 101.7 | 1  | 100% |
+| **\*1**  | Josiah Minick    | Buzz Hogs (River of Life) | 305   | 101.7 | 1  | 84%  |
+| 2        | Kamelia Skinner  | Minons ()                 | 280   | 93.3  | 2  | 83%  |
+| 3        | Colton Rosenbaum | Bethel Kids (Bethel AG)   | 165   | 55    |    | 67%  |
+| 4        | Lakin Shaw       | Minons ()                 | 155   | 51.7  | 2  | 83%  |
+| 5        | Sarah Swain      | Minons ()                 | 150   | 50    |    | 100% |
+| 6        | Nehemiah Page    | Buzz Hogs (River of Life) | 130   | 43.3  | 1  | 87%  |
+| 7        | Aubrey Brandon   | Warriors ()               | 75    | 25    |    | 83%  |
+| 8        | Cloe Graves      | Bethel Kids (Bethel AG)   | 45    | 15    |    | 67%  |
+| 9        | Jayden Bullock   | Bethel Kids (Bethel AG)   | 25    | 8.3   |    | 75%  |
+| 10       | Savanna Stephens | Minons ()                 | 20    | 6.7   |    | 100% |
+| 11       | Cherish Page     | Buzz Hogs (River of Life) | 15    | 5     |    | 66%  |
+| 12       | Addison Wolters  | Minons ()                 | 0     |       |    |      |
+| **\*12** | Kayla Barnhart   | Warriors ()               | 0     |       |    |      |
+| **\*12** | Aiden Scissell   | Warriors ()               | 0     |       |    |      |
+| **\*12** | Brittney Coast   | Warriors ()               | 0     |       |    |      |
+| **\*12** | Drake Ward       | Warriors ()               | 0     |       |    |      |
+| **\*12** | Brooklyn Barnard | Warriors ()               | 0     |       |    |      |
+| **\*12** | Jordan Hairston  | Warriors ()               | 0     |       |    |      |
+| 13       | Amelia James     | Bethel Kids (Bethel AG)   | -5    | -1.7  |    |      |
+
+
+## Northwest Area - 2nd & Under
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                     | W/L   | Total | Avg   | QO | Q% |
+|----:|-----------------------------------|-------|------:|------:|---:|---:|
+| 1.0 | Harrison K2 Blue (Harrison Faith) | 1 / 0 | 110   | 109.9 | 1  |    |
+| 2.0 | Trinity K2 (Trinity Fellowship)   | 0 / 1 | -10   | -10   |    |    |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #       | Quizzer          | Team / Church                     | Total | Avg | QO | Q% |
+|--------:|------------------|-----------------------------------|------:|----:|---:|---:|
+| 1       | Haleigh Griffin  | Harrison K2 Blue (Harrison Faith) | 85    | 85  | 1  |    |
+| 2       | Ashleigh Griffin | Harrison K2 Blue (Harrison Faith) | 20    | 20  |    |    |
+| 3       | Andi Wilson      | Harrison K2 Blue (Harrison Faith) | 15    | 15  |    |    |
+| 4       | Stevie Jones     | Harrison K2 Blue (Harrison Faith) | 0     |     |    |    |
+| **\*4** | Angel Cruz       | Trinity K2 (Trinity Fellowship)   | 0     |     |    |    |
+| **\*4** | Joe Faries       | Trinity K2 (Trinity Fellowship)   | 0     |     |    |    |
+| **\*4** | Linda Howard     | Trinity K2 (Trinity Fellowship)   | 0     |     |    |    |
+| **\*4** | Eva Payton       | Trinity K2 (Trinity Fellowship)   | 0     |     |    |    |
+| **\*4** | Josiah Stewart   | Trinity K2 (Trinity Fellowship)   | 0     |     |    |    |
+| 5       | Ella Eddings     | Harrison K2 Blue (Harrison Faith) | -5    | -5  |    |    |
+| 6       | Caleb Stewart    | Trinity K2 (Trinity Fellowship)   | -10   | -10 |    |    |
 
 
 ## Northwest Area - 3rd & 4th Grade
@@ -79,4 +183,37 @@ menubar_toc_static:
 | **\*7** | Riley Westacott  | Trinity 3-4 (Trinity Fellowship) | 0     |       |    |    |
 | 8       | Victoria Rojas   | Trinity 3-4 (Trinity Fellowship) | -10   | -5    |    |    |
 | 9       | Adalee Roberts   | Harrison 3-4 (Harrison Faith)    | -30   | -15   |    |    |
+
+
+## Northwest Area - 5th & 6th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                    | W/L   | Total | Avg   | QO | Q% |
+|----:|----------------------------------|-------|------:|------:|---:|---:|
+| 1.0 | Rogers 5-6 (Rogers First)        | 2 / 0 | 570   | 284.9 | 2  |    |
+| 2.0 | Harrison 5-6 (Harrison Faith)    | 1 / 1 | 355   | 177.4 | 2  |    |
+| 3.0 | Trinity 5-6 (Trinity Fellowship) | 0 / 2 | 40    | 20    |    |    |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #       | Quizzer            | Team / Church                    | Total | Avg  | QO | Q% |
+|--------:|--------------------|----------------------------------|------:|-----:|---:|---:|
+| 1       | Zachary Bernardini | Rogers 5-6 (Rogers First)        | 320   | 160  | 2  |    |
+| 2       | Kadence Still      | Harrison 5-6 (Harrison Faith)    | 180   | 90   | 1  |    |
+| 3       | Winston Fairchild  | Harrison 5-6 (Harrison Faith)    | 135   | 67.5 | 1  |    |
+| 4       | Landon Manweiler   | Rogers 5-6 (Rogers First)        | 120   | 60   |    |    |
+| 5       | Hannah Harvey      | Rogers 5-6 (Rogers First)        | 100   | 50   |    |    |
+| 6       | Bella Stewart      | Trinity 5-6 (Trinity Fellowship) | 40    | 20   |    |    |
+| **\*6** | Lillian Fairchild  | Harrison 5-6 (Harrison Faith)    | 40    | 20   |    |    |
+| 7       | Tielyr Boysen      | Rogers 5-6 (Rogers First)        | 30    | 15   |    |    |
+| 8       | Rachel Gregg       | Trinity 5-6 (Trinity Fellowship) | 0     |      |    |    |
+| **\*8** | Silvestre Trujillo | Trinity 5-6 (Trinity Fellowship) | 0     |      |    |    |
+| **\*8** | Lucas Paul         | Harrison 5-6 (Harrison Faith)    | 0     |      |    |    |
+| **\*8** | Empty Chair        | Harrison 5-6 (Harrison Faith)    | 0     |      |    |    |
+| **\*8** | Kaedon Roberts     | Harrison 5-6 (Harrison Faith)    | 0     |      |    |    |
 

--- a/_pages/jbq/2018/other/arkansas-razorback.md
+++ b/_pages/jbq/2018/other/arkansas-razorback.md
@@ -72,6 +72,48 @@ menubar_toc_static:
 | **\*22** | Caitlyn Jendrajas   | 5/6 Bible Bugs (Fordyce 1st Assembly)    | 0     |       |    |      |
 | 23       | Jordan Hairston     | McArthur Minions (McArthur A/G)          | -5    | -.8   |    |      |
 
+
+### Gold Division (PM)
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                            | W/L   | Total | Avg   | QO | Q%  |
+|----:|------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | 5/6 Bible Bugs (Fordyce 1st Assembly)    | 2 / 1 | 530   | 176.6 | 4  | 79% |
+| 2.0 | Buzz Hogs (River of Life)                | 2 / 1 | 425   | 141.6 | 2  | 72% |
+| 3.0 | McArthur Minions (McArthur A/G)          | 2 / 1 | 335   | 111.6 |    | 74% |
+| 4.0 | Crystal Hill Avengers (Crystal Hill A/G) | 0 / 3 | 190   | 63.3  |    | 67% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                            | Total | Avg   | QO | Q%   |
+|---------:|---------------------|------------------------------------------|------:|------:|---:|-----:|
+| 1        | Ansley Hornaday     | 5/6 Bible Bugs (Fordyce 1st Assembly)    | 355   | 118.3 | 3  | 95%  |
+| 2        | Lauryn Jackson      | Buzz Hogs (River of Life)                | 275   | 91.7  | 1  | 83%  |
+| 3        | Eli Turner          | 5/6 Bible Bugs (Fordyce 1st Assembly)    | 165   | 55    | 1  | 61%  |
+| 4        | Kamelia Skinner     | McArthur Minions (McArthur A/G)          | 160   | 53.3  |    | 71%  |
+| 5        | Anna Jordan         | Crystal Hill Avengers (Crystal Hill A/G) | 140   | 46.7  |    | 62%  |
+| 6        | Josiah Minick       | Buzz Hogs (River of Life)                | 85    | 28.3  | 1  | 61%  |
+| 7        | Lakin Shaw          | McArthur Minions (McArthur A/G)          | 80    | 26.7  |    | 71%  |
+| 8        | Sara Swain          | McArthur Minions (McArthur A/G)          | 75    | 25    |    | 75%  |
+| 9        | Nehemiah Page       | Buzz Hogs (River of Life)                | 70    | 23.3  |    | 80%  |
+| 10       | Braylon Sutherland  | Crystal Hill Avengers (Crystal Hill A/G) | 50    | 16.7  |    | 75%  |
+| 11       | Savanna Stephens    | McArthur Minions (McArthur A/G)          | 20    | 6.7   |    | 100% |
+| 12       | Anna Claire Collins | 5/6 Bible Bugs (Fordyce 1st Assembly)    | 10    | 3.3   |    | 99%  |
+| 13       | Kerra Nutt          | 5/6 Bible Bugs (Fordyce 1st Assembly)    | 0     |       |    |      |
+| **\*13** | Caitlyn Jendrajas   | 5/6 Bible Bugs (Fordyce 1st Assembly)    | 0     |       |    |      |
+| **\*13** | Trinity Terry       | Buzz Hogs (River of Life)                | 0     |       |    |      |
+| **\*13** | Cherish Page        | Buzz Hogs (River of Life)                | 0     |       |    |      |
+| **\*13** | Addisyn Wolters     | McArthur Minions (McArthur A/G)          | 0     |       |    |      |
+| **\*13** | Jordan Hairston     | McArthur Minions (McArthur A/G)          | 0     |       |    |      |
+| **\*13** | Brooklyn Sutherland | Crystal Hill Avengers (Crystal Hill A/G) | 0     |       |    |      |
+| **\*13** | Lennen Juarez       | Crystal Hill Avengers (Crystal Hill A/G) | 0     |       |    |      |
+| 14       | Peter Page          | Buzz Hogs (River of Life)                | -5    | -1.7  |    |      |
+
 ### Silver Division (PM)
 
 ### Teams

--- a/_pages/jbq/2018/tournaments/carolina-classic.md
+++ b/_pages/jbq/2018/tournaments/carolina-classic.md
@@ -130,3 +130,44 @@ menubar_toc_static:
 | **\*17** | Carson Sandberg    | SPY Kids (The Worship Center)                      | 0     |      |    |      |
 | 18       | Lynsey Bazemore    | Askewville (Bethel AG)                             | -5    | -1.3 |    |      |
 
+## Silver Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                         | W/L   | Total | Avg   | QO | Q%  |
+|----:|-------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Contagious Kindness (Mechanicsville Christian Center) | 4 / 0 | 930   | 232.4 | 3  | 93% |
+| 2.0 | Team-Concord cfa church (Concord cfa church)          | 3 / 1 | 620   | 155   | 3  | 88% |
+| 3.0 | Gushers Team A (Chapel Springs Church)                | 1 / 3 | 435   | 108.7 | 1  | 67% |
+| 4.0 | Guardians of the Gospel (LIFE Church AG)              | 1 / 3 | 390   | 97.5  | 1  | 74% |
+| 5.0 | Angel Warriors (Marion Iglesia Bethel)                | 1 / 3 | 345   | 86.2  | 2  | 73% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer          | Team / Church                                         | Total | Avg   | QO | Q%   |
+|---------:|------------------|-------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Angel Walker     | Contagious Kindness (Mechanicsville Christian Center) | 415   | 103.8 | 1  | 95%  |
+| 2        | Izlia Shepard    | Angel Warriors (Marion Iglesia Bethel)                | 335   | 83.8  | 2  | 72%  |
+| 3        | Savannah Harper  | Contagious Kindness (Mechanicsville Christian Center) | 285   | 71.3  |    | 84%  |
+| 4        | Gabe Hudson      | Team-Concord cfa church (Concord cfa church)          | 230   | 57.5  | 3  | 85%  |
+| 5        | Andea Mason      | Gushers Team A (Chapel Springs Church)                | 210   | 52.5  |    | 70%  |
+| 6        | Berkley Adams    | Contagious Kindness (Mechanicsville Christian Center) | 200   | 50    | 2  | 100% |
+| 7        | Lydia Hill       | Team-Concord cfa church (Concord cfa church)          | 200   | 50    |    | 100% |
+| **\*7**  | Chloe Bowden     | Guardians of the Gospel (LIFE Church AG)              | 200   | 50    |    | 68%  |
+| 8        | Kayleigh Henley  | Gushers Team A (Chapel Springs Church)                | 150   | 37.5  | 1  | 65%  |
+| 9        | Seth Hudson      | Team-Concord cfa church (Concord cfa church)          | 110   | 27.5  |    | 86%  |
+| 10       | Abby Thomas      | Guardians of the Gospel (LIFE Church AG)              | 95    | 23.8  | 1  | 90%  |
+| 11       | Leah Sowers      | Guardians of the Gospel (LIFE Church AG)              | 95    | 23.8  |    | 73%  |
+| 12       | Charlotte Smith  | Team-Concord cfa church (Concord cfa church)          | 80    | 20    |    | 87%  |
+| 13       | Audrey Mason     | Gushers Team A (Chapel Springs Church)                | 55    | 13.8  |    | 86%  |
+| 14       | Malia Ray        | Contagious Kindness (Mechanicsville Christian Center) | 30    | 7.5   |    | 100% |
+| 15       | Christina Thomas | Gushers Team A (Chapel Springs Church)                | 20    | 5     |    | 50%  |
+| 16       | Dorothy Shepard  | Angel Warriors (Marion Iglesia Bethel)                | 10    | 2.5   |    | 99%  |
+| 17       | Belva Fianko     | Gushers Team A (Chapel Springs Church)                | 0     |       |    |      |
+| **\*17** | Shammah Shepard  | Angel Warriors (Marion Iglesia Bethel)                | 0     |       |    |      |
+| **\*17** | Caleb Urbina     | Angel Warriors (Marion Iglesia Bethel)                | 0     |       |    |      |
+

--- a/_pages/jbq/2018/tournaments/the-iron.md
+++ b/_pages/jbq/2018/tournaments/the-iron.md
@@ -103,3 +103,15 @@ menubar_toc_static:
 | 14       | Hayden Wright      | Victory Boyz (Victory Church)            | 0     |       |    |      |
 | **\*14** | Jace Hance         | Victory Boyz (Victory Church)            | 0     |       |    |      |
 
+## Silver Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                         | W/L   | Total | Avg   | QO | Q% |
+|----:|---------------------------------------|-------|------:|------:|---:|---:|
+| 1.0 | Book 66 (Life Church)                 | 2 / 0 | 380   | 189.9 | 1  |    |
+| 2.0 | Quizzettes (LIFE Church AG)           | 1 / 1 | 285   | 142.4 | 2  |    |
+| 3.0 | Highpoint Quizzers (Highpoint Church) | 0 / 2 | 50    | 25    |    |    |
+

--- a/_pages/jbq/2019/districts/oklahoma.md
+++ b/_pages/jbq/2019/districts/oklahoma.md
@@ -1,0 +1,146 @@
+---
+layout: page
+title: "2019 Oklahoma District Finals"
+permalink: /jbq/2019/districts/oklahoma/
+date: "2019-02-23"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2019 Season
+    link: /jbq/2019/
+    icon: fas fa-home
+---
+
+## Advanced
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                            | W/L   | Total | Avg   | QO | Q%  |
+|----:|------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | United for Christ (The Bridge (Mustang)) | 6 / 0 | 1480  | 246.6 | 12 | 79% |
+| 2.0 | Newspring (Newspring Assembly (Jenks))   | 4 / 2 | 1035  | 172.5 | 2  | 90% |
+| 3.0 | God Squad (The Link (Elk City))          | 2 / 4 | 655   | 109.1 | 4  | 79% |
+| 4.0 | The Fuze (Faith Church (Tulsa))          | 0 / 6 | 240   | 40    |    | 76% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                            | Total | Avg   | QO | Q%   |
+|---------:|--------------------|------------------------------------------|------:|------:|---:|-----:|
+| 1        | Christian Alapati  | United for Christ (The Bridge (Mustang)) | 905   | 150.8 | 6  | 92%  |
+| 2        | Carson Fincher     | United for Christ (The Bridge (Mustang)) | 460   | 76.7  | 5  | 83%  |
+| 3        | Ashlin Vanderslice | Newspring (Newspring Assembly (Jenks))   | 435   | 72.5  | 1  | 83%  |
+| 4        | Dillon Baker       | God Squad (The Link (Elk City))          | 375   | 62.5  | 2  | 74%  |
+| 5        | Addison Beasley    | Newspring (Newspring Assembly (Jenks))   | 360   | 60    |    | 100% |
+| 6        | Abigail Cothran    | Newspring (Newspring Assembly (Jenks))   | 240   | 40    | 1  | 92%  |
+| 7        | Noah Cook          | God Squad (The Link (Elk City))          | 180   | 30    | 2  | 89%  |
+| 8        | Garrett McElroy    | United for Christ (The Bridge (Mustang)) | 130   | 21.7  | 1  | 65%  |
+| 9        | Claire Crook       | The Fuze (Faith Church (Tulsa))          | 120   | 20    |    | 86%  |
+| 10       | Cheyenne Cook      | God Squad (The Link (Elk City))          | 80    | 13.3  |    | 75%  |
+| 11       | David Wineinger    | The Fuze (Faith Church (Tulsa))          | 65    | 10.8  |    | 58%  |
+| 12       | Henry Wineinger    | The Fuze (Faith Church (Tulsa))          | 30    | 5     |    | 100% |
+| 13       | Grace Carlson      | The Fuze (Faith Church (Tulsa))          | 25    | 4.2   |    | 75%  |
+| 14       | Kaitlyn Baker      | God Squad (The Link (Elk City))          | 20    | 3.3   |    | 75%  |
+| 15       | Jonathan Wineinger | The Fuze (Faith Church (Tulsa))          | 0     |       |    |      |
+| **\*15** | Kivi Goins         | The Fuze (Faith Church (Tulsa))          | 0     |       |    |      |
+| 16       | Zoey Fischer       | United for Christ (The Bridge (Mustang)) | -15   | -2.5  |    | 20%  |
+
+
+## Beginner
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                               | W/L   | Total | Avg | QO | Q%   |
+|----:|---------------------------------------------|-------|------:|----:|---:|-----:|
+| 1.0 | The Bridge (The Bridge (Mustang))           | 5 / 0 | 915   | 183 | 4  | 95%  |
+| 2.0 | Powerhouse Kidz (Broken Bow First Assembly) | 4 / 1 | 470   | 94  | 3  | 80%  |
+| 3.0 | ReAction (Faith Church (Tulsa))             | 3 / 2 | 275   | 55  | 2  | 83%  |
+| 4.0 | Airborne (The Link (Elk City))              | 2 / 3 | 240   | 48  |    | 80%  |
+| 5.0 | Christian Chapel (Christian Chapel (Tulsa)) | 1 / 4 | 225   | 45  |    | 86%  |
+| 6.0 | Newspring (Newspring Assembly (Jenks))      | 0 / 5 | 20    | 4   |    | 100% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                               | Total | Avg | QO | Q%   |
+|---------:|--------------------|---------------------------------------------|------:|----:|---:|-----:|
+| 1        | Cannon Stephens    | The Bridge (The Bridge (Mustang))           | 345   | 69  |    | 95%  |
+| 2        | Madison Stephens   | The Bridge (The Bridge (Mustang))           | 300   | 60  | 3  | 100% |
+| 3        | Benjamin Hernandez | Powerhouse Kidz (Broken Bow First Assembly) | 290   | 58  | 2  | 92%  |
+| 4        | Harlan Yousey      | The Bridge (The Bridge (Mustang))           | 275   | 55  | 1  | 94%  |
+| 5        | Carissa Fair       | ReAction (Faith Church (Tulsa))             | 245   | 49  | 2  | 81%  |
+| 6        | Lydia Beiler       | Christian Chapel (Christian Chapel (Tulsa)) | 170   | 34  |    | 100% |
+| 7        | Gadiel Zaragoza    | Powerhouse Kidz (Broken Bow First Assembly) | 135   | 27  | 1  | 67%  |
+| 8        | Isaiah Arvizu      | Airborne (The Link (Elk City))              | 115   | 23  |    | 87%  |
+| 9        | Alexa Santiago     | Airborne (The Link (Elk City))              | 100   | 20  |    | 100% |
+| 10       | Jazmyn Costa       | ReAction (Faith Church (Tulsa))             | 30    | 6   |    | 100% |
+| **\*10** | Kenley McComber    | Christian Chapel (Christian Chapel (Tulsa)) | 30    | 6   |    | 100% |
+| 11       | Jimmy Crow         | Powerhouse Kidz (Broken Bow First Assembly) | 25    | 5   |    | 66%  |
+| **\*11** | Emma Buchanan      | Christian Chapel (Christian Chapel (Tulsa)) | 25    | 5   |    | 60%  |
+| 12       | Bella Dickerson    | Powerhouse Kidz (Broken Bow First Assembly) | 20    | 4   |    | 100% |
+| **\*12** | Presley Wyers      | Newspring (Newspring Assembly (Jenks))      | 20    | 4   |    | 99%  |
+| **\*12** | Elizabeth Cook     | Airborne (The Link (Elk City))              | 20    | 4   |    | 57%  |
+| 13       | Aaliyah Arvizu     | Airborne (The Link (Elk City))              | 5     | 1   |    | 33%  |
+| 14       | Adelina Vasquez    | The Bridge (The Bridge (Mustang))           | 0     |     |    |      |
+| **\*14** | Gideon Wineinger   | ReAction (Faith Church (Tulsa))             | 0     |     |    |      |
+| **\*14** | Anthony Wineinger  | ReAction (Faith Church (Tulsa))             | 0     |     |    |      |
+| **\*14** | LJ Rinkel          | Newspring (Newspring Assembly (Jenks))      | 0     |     |    |      |
+| **\*14** | Ava Osterhout      | Newspring (Newspring Assembly (Jenks))      | 0     |     |    |      |
+| **\*14** | Charlotte Avey     | Newspring (Newspring Assembly (Jenks))      | 0     |     |    |      |
+| 15       | Zivah Warnemuende  | The Bridge (The Bridge (Mustang))           | -5    | -1  |    |      |
+
+
+## Intermediate
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                | W/L   | Total | Avg | QO | Q%   |
+|----:|----------------------------------------------|-------|------:|----:|---:|-----:|
+| 1.0 | Powerhouse Kidz (Broken Bow First Assembly)  | 5 / 0 | 965   | 193 | 7  | 85%  |
+| 2.0 | Christian Chapel (Christian Chapel (Tulsa))  | 4 / 1 | 560   | 112 | 3  | 86%  |
+| 3.0 | Spirit Church (Spirit Church (Bartlesville)) | 2 / 3 | 405   | 81  | 1  | 87%  |
+| 4.0 | Connect Quizzers (Miami First Assembly)      | 2 / 3 | 345   | 69  |    | 82%  |
+| 5.0 | Verdigris Assembly (Verdigris Assembly)      | 2 / 3 | 310   | 62  | 2  | 100% |
+| 6.0 | Newspring (Newspring Assembly (Jenks))       | 0 / 5 | 240   | 48  | 1  | 74%  |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                | Total | Avg | QO | Q%   |
+|---------:|-------------------|----------------------------------------------|------:|----:|---:|-----:|
+| 1        | Rhys Hoover       | Powerhouse Kidz (Broken Bow First Assembly)  | 515   | 103 | 3  | 87%  |
+| 2        | Caleb Beiler      | Christian Chapel (Christian Chapel (Tulsa))  | 365   | 73  | 3  | 85%  |
+| 3        | Grace Miller      | Verdigris Assembly (Verdigris Assembly)      | 310   | 62  | 2  | 100% |
+| 4        | Camdyn Quiroz     | Powerhouse Kidz (Broken Bow First Assembly)  | 280   | 56  | 3  | 79%  |
+| 5        | Delaney Hillestad | Connect Quizzers (Miami First Assembly)      | 235   | 47  |    | 81%  |
+| 6        | Chase Laxson      | Spirit Church (Spirit Church (Bartlesville)) | 215   | 43  | 1  | 93%  |
+| 7        | Nesly Zaragoza    | Powerhouse Kidz (Broken Bow First Assembly)  | 170   | 34  | 1  | 89%  |
+| 8        | Deacon Cothran    | Newspring (Newspring Assembly (Jenks))       | 155   | 31  | 1  | 71%  |
+| 9        | Will Isgrigg      | Christian Chapel (Christian Chapel (Tulsa))  | 135   | 27  |    | 84%  |
+| 10       | Cody Laxson       | Spirit Church (Spirit Church (Bartlesville)) | 90    | 18  |    | 77%  |
+| 11       | Chase Avey        | Newspring (Newspring Assembly (Jenks))       | 85    | 17  |    | 80%  |
+| 12       | Kaitlyn Robertson | Spirit Church (Spirit Church (Bartlesville)) | 60    | 12  |    | 100% |
+| **\*12** | Britain Isgrigg   | Christian Chapel (Christian Chapel (Tulsa))  | 60    | 12  |    | 100% |
+| 13       | Gracy Ward        | Connect Quizzers (Miami First Assembly)      | 40    | 8   |    | 100% |
+| 14       | Alline Clapp      | Connect Quizzers (Miami First Assembly)      | 30    | 6   |    | 67%  |
+| **\*14** | Bethany Burns     | Spirit Church (Spirit Church (Bartlesville)) | 30    | 6   |    | 66%  |
+| 15       | Emma Ward         | Connect Quizzers (Miami First Assembly)      | 20    | 4   |    | 100% |
+| **\*15** | Aubrey Bunch      | Connect Quizzers (Miami First Assembly)      | 20    | 4   |    | 100% |
+| 16       | Kaylee Feuerborn  | Spirit Church (Spirit Church (Bartlesville)) | 10    | 2   |    | 99%  |
+| 17       | Linzey Abel       | Verdigris Assembly (Verdigris Assembly)      | 0     |     |    |      |
+| **\*17** | Kylin Abel        | Verdigris Assembly (Verdigris Assembly)      | 0     |     |    |      |
+| **\*17** | Jaycub Feuerborn  | Spirit Church (Spirit Church (Bartlesville)) | 0     |     |    |      |
+| **\*17** | Landon Crow       | Powerhouse Kidz (Broken Bow First Assembly)  | 0     |     |    |      |
+| **\*17** | Molly Rinkel      | Newspring (Newspring Assembly (Jenks))       | 0     |     |    |      |
+| **\*17** | Jake Frusciante   | Newspring (Newspring Assembly (Jenks))       | 0     |     |    |      |
+

--- a/_pages/jbq/2019/districts/peninsular-florida.md
+++ b/_pages/jbq/2019/districts/peninsular-florida.md
@@ -390,3 +390,45 @@ menubar_toc_static:
 | 15       | Ian Scott         | Warriors for Jesus of City Church of Orlando (City Church of Orlando) | -5    | -1  |    |    |
 | 16       | Zion Small        | Christian Life Center (Fort Lauderdale) #3 (Christian Life Center)    | -15   | -3  |    |    |
 
+
+## Flight X2
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                                        | W/L   | Total | Avg  | QO | Q% |
+|----:|--------------------------------------------------------------------------------------|-------|------:|-----:|---:|---:|
+| 1.1 | Oxford - Young Bucks #3 (Oxford Assembly of God)                                     | 4 / 1 | 480   | 96   | 6  |    |
+| 2.1 | New Life Assembly (Lehigh) X League (New Life Assembly)                              | 4 / 1 | 475   | 95   | 5  |    |
+| 3.1 | Ocala X-Men (First Assembly of God)                                                  | 1 / 3 | 290   | 72.5 | 3  |    |
+| 4.0 | Highpoint HalfPints Highpoint Church (Port Saint Lucie) (Highpoint Community Church) | 2 / 3 | 165   | 33   |    |    |
+| 5.0 | First Assembly Deland (Deland) #3 (First Assembly Deland)                            | 1 / 4 | 170   | 34   |    |    |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                                                        | Total | Avg  | QO | Q% |
+|---------:|-------------------|--------------------------------------------------------------------------------------|------:|-----:|---:|---:|
+| 1        | Emmett Strickland | Oxford - Young Bucks #3 (Oxford Assembly of God)                                     | 325   | 65   | 5  |    |
+| 2        | JJ Parrales       | Ocala X-Men (First Assembly of God)                                                  | 250   | 62.5 | 3  |    |
+| 3        | Daniel Fernandez  | New Life Assembly (Lehigh) X League (New Life Assembly)                              | 245   | 49   | 3  |    |
+| 4        | Kayden Alicea     | New Life Assembly (Lehigh) X League (New Life Assembly)                              | 230   | 46   | 2  |    |
+| 5        | Joel Blades       | First Assembly Deland (Deland) #3 (First Assembly Deland)                            | 140   | 28   |    |    |
+| 6        | Josiah Hamblen    | Oxford - Young Bucks #3 (Oxford Assembly of God)                                     | 130   | 26   | 1  |    |
+| 7        | Caleb Sullivan    | Highpoint HalfPints Highpoint Church (Port Saint Lucie) (Highpoint Community Church) | 105   | 21   |    |    |
+| 8        | Lucas Serrano     | Highpoint HalfPints Highpoint Church (Port Saint Lucie) (Highpoint Community Church) | 60    | 12   |    |    |
+| 9        | Aiden Root        | Ocala X-Men (First Assembly of God)                                                  | 45    | 11.3 |    |    |
+| 10       | Kindle Blades     | First Assembly Deland (Deland) #3 (First Assembly Deland)                            | 30    | 6    |    |    |
+| 11       | Eli Hahn          | Oxford - Young Bucks #3 (Oxford Assembly of God)                                     | 25    | 5    |    |    |
+| 12       | Kinzli Capel      | First Assembly Deland (Deland) #3 (First Assembly Deland)                            | 0     |      |    |    |
+| **\*12** | Yemi Fawole       | Oxford - Young Bucks #3 (Oxford Assembly of God)                                     | 0     |      |    |    |
+| **\*12** | Kathleen Mec-El   | New Life Assembly (Lehigh) X League (New Life Assembly)                              | 0     |      |    |    |
+| **\*12** | Kaitlande Jacques | New Life Assembly (Lehigh) X League (New Life Assembly)                              | 0     |      |    |    |
+| **\*12** | Brianna Upchurch  | First Assembly Deland (Deland) #3 (First Assembly Deland)                            | 0     |      |    |    |
+| **\*12** | Aliahna Serrano   | Highpoint HalfPints Highpoint Church (Port Saint Lucie) (Highpoint Community Church) | 0     |      |    |    |
+| **\*12** | Ahnaley Serrano   | Highpoint HalfPints Highpoint Church (Port Saint Lucie) (Highpoint Community Church) | 0     |      |    |    |
+| **\*12** | Kira Carlson      | Highpoint HalfPints Highpoint Church (Port Saint Lucie) (Highpoint Community Church) | 0     |      |    |    |
+| 13       | Anthony Savarese  | Ocala X-Men (First Assembly of God)                                                  | -5    | -1.3 |    |    |
+

--- a/_pages/jbq/2019/districts/southern-missouri.md
+++ b/_pages/jbq/2019/districts/southern-missouri.md
@@ -51,46 +51,45 @@ menubar_toc_static:
 | 17       | Joe Whitaker       | Sugar Rush (Central Assembly)           | 0     |       |    |      |
 | **\*17** | Cam Risner         | Crown Pointe A (Lee\'s Summit, MO)      | 0     |       |    |      |
 
-
-## B Acheiver
+## A Achiever
 
 ### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points*
 
-| #   | Team / Church                             | W/L   | Total | Avg   | QO | Q%  |
-|----:|-------------------------------------------|-------|------:|------:|---:|----:|
-| 1.1 | Followers of Jesus (West County Assembly) | 3 / 1 | 575   | 143.7 | 1  | 94% |
-| 2.0 | The Super Quizzers (First Assembly Rolla) | 3 / 1 | 480   | 120   | 4  | 79% |
-| 3.0 | Giant Slayers B (First Assembly De Soto)  | 2 / 2 | 505   | 126.2 | 1  | 92% |
-| 4.0 | The Quizmasters (Pebble Creek )           | 1 / 3 | 470   | 117.5 | 1  | 85% |
-| 5.0 | B Sharps (Life360 Church)                 | 1 / 3 | 330   | 82.5  |    | 83% |
+| #   | Team / Church                             | W/L   | Total | Avg   | QO | Q%   |
+|----:|-------------------------------------------|-------|------:|------:|---:|-----:|
+| 1.1 | Giant Slayers A (First Assembly De Soto)  | 3 / 1 | 560   | 140   | 1  | 74%  |
+| 2.0 | Bible Giants (Pebble Creek)               | 3 / 1 | 650   | 162.5 | 4  | 90%  |
+| 3.0 | Jesus Jedis (Life360 Church)              | 2 / 2 | 655   | 163.7 | 6  | 84%  |
+| 4.0 | Undercover Buzzers (West County Assembly) | 1 / 3 | 415   | 103.7 | 1  | 93%  |
+| 5.0 | Checkmates (Highway Assembly)             | 1 / 3 | 410   | 102.5 | 3  | 100% |
 
 ### Individuals
 
 *Ties broken by Average Points then Total Quiz Outs*
 
-| #        | Quizzer            | Team / Church                             | Total | Avg  | QO | Q%   |
-|---------:|--------------------|-------------------------------------------|------:|-----:|---:|-----:|
-| 1        | Shawn Ramaji       | Followers of Jesus (West County Assembly) | 380   | 95   | 1  | 100% |
-| 2        | Josiah Gibson      | The Super Quizzers (First Assembly Rolla) | 320   | 80   | 4  | 89%  |
-| 3        | Skylar Turner      | Giant Slayers B (First Assembly De Soto)  | 320   | 80   | 1  | 100% |
-| 4        | Halle Korth        | The Quizmasters (Pebble Creek )           | 230   | 57.5 | 1  | 87%  |
-| 5        | Conner Sauchuk     | B Sharps (Life360 Church)                 | 175   | 43.8 |    | 75%  |
-| 6        | Gracie Gibson      | The Super Quizzers (First Assembly Rolla) | 160   | 40   |    | 65%  |
-| 7        | Stephen Nichol     | Giant Slayers B (First Assembly De Soto)  | 130   | 32.5 |    | 87%  |
-| 8        | Abhishek Mothukuri | Followers of Jesus (West County Assembly) | 125   | 31.3 |    | 86%  |
-| 9        | Jade Atchison      | B Sharps (Life360 Church)                 | 120   | 30   |    | 100% |
-| 10       | Jaclyn Holmes      | The Quizmasters (Pebble Creek )           | 95    | 23.8 |    | 75%  |
-| 11       | Jack Holmes        | The Quizmasters (Pebble Creek )           | 90    | 22.5 |    | 100% |
-| 12       | Anish Gundu        | Followers of Jesus (West County Assembly) | 70    | 17.5 |    | 100% |
-| 13       | Isabel Nichol      | Giant Slayers B (First Assembly De Soto)  | 55    | 13.8 |    | 86%  |
-| **\*13** | Madeline Taylor    | The Quizmasters (Pebble Creek )           | 55    | 13.8 |    | 80%  |
-| 14       | Corbin Harris      | B Sharps (Life360 Church)                 | 20    | 5    |    | 100% |
-| 15       | Garrett Van Natta  | B Sharps (Life360 Church)                 | 15    | 3.8  |    | 66%  |
-| 16       | Will Holmes        | The Quizmasters (Pebble Creek )           | 0     |      |    |      |
-| **\*16** | Quinton Lockhart   | The Quizmasters (Pebble Creek )           | 0     |      |    |      |
-
+| #        | Quizzer         | Team / Church                             | Total | Avg  | QO | Q%   |
+|---------:|-----------------|-------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Noah Fulton     | Bible Giants (Pebble Creek)               | 480   | 120  | 3  | 85%  |
+| 2        | Jason Cerce     | Checkmates (Highway Assembly)             | 380   | 95   | 3  | 100% |
+| 3        | Brant Maschino  | Jesus Jedis (Life360 Church)              | 375   | 93.8 | 2  | 80%  |
+| 4        | Isaac Elliott   | Undercover Buzzers (West County Assembly) | 270   | 67.5 | 1  | 93%  |
+| 5        | Brady Williams  | Jesus Jedis (Life360 Church)              | 260   | 65   | 4  | 86%  |
+| 6        | Kennedy Shores  | Giant Slayers A (First Assembly De Soto)  | 185   | 46.3 | 1  | 95%  |
+| 7        | Bryce Wright    | Giant Slayers A (First Assembly De Soto)  | 180   | 45   |    | 100% |
+| 8        | Jarrett Holmes  | Bible Giants (Pebble Creek)               | 170   | 42.5 | 1  | 100% |
+| 9        | Chase Steward   | Giant Slayers A (First Assembly De Soto)  | 150   | 37.5 |    | 57%  |
+| 10       | Isaac Koenig    | Undercover Buzzers (West County Assembly) | 110   | 27.5 |    | 100% |
+| 11       | Kaiden Shores   | Giant Slayers A (First Assembly De Soto)  | 45    | 11.3 |    | 58%  |
+| 12       | Gideon Koenig   | Undercover Buzzers (West County Assembly) | 35    | 8.8  |    | 83%  |
+| 13       | Josh Cerce      | Checkmates (Highway Assembly)             | 30    | 7.5  |    | 100% |
+| 14       | Noah Williams   | Jesus Jedis (Life360 Church)              | 20    | 5    |    | 100% |
+| 15       | Ayden Shaler    | Jesus Jedis (Life360 Church)              | 0     |      |    |      |
+| **\*15** | Syndel Leeper   | Jesus Jedis (Life360 Church)              | 0     |      |    |      |
+| **\*15** | Morgan Harris   | Jesus Jedis (Life360 Church)              | 0     |      |    |      |
+| **\*15** | Shayd Van Buren | Checkmates (Highway Assembly)             | 0     |      |    |      |
+| **\*15** | Wyatt Lockhart  | Bible Giants (Pebble Creek)               | 0     |      |    |      |
 
 ## B Level
 
@@ -149,6 +148,79 @@ menubar_toc_static:
 | **\*29** | Wil Risner         | Crown Pointe B (Lee\'s Summit, MO)           | 0     |       |    |      |
 | **\*29** | McKenzie Murray    | Blessed Bible Girls (First Assembly Bolivar) | 0     |       |    |      |
 
+## B Master
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                | W/L   | Total | Avg   | QO | Q%  |
+|----:|----------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Blessed Bible Girls (First Assembly Bolivar) | 5 / 1 | 1070  | 178.3 | 7  | 92% |
+| 2.1 | Crown Pointe B (Lee\'s Summit, MO)           | 3 / 3 | 845   | 140.8 | 7  | 75% |
+| 3.1 | Bible B\'s (First Assembly Bolivar)          | 3 / 3 | 665   | 110.8 | 2  | 89% |
+| 4.0 | Pardon the Interruption (Central Assembly)   | 1 / 5 | 510   | 85    |    | 70% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer         | Team / Church                                | Total | Avg   | QO | Q%   |
+|---------:|-----------------|----------------------------------------------|------:|------:|---:|-----:|
+| 1        | Esther Lu       | Blessed Bible Girls (First Assembly Bolivar) | 650   | 108.3 | 3  | 94%  |
+| 2        | Benaiah Wolf    | Bible B\'s (First Assembly Bolivar)          | 550   | 91.7  | 2  | 94%  |
+| 3        | Anna Lu         | Blessed Bible Girls (First Assembly Bolivar) | 405   | 67.5  | 4  | 92%  |
+| 4        | London Lovelace | Crown Pointe B (Lee\'s Summit, MO)           | 400   | 66.7  | 3  | 67%  |
+| 5        | Caleb Brookbank | Crown Pointe B (Lee\'s Summit, MO)           | 385   | 64.2  | 4  | 80%  |
+| 6        | Marshall Meyers | Pardon the Interruption (Central Assembly)   | 200   | 33.3  |    | 85%  |
+| 7        | JJ Meyers       | Pardon the Interruption (Central Assembly)   | 165   | 27.5  |    | 58%  |
+| 8        | Daniel Rogers   | Pardon the Interruption (Central Assembly)   | 145   | 24.2  |    | 70%  |
+| 9        | Asa Murray      | Bible B\'s (First Assembly Bolivar)          | 95    | 15.8  |    | 79%  |
+| 10       | Cadence Chiles  | Crown Pointe B (Lee\'s Summit, MO)           | 60    | 10    |    | 100% |
+| 11       | Lilli Hass      | Blessed Bible Girls (First Assembly Bolivar) | 20    | 3.3   |    | 100% |
+| **\*11** | Alden Gardner   | Bible B\'s (First Assembly Bolivar)          | 20    | 3.3   |    | 100% |
+| 12       | Wil Risner      | Crown Pointe B (Lee\'s Summit, MO)           | 0     |       |    |      |
+| 13       | McKenzie Murray | Blessed Bible Girls (First Assembly Bolivar) | -5    | -.8   |    |      |
+
+
+## B Achiever
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                             | W/L   | Total | Avg   | QO | Q%  |
+|----:|-------------------------------------------|-------|------:|------:|---:|----:|
+| 1.1 | Followers of Jesus (West County Assembly) | 3 / 1 | 575   | 143.7 | 1  | 94% |
+| 2.0 | The Super Quizzers (First Assembly Rolla) | 3 / 1 | 480   | 120   | 4  | 79% |
+| 3.0 | Giant Slayers B (First Assembly De Soto)  | 2 / 2 | 505   | 126.2 | 1  | 92% |
+| 4.0 | The Quizmasters (Pebble Creek )           | 1 / 3 | 470   | 117.5 | 1  | 85% |
+| 5.0 | B Sharps (Life360 Church)                 | 1 / 3 | 330   | 82.5  |    | 83% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                             | Total | Avg  | QO | Q%   |
+|---------:|--------------------|-------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Shawn Ramaji       | Followers of Jesus (West County Assembly) | 380   | 95   | 1  | 100% |
+| 2        | Josiah Gibson      | The Super Quizzers (First Assembly Rolla) | 320   | 80   | 4  | 89%  |
+| 3        | Skylar Turner      | Giant Slayers B (First Assembly De Soto)  | 320   | 80   | 1  | 100% |
+| 4        | Halle Korth        | The Quizmasters (Pebble Creek )           | 230   | 57.5 | 1  | 87%  |
+| 5        | Conner Sauchuk     | B Sharps (Life360 Church)                 | 175   | 43.8 |    | 75%  |
+| 6        | Gracie Gibson      | The Super Quizzers (First Assembly Rolla) | 160   | 40   |    | 65%  |
+| 7        | Stephen Nichol     | Giant Slayers B (First Assembly De Soto)  | 130   | 32.5 |    | 87%  |
+| 8        | Abhishek Mothukuri | Followers of Jesus (West County Assembly) | 125   | 31.3 |    | 86%  |
+| 9        | Jade Atchison      | B Sharps (Life360 Church)                 | 120   | 30   |    | 100% |
+| 10       | Jaclyn Holmes      | The Quizmasters (Pebble Creek )           | 95    | 23.8 |    | 75%  |
+| 11       | Jack Holmes        | The Quizmasters (Pebble Creek )           | 90    | 22.5 |    | 100% |
+| 12       | Anish Gundu        | Followers of Jesus (West County Assembly) | 70    | 17.5 |    | 100% |
+| 13       | Isabel Nichol      | Giant Slayers B (First Assembly De Soto)  | 55    | 13.8 |    | 86%  |
+| **\*13** | Madeline Taylor    | The Quizmasters (Pebble Creek )           | 55    | 13.8 |    | 80%  |
+| 14       | Corbin Harris      | B Sharps (Life360 Church)                 | 20    | 5    |    | 100% |
+| 15       | Garrett Van Natta  | B Sharps (Life360 Church)                 | 15    | 3.8  |    | 66%  |
+| 16       | Will Holmes        | The Quizmasters (Pebble Creek )           | 0     |      |    |      |
+| **\*16** | Quinton Lockhart   | The Quizmasters (Pebble Creek )           | 0     |      |    |      |
 
 ## C Level
 
@@ -199,6 +271,41 @@ menubar_toc_static:
 | 21       | Malachi Hasty      | Mighty Quizzers (West County Assembly)    | -5    | -.8  |    | 25%  |
 | **\*21** | Zander Tuttle      | Lightning Buzzers (Life360 Church)        | -5    | -.8  |    |      |
 
+## C Master
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                           | W/L   | Total | Avg   | QO | Q%  |
+|----:|-----------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Lightning Buzzers (Life360 Church)      | 5 / 1 | 650   | 108.3 | 8  | 76% |
+| 2.0 | Buzzing Bees B (First Assembly Lebanon) | 3 / 3 | 510   | 85    | 3  | 85% |
+| 3.0 | Quickest Quizzers (Central Assembly)    | 2 / 4 | 540   | 90    | 5  | 96% |
+| 4.0 | Evangel Temple (Springfield, MO)        | 2 / 4 | 445   | 74.2  |    | 80% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                           | Total | Avg  | QO | Q%   |
+|---------:|-------------------|-----------------------------------------|------:|-----:|---:|-----:|
+| 1        | Leighton Riffe    | Quickest Quizzers (Central Assembly)    | 380   | 63.3 | 5  | 100% |
+| 2        | William Tuttle    | Lightning Buzzers (Life360 Church)      | 335   | 55.8 | 5  | 79%  |
+| 3        | Landon Davis      | Lightning Buzzers (Life360 Church)      | 315   | 52.5 | 3  | 82%  |
+| 4        | CHRISTOPHER AVERY | Buzzing Bees B (First Assembly Lebanon) | 250   | 41.7 | 2  | 89%  |
+| 5        | JERICA LEWIS      | Buzzing Bees B (First Assembly Lebanon) | 235   | 39.2 | 1  | 89%  |
+| 6        | Maddie Hartman    | Evangel Temple (Springfield, MO)        | 170   | 28.3 |    | 83%  |
+| 7        | Ancil Shayju      | Quickest Quizzers (Central Assembly)    | 160   | 26.7 |    | 89%  |
+| 8        | Braiden Drake     | Evangel Temple (Springfield, MO)        | 125   | 20.8 |    | 93%  |
+| 9        | Brennan Drake     | Evangel Temple (Springfield, MO)        | 110   | 18.3 |    | 67%  |
+| 10       | Kinleigh Drake    | Evangel Temple (Springfield, MO)        | 30    | 5    |    | 100% |
+| 11       | JONAH LEWIS       | Buzzing Bees B (First Assembly Lebanon) | 25    | 4.2  |    | 75%  |
+| 12       | Charis Ireland    | Evangel Temple (Springfield, MO)        | 10    | 1.7  |    | 99%  |
+| 13       | Ethan Van Natta   | Lightning Buzzers (Life360 Church)      | 5     | .8   |    | 50%  |
+| 14       | LIZ KRULL         | Buzzing Bees B (First Assembly Lebanon) | 0     |      |    | 33%  |
+| **\*14** | JOSIAH LEWIS      | Buzzing Bees B (First Assembly Lebanon) | 0     |      |    |      |
+| 15       | Zander Tuttle     | Lightning Buzzers (Life360 Church)      | -5    | -.8  |    | 29%  |
 
 ## C Achiever
 

--- a/_pages/jbq/2019/other/arkansas-districts-qualifying.md
+++ b/_pages/jbq/2019/other/arkansas-districts-qualifying.md
@@ -61,7 +61,49 @@ menubar_toc_static:
 | 15       | Karaline Porter      | Changepoint Assembly of God (Cabot) #1 (Changepoint Assembly of God) | -5    | -1.3  |    |      |
 
 
-## North Central Area - 5th & 6th
+## North Central Area - 3rd & 4th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                                                  | W/L   | Total | Avg   | QO | Q%   |
+|----:|------------------------------------------------------------------------------------------------|-------|------:|------:|---:|-----:|
+| 1.0 | McArthur AG 3-4 (Jacksonville) (McArthur Assembly of God)                                      | 4 / 0 | 650   | 162.5 | 3  | 96%  |
+| 2.0 | Open Arms Assembly of God (Beebe) #2 (Open Arms Assembly of God)                               | 3 / 1 | 260   | 65    | 1  | 90%  |
+| 3.0 | Changepoint Assembly of God (Cabot) #2 (Changepoint Assembly of God)                           | 2 / 2 | 420   | 105   | 1  | 100% |
+| 4.0 | The Ridge Assembly of Sherwood (Sherwood) #1 (The Ridge Assembly of Sherwood)                  | 1 / 3 | 180   | 45    |    | 90%  |
+| 5.0 | River of Life Assemblies of God Church (Mabelvale) #1 (River of Life Assemblies of God Church) | 0 / 4 | 20    | 5     |    | 100% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer          | Team / Church                                                                                  | Total | Avg  | QO | Q%   |
+|---------:|------------------|------------------------------------------------------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Carly Shalter    | McArthur AG 3-4 (Jacksonville) (McArthur Assembly of God)                                      | 305   | 76.3 | 1  | 88%  |
+| 2        | Karter Ballard   | McArthur AG 3-4 (Jacksonville) (McArthur Assembly of God)                                      | 255   | 63.8 | 2  | 100% |
+| 3        | Joshua McCall    | Changepoint Assembly of God (Cabot) #2 (Changepoint Assembly of God)                           | 210   | 52.5 |    | 100% |
+| 4        | Jayden Maris     | Changepoint Assembly of God (Cabot) #2 (Changepoint Assembly of God)                           | 200   | 50   | 1  | 100% |
+| 5        | Zane Williams    | Open Arms Assembly of God (Beebe) #2 (Open Arms Assembly of God)                               | 195   | 48.8 | 1  | 93%  |
+| 6        | Jackson Eckart   | The Ridge Assembly of Sherwood (Sherwood) #1 (The Ridge Assembly of Sherwood)                  | 115   | 28.8 |    | 92%  |
+| 7        | ReeceAnn Jones   | McArthur AG 3-4 (Jacksonville) (McArthur Assembly of God)                                      | 80    | 20   |    | 100% |
+| 8        | Skyla Cope       | The Ridge Assembly of Sherwood (Sherwood) #1 (The Ridge Assembly of Sherwood)                  | 35    | 8.8  |    | 80%  |
+| **\*8**  | Jordyn Rhine     | Open Arms Assembly of God (Beebe) #2 (Open Arms Assembly of God)                               | 35    | 8.8  |    | 75%  |
+| 9        | Nevaeh Watson    | The Ridge Assembly of Sherwood (Sherwood) #1 (The Ridge Assembly of Sherwood)                  | 30    | 7.5  |    | 100% |
+| **\*9**  | Joshua McGehee   | Open Arms Assembly of God (Beebe) #2 (Open Arms Assembly of God)                               | 30    | 7.5  |    | 100% |
+| 10       | Trinity Terry    | River of Life Assemblies of God Church (Mabelvale) #1 (River of Life Assemblies of God Church) | 20    | 5    |    | 99%  |
+| 11       | Alice Weeley     | McArthur AG 3-4 (Jacksonville) (McArthur Assembly of God)                                      | 10    | 2.5  |    | 99%  |
+| **\*11** | Sydni Ezell-Teel | Changepoint Assembly of God (Cabot) #2 (Changepoint Assembly of God)                           | 10    | 2.5  |    | 99%  |
+| 12       | Asher Holloway   | The Ridge Assembly of Sherwood (Sherwood) #1 (The Ridge Assembly of Sherwood)                  | 0     |      |    |      |
+| **\*12** | Kenny Baez       | River of Life Assemblies of God Church (Mabelvale) #1 (River of Life Assemblies of God Church) | 0     |      |    |      |
+| **\*12** | Miah Ramirez     | McArthur AG 3-4 (Jacksonville) (McArthur Assembly of God)                                      | 0     |      |    |      |
+| **\*12** | Ty Jacobs        | McArthur AG 3-4 (Jacksonville) (McArthur Assembly of God)                                      | 0     |      |    |      |
+| **\*12** | Anya Abdullah    | McArthur AG 3-4 (Jacksonville) (McArthur Assembly of God)                                      | 0     |      |    |      |
+
+
+
+## North Central Area - 5th & 6th Grade
 
 ### Teams
 

--- a/_pages/jbq/2019/tournaments/carolina-classic.md
+++ b/_pages/jbq/2019/tournaments/carolina-classic.md
@@ -133,6 +133,38 @@ menubar_toc_static:
 | **\*14** | Zoe Nerquaye-Tetteh   | Chapel Springs Assembly of God Church (Bristow) #1 (Chapel Springs Assembly of God Church)  | 0     |      |    |    |
 | **\*14** | Joelle Domfeh         | Chapel Springs Assembly of God Church (Bristow) #1 (Chapel Springs Assembly of God Church)  | 0     |      |    |    |
 
+## Silver Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                                         | W/L   | Total | Avg   | QO | Q% |
+|----:|---------------------------------------------------------------------------------------|-------|------:|------:|---:|---:|
+| 1.0 | Askewville Bethel Assembly of God (Windsor) #1 (Askewville Bethel Assembly of God)    | 2 / 0 | 400   | 199.9 | 1  |    |
+| 2.0 | The Defenders (Concord) (First Assembly of God)                                       | 1 / 1 | 290   | 144.9 | 1  |    |
+| 3.0 | Mechanicsville Christian Center (Mechanicsville) #2 (Mechanicsville Christian Center) | 0 / 2 | 90    | 45    |    |    |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #       | Quizzer               | Team / Church                                                                         | Total | Avg  | QO | Q% |
+|--------:|-----------------------|---------------------------------------------------------------------------------------|------:|-----:|---:|---:|
+| 1       | Austin Perry          | Askewville Bethel Assembly of God (Windsor) #1 (Askewville Bethel Assembly of God)    | 190   | 95   | 1  |    |
+| 2       | Lindsey Perry         | Askewville Bethel Assembly of God (Windsor) #1 (Askewville Bethel Assembly of God)    | 190   | 95   |    |    |
+| 3       | Miles Pierce          | The Defenders (Concord) (First Assembly of God)                                       | 115   | 57.5 | 1  |    |
+| 4       | Seth Hudson           | The Defenders (Concord) (First Assembly of God)                                       | 60    | 30   |    |    |
+| **\*4** | Lydia Hill            | The Defenders (Concord) (First Assembly of God)                                       | 60    | 30   |    |    |
+| 5       | Mary-Michael Lawrence | Mechanicsville Christian Center (Mechanicsville) #2 (Mechanicsville Christian Center) | 40    | 20   |    |    |
+| **\*5** | Berkley Adams         | Mechanicsville Christian Center (Mechanicsville) #2 (Mechanicsville Christian Center) | 40    | 20   |    |    |
+| 6       | Caleb Senthil         | The Defenders (Concord) (First Assembly of God)                                       | 35    | 17.5 |    |    |
+| 7       | Megan Pierce          | The Defenders (Concord) (First Assembly of God)                                       | 20    | 10   |    |    |
+| **\*7** | Shane Lowers          | Askewville Bethel Assembly of God (Windsor) #1 (Askewville Bethel Assembly of God)    | 20    | 10   |    |    |
+| 8       | Kaleb Stanley         | Mechanicsville Christian Center (Mechanicsville) #2 (Mechanicsville Christian Center) | 10    | 5    |    |    |
+| 9       | Malia Ray             | Mechanicsville Christian Center (Mechanicsville) #2 (Mechanicsville Christian Center) | 0     |      |    |    |
+| **\*9** | Angelia Ray           | Mechanicsville Christian Center (Mechanicsville) #2 (Mechanicsville Christian Center) | 0     |      |    |    |
+| **\*9** | Olivia Bazemore       | Askewville Bethel Assembly of God (Windsor) #1 (Askewville Bethel Assembly of God)    | 0     |      |    |    |
 
 ## Bronze Division
 

--- a/_pages/jbq/2020/districts/georgia.md
+++ b/_pages/jbq/2020/districts/georgia.md
@@ -1,0 +1,156 @@
+---
+layout: page
+title: "2020 Georgia District Finals"
+permalink: /jbq/2020/districts/georgia/
+date: "2020-03-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2020 Season
+    link: /jbq/2020/
+    icon: fas fa-home
+---
+
+## District Finals A
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                                   | W/L   | Total | Avg   | QO | Q%  |
+|----:|---------------------------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Anointed Ones (Atlanta Indian Prayer Fellowship)                                | 6 / 0 | 1700  | 283.3 | 13 | 91% |
+| 2.0 | ATC Flames - Atlanta Tamil Church (Norcross) (Atlanta Tamil Church)             | 5 / 1 | 1060  | 176.6 | 7  | 98% |
+| 3.1 | Toccoa Assembly of God (Toccoa) #1 (Toccoa Assembly of God)                     | 3 / 3 | 960   | 160   | 6  | 81% |
+| 4.0 | Bereans (Georgia Christian Assembly Church of God)                              | 3 / 3 | 940   | 156.6 | 5  | 92% |
+| 5.0 | Royal Diadem (Atlanta Indian Prayer Fellowship)                                 | 2 / 4 | 810   | 135   | 7  | 95% |
+| 6.0 | Calvary Assembly Church of God (snellville) #1 (Calvary Assembly Church of God) | 1 / 5 | 715   | 119.1 | 1  | 95% |
+| 7.0 | Jesus Warriors (World Harvest Church)                                           | 1 / 5 | 525   | 87.5  | 2  | 75% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                                                                   | Total | Avg   | QO | Q%   |
+|---------:|------------------------|---------------------------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Leslie Grace Cowan     | Toccoa Assembly of God (Toccoa) #1 (Toccoa Assembly of God)                     | 865   | 144.2 | 6  | 92%  |
+| 2        | Steve Joy              | Anointed Ones (Atlanta Indian Prayer Fellowship)                                | 850   | 141.7 | 6  | 90%  |
+| 3        | Joel Christopher       | ATC Flames - Atlanta Tamil Church (Norcross) (Atlanta Tamil Church)             | 670   | 111.7 | 5  | 97%  |
+| 4        | Jeremiah Moses Raj     | Bereans (Georgia Christian Assembly Church of God)                              | 670   | 111.7 | 4  | 91%  |
+| 5        | Joshua Gunasingh       | Anointed Ones (Atlanta Indian Prayer Fellowship)                                | 480   | 80    | 2  | 89%  |
+| 6        | Harrison Aaron         | Royal Diadem (Atlanta Indian Prayer Fellowship)                                 | 470   | 78.3  | 5  | 97%  |
+| 7        | Jason Daniel           | Calvary Assembly Church of God (snellville) #1 (Calvary Assembly Church of God) | 440   | 73.3  | 1  | 100% |
+| 8        | Tomi Akinsanmi         | Jesus Warriors (World Harvest Church)                                           | 390   | 65    | 2  | 76%  |
+| 9        | Alwin Stephen          | Anointed Ones (Atlanta Indian Prayer Fellowship)                                | 370   | 61.7  | 5  | 94%  |
+| 10       | Bharat Rajesh          | Royal Diadem (Atlanta Indian Prayer Fellowship)                                 | 330   | 55    | 2  | 92%  |
+| 11       | Kaitlin Johanna Harris | ATC Flames - Atlanta Tamil Church (Norcross) (Atlanta Tamil Church)             | 310   | 51.7  | 2  | 100% |
+| 12       | Joseph Ganji           | Bereans (Georgia Christian Assembly Church of God)                              | 220   | 36.7  | 1  | 91%  |
+| 13       | Johanna Shinu          | Calvary Assembly Church of God (snellville) #1 (Calvary Assembly Church of God) | 220   | 36.7  |    | 93%  |
+| 14       | Liberty Kay            | Toccoa Assembly of God (Toccoa) #1 (Toccoa Assembly of God)                     | 100   | 16.7  |    | 64%  |
+| 15       | Jessica Abraham        | ATC Flames - Atlanta Tamil Church (Norcross) (Atlanta Tamil Church)             | 80    | 13.3  |    | 100% |
+| 16       | Liliana                | Jesus Warriors (World Harvest Church)                                           | 65    | 10.8  |    | 67%  |
+| 17       | Joshua Samuel          | Calvary Assembly Church of God (snellville) #1 (Calvary Assembly Church of God) | 55    | 9.2   |    | 86%  |
+| 18       | Semilore Akinsola      | Jesus Warriors (World Harvest Church)                                           | 45    | 7.5   |    | 83%  |
+| 19       | Naomi Philip           | Bereans (Georgia Christian Assembly Church of God)                              | 40    | 6.7   |    | 100% |
+| 20       | Elizabeth Case         | Jesus Warriors (World Harvest Church)                                           | 15    | 2.5   |    | 66%  |
+| 21       | Tiffanie Nthale        | Jesus Warriors (World Harvest Church)                                           | 10    | 1.7   |    | 99%  |
+| **\*21** | Britney Martin         | Royal Diadem (Atlanta Indian Prayer Fellowship)                                 | 10    | 1.7   |    | 99%  |
+| **\*21** | Rachel Abraham         | Bereans (Georgia Christian Assembly Church of God)                              | 10    | 1.7   |    | 99%  |
+| 22       | Kenley Whitaker        | Toccoa Assembly of God (Toccoa) #1 (Toccoa Assembly of God)                     | 0     |       |    |      |
+| **\*22** | Neveah Holland         | Toccoa Assembly of God (Toccoa) #1 (Toccoa Assembly of God)                     | 0     |       |    |      |
+| **\*22** | Annette                | Calvary Assembly Church of God (snellville) #1 (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*22** | Annette Patrick        | Calvary Assembly Church of God (snellville) #1 (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*22** | Mya Coxall             | Jesus Warriors (World Harvest Church)                                           | 0     |       |    |      |
+| **\*22** | Jason John Wesley      | ATC Flames - Atlanta Tamil Church (Norcross) (Atlanta Tamil Church)             | 0     |       |    |      |
+| 23       | Gracie Vickery         | Toccoa Assembly of God (Toccoa) #1 (Toccoa Assembly of God)                     | -5    | -.8   |    |      |
+
+
+## District Finals B
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                                   | W/L   | Total | Avg   | QO | Q%  |
+|----:|---------------------------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Signet Ring (Atlanta Indian Prayer Fellowship)                                  | 4 / 0 | 910   | 227.4 | 7  | 90% |
+| 2.0 | Lifeline Church B-1 (Lifeline Church)                                           | 3 / 1 | 750   | 187.5 | 6  | 84% |
+| 3.0 | Calvary Assembly Church of God (Snellville) #2 (Calvary Assembly Church of God) | 2 / 2 | 520   | 130   | 1  | 91% |
+| 4.0 | ATC Ignite - Atlanta Tamil Church (Norcross) (Atlanta Tamil Church)             | 1 / 3 | 445   | 111.2 | 3  | 92% |
+| 5.0 | Chosen Generation (Atlanta Indian Prayer Fellowship)                            | 0 / 4 | 230   | 57.5  | 2  | 90% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                  | Team / Church                                                                   | Total | Avg   | QO | Q%   |
+|---------:|--------------------------|---------------------------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Adrin Joseph             | Signet Ring (Atlanta Indian Prayer Fellowship)                                  | 455   | 113.8 | 4  | 95%  |
+| 2        | Kevin Jonathan           | Signet Ring (Atlanta Indian Prayer Fellowship)                                  | 360   | 90    | 3  | 85%  |
+| 3        | Joel Kakarlamudi         | Lifeline Church B-1 (Lifeline Church)                                           | 290   | 72.5  | 3  | 100% |
+| 4        | Abhishekth Somepalli     | Lifeline Church B-1 (Lifeline Church)                                           | 285   | 71.3  | 2  | 85%  |
+| 5        | Sarah Lejo               | Calvary Assembly Church of God (Snellville) #2 (Calvary Assembly Church of God) | 270   | 67.5  | 1  | 100% |
+| 6        | Kevin Samuel Harris      | ATC Ignite - Atlanta Tamil Church (Norcross) (Atlanta Tamil Church)             | 230   | 57.5  | 3  | 90%  |
+| 7        | Mrithun Renat Sriraman   | ATC Ignite - Atlanta Tamil Church (Norcross) (Atlanta Tamil Church)             | 165   | 41.3  |    | 92%  |
+| 8        | Joanna Varghese          | Calvary Assembly Church of God (Snellville) #2 (Calvary Assembly Church of God) | 160   | 40    |    | 91%  |
+| 9        | Harshish Jayakrishnan    | Chosen Generation (Atlanta Indian Prayer Fellowship)                            | 145   | 36.3  | 2  | 92%  |
+| 10       | Amulya Thammadi          | Lifeline Church B-1 (Lifeline Church)                                           | 145   | 36.3  | 1  | 68%  |
+| 11       | Saki Veera               | Signet Ring (Atlanta Indian Prayer Fellowship)                                  | 95    | 23.8  |    | 91%  |
+| 12       | Joshua Rachakatla        | Chosen Generation (Atlanta Indian Prayer Fellowship)                            | 75    | 18.8  |    | 83%  |
+| 13       | Mrinalika Renee Sriraman | ATC Ignite - Atlanta Tamil Church (Norcross) (Atlanta Tamil Church)             | 50    | 12.5  |    | 100% |
+| **\*13** | Gaius Lejo               | Calvary Assembly Church of God (Snellville) #2 (Calvary Assembly Church of God) | 50    | 12.5  |    | 75%  |
+| 14       | Bryan Biji Thomas        | Calvary Assembly Church of God (Snellville) #2 (Calvary Assembly Church of God) | 40    | 10    |    | 100% |
+| 15       | Enoch Thammadi           | Lifeline Church B-1 (Lifeline Church)                                           | 30    | 7.5   |    | 100% |
+| 16       | Harshini Jayakrishnan    | Chosen Generation (Atlanta Indian Prayer Fellowship)                            | 10    | 2.5   |    | 99%  |
+| 17       | Jemimah Biji Thomas      | Calvary Assembly Church of God (Snellville) #2 (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*17** | Nolan Oakley             | Calvary Assembly Church of God (Snellville) #2 (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*17** | Jeremy Matthew           | Calvary Assembly Church of God (Snellville) #2 (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*17** | Betzy Rajkumar           | Signet Ring (Atlanta Indian Prayer Fellowship)                                  | 0     |       |    |      |
+| **\*17** | Giftson Prabhu           | Chosen Generation (Atlanta Indian Prayer Fellowship)                            | 0     |       |    |      |
+| **\*17** | JohnBen Allan            | Chosen Generation (Atlanta Indian Prayer Fellowship)                            | 0     |       |    |      |
+| **\*17** | Sarah Cherubina Samuel   | ATC Ignite - Atlanta Tamil Church (Norcross) (Atlanta Tamil Church)             | 0     |       |    |      |
+| **\*17** | Alverna Mervyn           | ATC Ignite - Atlanta Tamil Church (Norcross) (Atlanta Tamil Church)             | 0     |       |    |      |
+
+
+## District Finals X
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                                    | W/L   | Total | Avg   | QO | Q%  |
+|----:|----------------------------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Assembly of God Tabernacle (Decatur) #1 (Assembly of God Tabernacle)             | 6 / 0 | 1305  | 217.5 | 7  | 95% |
+| 2.0 | Trinity Church - Lions (Trinity Fellowship Assembly of God)                      | 3 / 3 | 130   | 21.7  |    | 73% |
+| 3.0 | Trinity Church - Lions II (Trinity Fellowship Assembly of God)                   | 2 / 4 | 140   | 23.3  | 1  | 61% |
+| 4.0 | The Assembly at Warner Robins (Warner Robins) #1 (The Assembly at Warner Robins) | 1 / 5 | 10    | 1.7   |    | 43% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer             | Team / Church                                                                    | Total | Avg   | QO | Q%   |
+|---------:|---------------------|----------------------------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Winner Kpayizoun    | Assembly of God Tabernacle (Decatur) #1 (Assembly of God Tabernacle)             | 735   | 122.5 | 4  | 93%  |
+| 2        | Jibri Jones         | Assembly of God Tabernacle (Decatur) #1 (Assembly of God Tabernacle)             | 305   | 50.8  | 3  | 96%  |
+| 3        | Joshua White        | Assembly of God Tabernacle (Decatur) #1 (Assembly of God Tabernacle)             | 140   | 23.3  |    | 100% |
+| 4        | Christa Williams    | Assembly of God Tabernacle (Decatur) #1 (Assembly of God Tabernacle)             | 125   | 20.8  |    | 92%  |
+| 5        | Tyler Gum           | Trinity Church - Lions II (Trinity Fellowship Assembly of God)                   | 105   | 17.5  | 1  | 64%  |
+| 6        | Cameron Fader       | Trinity Church - Lions (Trinity Fellowship Assembly of God)                      | 100   | 16.7  |    | 71%  |
+| 7        | Joshua Schatzberg   | Trinity Church - Lions (Trinity Fellowship Assembly of God)                      | 30    | 5     |    | 80%  |
+| 8        | Ayanna Palmer       | Trinity Church - Lions II (Trinity Fellowship Assembly of God)                   | 25    | 4.2   |    | 53%  |
+| 9        | Michael Holloway    | The Assembly at Warner Robins (Warner Robins) #1 (The Assembly at Warner Robins) | 20    | 3.3   |    | 66%  |
+| 10       | Cody Gum            | Trinity Church - Lions II (Trinity Fellowship Assembly of God)                   | 10    | 1.7   |    | 99%  |
+| 11       | Ethan Schatzberg    | Trinity Church - Lions (Trinity Fellowship Assembly of God)                      | 0     |       |    |      |
+| **\*11** | Evie Fader          | Trinity Church - Lions (Trinity Fellowship Assembly of God)                      | 0     |       |    |      |
+| **\*11** | Tristian Schatzberg | Trinity Church - Lions (Trinity Fellowship Assembly of God)                      | 0     |       |    |      |
+| **\*11** | Zander Palmer       | Trinity Church - Lions II (Trinity Fellowship Assembly of God)                   | 0     |       |    |      |
+| **\*11** | Arabella Palmer     | Trinity Church - Lions II (Trinity Fellowship Assembly of God)                   | 0     |       |    |      |
+| **\*11** | Haley Callaway      | Trinity Church - Lions II (Trinity Fellowship Assembly of God)                   | 0     |       |    |      |
+| **\*11** | Aria Schatzberg     | Trinity Church - Lions II (Trinity Fellowship Assembly of God)                   | 0     |       |    |      |
+| **\*11** | Caronee Holloway    | The Assembly at Warner Robins (Warner Robins) #1 (The Assembly at Warner Robins) | 0     |       |    |      |
+| **\*11** | Isabella Turpin     | The Assembly at Warner Robins (Warner Robins) #1 (The Assembly at Warner Robins) | 0     |       |    |      |
+| **\*11** | Austin Turpin       | The Assembly at Warner Robins (Warner Robins) #1 (The Assembly at Warner Robins) | 0     |       |    |      |
+| **\*11** | Ansleigh Byrd       | The Assembly at Warner Robins (Warner Robins) #1 (The Assembly at Warner Robins) | 0     |       |    |      |
+| 12       | Andrew Lodde        | The Assembly at Warner Robins (Warner Robins) #1 (The Assembly at Warner Robins) | -10   | -1.7  |    | 25%  |

--- a/_pages/jbq/2020/districts/oklahoma.md
+++ b/_pages/jbq/2020/districts/oklahoma.md
@@ -12,6 +12,44 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
+## Advanced
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                | W/L   | Total | Avg   | QO | Q%  |
+|----:|--------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | United for Christ (The Bridge Assembly of God)               | 6 / 0 | 1605  | 267.5 | 12 | 93% |
+| 2.0 | Newspring Family Church (Jenks) #1 (Newspring Family Church) | 4 / 2 | 1160  | 193.3 | 5  | 90% |
+| 3.0 | Ignite the Fuze (Faith Church)                               | 2 / 4 | 530   | 88.3  | 2  | 73% |
+| 4.0 | Verse Vikings (Grand Assembly of God)                        | 0 / 6 | 160   | 26.7  | 1  | 79% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                                                | Total | Avg   | QO | Q%   |
+|---------:|----------------------|--------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Christian Alapati    | United for Christ (The Bridge Assembly of God)               | 915   | 152.5 | 6  | 95%  |
+| 2        | Ashlin Vanderslice   | Newspring Family Church (Jenks) #1 (Newspring Family Church) | 630   | 105   | 3  | 94%  |
+| 3        | Garrett McElroy      | United for Christ (The Bridge Assembly of God)               | 405   | 67.5  | 6  | 92%  |
+| 4        | Addison Beasley      | Newspring Family Church (Jenks) #1 (Newspring Family Church) | 285   | 47.5  |    | 91%  |
+| 5        | Deacon Cothran       | Newspring Family Church (Jenks) #1 (Newspring Family Church) | 225   | 37.5  | 2  | 85%  |
+| 6        | Dax Walsh            | Verse Vikings (Grand Assembly of God)                        | 165   | 27.5  | 1  | 79%  |
+| 7        | Harlan Yousey        | United for Christ (The Bridge Assembly of God)               | 160   | 26.7  |    | 90%  |
+| **\*7**  | David Wineinger      | Ignite the Fuze (Faith Church)                               | 160   | 26.7  |    | 82%  |
+| 8        | Jonathan Wineinger   | Ignite the Fuze (Faith Church)                               | 150   | 25    | 2  | 62%  |
+| 9        | Henry Wineinger      | Ignite the Fuze (Faith Church)                               | 130   | 21.7  |    | 83%  |
+| 10       | Zoey Fischer         | United for Christ (The Bridge Assembly of God)               | 125   | 20.8  |    | 92%  |
+| 11       | Claire Crook         | Ignite the Fuze (Faith Church)                               | 50    | 8.3   |    | 100% |
+| 12       | Carissa Fair         | Ignite the Fuze (Faith Church)                               | 40    | 6.7   |    | 100% |
+| 13       | Chase Avey           | Newspring Family Church (Jenks) #1 (Newspring Family Church) | 20    | 3.3   |    | 100% |
+| 14       | Victoria Nygaard     | Verse Vikings (Grand Assembly of God)                        | 0     |       |    |      |
+| **\*14** | Breianna Bickerstaff | Verse Vikings (Grand Assembly of God)                        | 0     |       |    |      |
+| **\*14** | Charity Gray         | Ignite the Fuze (Faith Church)                               | 0     |       |    |      |
+
+
 ## Intermediate
 
 ### Teams
@@ -45,4 +83,51 @@ menubar_toc_static:
 | **\*10** | Josie Dobbs        | God Squad (The Link)                                              | 0     |      |    |      |
 | **\*10** | Aaliyah Arvizu     | God Squad (The Link)                                              | 0     |      |    |      |
 | 11       | Gadiel Zaragoza    | Powerhouse Kids (First Assembly of God)                           | -5    | -1.3 |    | 33%  |
+
+## Beginner
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                | W/L   | Total | Avg  | QO | Q%  |
+|----:|--------------------------------------------------------------|-------|------:|-----:|---:|----:|
+| 1.1 | Newspring Family Church (Jenks) #2 (Newspring Family Church) | 3 / 1 | 150   | 37.5 | 1  | 84% |
+| 2.0 | Rocket ReAction (Faith Church)                               | 3 / 1 | 300   | 75   | 1  | 82% |
+| 3.1 | The Bridge (The Bridge Assembly of God)                      | 2 / 2 | 245   | 61.2 | 2  | 80% |
+| 4.0 | Airborne (The Link)                                          | 2 / 2 | 200   | 50   |    | 87% |
+| 5.0 | Word Warriers (Grand Assembly of God)                        | 0 / 4 | 110   | 27.5 |    | 82% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                                                | Total | Avg  | QO | Q%   |
+|---------:|--------------------|--------------------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Ryan Mills         | The Bridge (The Bridge Assembly of God)                      | 235   | 58.8 | 2  | 84%  |
+| 2        | Jazmyn Costa       | Rocket ReAction (Faith Church)                               | 180   | 45   | 1  | 87%  |
+| 3        | Levi Vanderslice   | Newspring Family Church (Jenks) #2 (Newspring Family Church) | 165   | 41.3 | 1  | 94%  |
+| 4        | Alexa Santiago     | Airborne (The Link)                                          | 150   | 37.5 |    | 100% |
+| 5        | Olivia Standing    | Word Warriers (Grand Assembly of God)                        | 80    | 20   |    | 100% |
+| 6        | Toby Cress         | Airborne (The Link)                                          | 65    | 16.3 |    | 83%  |
+| **\*6**  | Gideon Wineinger   | Rocket ReAction (Faith Church)                               | 65    | 16.3 |    | 73%  |
+| 7        | Elijah Gray        | Rocket ReAction (Faith Church)                               | 55    | 13.8 |    | 83%  |
+| 8        | Issac Fierro       | Word Warriers (Grand Assembly of God)                        | 40    | 10   |    | 75%  |
+| 9        | Gunner McElroy     | The Bridge (The Bridge Assembly of God)                      | 30    | 7.5  |    | 100% |
+| 10       | Christina Santiago | Airborne (The Link)                                          | 0     |      |    |      |
+| **\*10** | Arnardo Salgado    | Airborne (The Link)                                          | 0     |      |    |      |
+| **\*10** | Jayms Fraley       | Airborne (The Link)                                          | 0     |      |    |      |
+| **\*10** | Enoch Gray         | Rocket ReAction (Faith Church)                               | 0     |      |    |      |
+| **\*10** | Anthony Wineinger  | Rocket ReAction (Faith Church)                               | 0     |      |    |      |
+| **\*10** | Hope Gray          | Rocket ReAction (Faith Church)                               | 0     |      |    |      |
+| **\*10** | Rosie Crook        | Rocket ReAction (Faith Church)                               | 0     |      |    |      |
+| **\*10** | Tate Walsh         | Word Warriers (Grand Assembly of God)                        | 0     |      |    |      |
+| **\*10** | Madison Gadd       | Newspring Family Church (Jenks) #2 (Newspring Family Church) | 0     |      |    |      |
+| **\*10** | David Gadd         | Newspring Family Church (Jenks) #2 (Newspring Family Church) | 0     |      |    |      |
+| **\*10** | Amelia Avery       | The Bridge (The Bridge Assembly of God)                      | 0     |      |    |      |
+| 11       | Raylyn Bickerstaff | Word Warriers (Grand Assembly of God)                        | -10   | -2.5 |    |      |
+| 12       | Jimma Fraley       | Airborne (The Link)                                          | -15   | -3.8 |    |      |
+| **\*12** | Kassidy Haws       | Newspring Family Church (Jenks) #2 (Newspring Family Church) | -15   | -3.8 |    |      |
+| 13       | Ethan Whitaker     | The Bridge (The Bridge Assembly of God)                      | -20   | -5   |    |      |
+
 

--- a/_pages/jbq/2020/districts/peninsular-florida.md
+++ b/_pages/jbq/2020/districts/peninsular-florida.md
@@ -346,3 +346,48 @@ menubar_toc_static:
 | **\*15** | Abigail Okoh           | CLC Next Generation (Christian Life Center)                 | 0     |      |    |      |
 | **\*15** | Tyler Udell            | EvAngel Angels (Evangel Assembly of God)                    | 0     |      |    |      |
 
+
+## Flight X2
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                                | W/L   | Total | Avg | QO | Q%   |
+|----:|------------------------------------------------------------------------------|-------|------:|----:|---:|-----:|
+| 1.0 | Freedom Wave Walkers (Freedom Christian Fellowship of the Assemblies of God) | 5 / 0 | 340   | 68  |    | 80%  |
+| 2.0 | JBQ Jaguars (Faith Assembly of God)                                          | 4 / 1 | 350   | 70  | 3  | 68%  |
+| 3.0 | New Life Assembly (Lehigh) #5- Rodriquez (New Life Assembly)                 | 3 / 2 | 255   | 51  | 1  | 82%  |
+| 4.0 | First Assembly Deland (Deland) #2 (First Assembly Deland)                    | 2 / 3 | 140   | 28  |    | 80%  |
+| 5.0 | New Life Assembly (Lehigh) #3-Brazeal (New Life Assembly)                    | 1 / 4 | 160   | 32  | 1  | 69%  |
+| 6.0 | Highpoint Church (Port Saint Lucie) #2 (Highpoint Community Church)          | 0 / 5 | 50    | 10  |    | 100% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                                                                | Total | Avg | QO | Q%   |
+|---------:|--------------------|------------------------------------------------------------------------------|------:|----:|---:|-----:|
+| 1        | Micah Wise         | JBQ Jaguars (Faith Assembly of God)                                          | 255   | 51  | 3  | 83%  |
+| 2        | Amari Mathurin     | New Life Assembly (Lehigh) #5- Rodriquez (New Life Assembly)                 | 220   | 44  | 1  | 96%  |
+| 3        | Sabina Myers       | Freedom Wave Walkers (Freedom Christian Fellowship of the Assemblies of God) | 220   | 44  |    | 92%  |
+| 4        | Kaitlande Jacques  | New Life Assembly (Lehigh) #3-Brazeal (New Life Assembly)                    | 140   | 28  | 1  | 100% |
+| 5        | Jerlyn Pawlak      | First Assembly Deland (Deland) #2 (First Assembly Deland)                    | 105   | 21  |    | 92%  |
+| 6        | Benjamin Reilly    | JBQ Jaguars (Faith Assembly of God)                                          | 85    | 17  |    | 54%  |
+| 7        | Cole Myers         | Freedom Wave Walkers (Freedom Christian Fellowship of the Assemblies of God) | 80    | 16  |    | 82%  |
+| 8        | Kallen Alicea      | New Life Assembly (Lehigh) #5- Rodriquez (New Life Assembly)                 | 40    | 8   |    | 60%  |
+| **\*8**  | Olachi Ohiaeriaku  | Freedom Wave Walkers (Freedom Christian Fellowship of the Assemblies of God) | 40    | 8   |    | 54%  |
+| 9        | Titus Blades       | First Assembly Deland (Deland) #2 (First Assembly Deland)                    | 35    | 7   |    | 80%  |
+| 10       | Sebastian Jimenez  | Highpoint Church (Port Saint Lucie) #2 (Highpoint Community Church)          | 30    | 6   |    | 100% |
+| 11       | Ahnaley Serrano    | Highpoint Church (Port Saint Lucie) #2 (Highpoint Community Church)          | 20    | 4   |    | 100% |
+| 12       | Victoria Fernandez | New Life Assembly (Lehigh) #3-Brazeal (New Life Assembly)                    | 10    | 2   |    | 50%  |
+| **\*12** | Elizabeth Godfrey  | JBQ Jaguars (Faith Assembly of God)                                          | 10    | 2   |    | 50%  |
+| **\*12** | Joseph Rodriquez   | New Life Assembly (Lehigh) #3-Brazeal (New Life Assembly)                    | 10    | 2   |    | 42%  |
+| 13       | Kindle Blades      | First Assembly Deland (Deland) #2 (First Assembly Deland)                    | 0     |     |    | 33%  |
+| **\*13** | Adalynn Vasquez    | New Life Assembly (Lehigh) #5- Rodriquez (New Life Assembly)                 | 0     |     |    |      |
+| **\*13** | Tabitha Hursell    | New Life Assembly (Lehigh) #3-Brazeal (New Life Assembly)                    | 0     |     |    |      |
+| **\*13** | Zion Castro        | Highpoint Church (Port Saint Lucie) #2 (Highpoint Community Church)          | 0     |     |    |      |
+| **\*13** | Adrian Torres      | Freedom Wave Walkers (Freedom Christian Fellowship of the Assemblies of God) | 0     |     |    |      |
+| **\*13** | Aubrey Lexius      | Freedom Wave Walkers (Freedom Christian Fellowship of the Assemblies of God) | 0     |     |    |      |
+| 14       | Kathleen Mec-El    | New Life Assembly (Lehigh) #5- Rodriquez (New Life Assembly)                 | -5    | -1  |    |      |
+

--- a/_pages/jbq/2020/other/arkansas-districts-qualifying.md
+++ b/_pages/jbq/2020/other/arkansas-districts-qualifying.md
@@ -12,7 +12,7 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## North Central Area - 2nd and under
+## North Central Area - 2nd & Under
 
 ### Teams
 
@@ -66,4 +66,86 @@ menubar_toc_static:
 | **\*20** | Harper Herbert   | Bethel (Bethel)              | 0     |       |    |      |
 | **\*20** | Kinsley Moore    | Bethel (Bethel)              | 0     |       |    |      |
 | 21       | Londen Cotner    | McArthur Mermaids (McArthur) | -5    | -.8   |    | 33%  |
+
+## North Central Area - 3rd & 4th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church               | W/L   | Total | Avg   | QO | Q%  |
+|----:|-----------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Change Point (Change Point) | 2 / 1 | 455   | 151.6 | 3  | 97% |
+| 2.0 | McArthur A (McArthur)       | 2 / 1 | 325   | 108.3 |    | 81% |
+| 3.0 | Bethel (Bethel)             | 2 / 1 | 280   | 93.3  | 1  | 81% |
+| 4.0 | Buzz Hogs (River of Life)   | 0 / 3 | 10    | 3.3   |    | 45% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church               | Total | Avg  | QO | Q%   |
+|---------:|-------------------|-----------------------------|------:|-----:|---:|-----:|
+| 1        | Noah Brady        | Change Point (Change Point) | 250   | 83.3 | 2  | 100% |
+| 2        | Kayden Johnson    | Bethel (Bethel)             | 250   | 83.3 | 1  | 87%  |
+| 3        | Jayden Maris      | Change Point (Change Point) | 145   | 48.3 | 1  | 90%  |
+| 4        | Lexi Shalter      | McArthur A (McArthur)       | 100   | 33.3 |    | 67%  |
+| 5        | Karter Ballard    | McArthur A (McArthur)       | 80    | 26.7 |    | 100% |
+| 6        | Joshua Clark      | McArthur A (McArthur)       | 75    | 25   |    | 73%  |
+| 7        | Taylinn Cotner    | McArthur A (McArthur)       | 70    | 23.3 |    | 100% |
+| 8        | Trevor Maris      | Change Point (Change Point) | 60    | 20   |    | 100% |
+| 9        | Kayden Moore      | Bethel (Bethel)             | 30    | 10   |    | 67%  |
+| 10       | Lyle Wake         | Buzz Hogs (River of Life)   | 10    | 3.3  |    | 45%  |
+| 11       | Connor Carlisle   | Change Point (Change Point) | 0     |      |    |      |
+| **\*11** | Reece Hall-Folsom | Buzz Hogs (River of Life)   | 0     |      |    |      |
+| **\*11** | Caleb Hoofman     | Buzz Hogs (River of Life)   | 0     |      |    |      |
+| **\*11** | Mikaela Herbert   | Bethel (Bethel)             | 0     |      |    |      |
+| **\*11** | Mel Stone         | McArthur A (McArthur)       | 0     |      |    |      |
+| **\*11** | Addison Cotner    | McArthur A (McArthur)       | 0     |      |    |      |
+
+
+## North Central Area - 5th & 6th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church               | W/L   | Total | Avg | QO | Q%   |
+|----:|-----------------------------|-------|------:|----:|---:|-----:|
+| 1.0 | McArthur A (McArthur)       | 5 / 0 | 1105  | 221 | 4  | 86%  |
+| 2.0 | Bethel (Bethel)             | 4 / 1 | 900   | 180 | 5  | 87%  |
+| 3.0 | Buzz Hogs (River of Life)   | 3 / 2 | 930   | 186 | 6  | 85%  |
+| 4.0 | McArthur B (McArthur)       | 2 / 3 | 355   | 71  | 1  | 90%  |
+| 5.0 | Change Point (Change Point) | 1 / 4 | 315   | 63  | 2  | 95%  |
+| 6.0 | The Ridge (The Ridge)       | 0 / 5 | 130   | 26  |    | 100% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer         | Team / Church               | Total | Avg | QO | Q%   |
+|---------:|-----------------|-----------------------------|------:|----:|---:|-----:|
+| 1        | Jordyn Smith    | Bethel (Bethel)             | 745   | 149 | 5  | 91%  |
+| 2        | Josiah Minick   | Buzz Hogs (River of Life)   | 565   | 113 | 3  | 86%  |
+| 3        | Aubrey Brandon  | McArthur A (McArthur)       | 530   | 106 | 3  | 100% |
+| 4        | Joshua McCall   | Change Point (Change Point) | 305   | 61  | 2  | 95%  |
+| 5        | Sara Swain      | McArthur A (McArthur)       | 260   | 52  |    | 73%  |
+| 6        | Grace Parnell   | Buzz Hogs (River of Life)   | 230   | 46  | 3  | 79%  |
+| 7        | Carly Shalter   | McArthur B (McArthur)       | 230   | 46  | 1  | 88%  |
+| 8        | Clayton Ballard | McArthur A (McArthur)       | 140   | 28  | 1  | 87%  |
+| 9        | Addisyn Wolters | McArthur A (McArthur)       | 135   | 27  |    | 83%  |
+| 10       | Nicole Clark    | McArthur B (McArthur)       | 125   | 25  |    | 93%  |
+| 11       | Skyla Cope      | The Ridge (The Ridge)       | 100   | 20  |    | 100% |
+| **\*11** | Kaitlyn Mogish  | Bethel (Bethel)             | 100   | 20  |    | 92%  |
+| 12       | Bri Rasdon      | Buzz Hogs (River of Life)   | 95    | 19  |    | 90%  |
+| 13       | Addyson Herbert | Bethel (Bethel)             | 55    | 11  |    | 70%  |
+| 14       | Scout Bateman   | McArthur A (McArthur)       | 45    | 9   |    | 67%  |
+| 15       | Maggie Baez     | Buzz Hogs (River of Life)   | 40    | 8   |    | 100% |
+| 16       | Nevaeh Watson   | The Ridge (The Ridge)       | 20    | 4   |    | 99%  |
+| 17       | Leah Carlisle   | Change Point (Change Point) | 10    | 2   |    | 99%  |
+| **\*17** | Kirsten Boyer   | The Ridge (The Ridge)       | 10    | 2   |    | 99%  |
+| 18       | Quizzer-3       | Change Point (Change Point) | 0     |     |    |      |
+| **\*18** | Jackson Eckart  | The Ridge (The Ridge)       | 0     |     |    |      |
+| **\*18** | Aidan Scissell  | McArthur B (McArthur)       | 0     |     |    |      |
+| **\*18** | Evie Herrin     | McArthur B (McArthur)       | 0     |     |    |      |
 

--- a/_pages/jbq/2020/tournaments/snow-bowl.md
+++ b/_pages/jbq/2020/tournaments/snow-bowl.md
@@ -12,43 +12,6 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## PeeWee Division
-
-### Teams
-
-*2 way ties broken by head to head, 3+ way ties broken by points*
-
-| #   | Team / Church                            | W/L   | Total | Avg  | QO | Q%  |
-|----:|------------------------------------------|-------|------:|-----:|---:|----:|
-| 1.0 | The Mini Heroes (The Oaks Church)        | 3 / 0 | 450   | 150  | 4  | 88% |
-| 2.0 | Mission Possible (Mountain Creek church) | 2 / 1 | 130   | 43.3 | 2  | 56% |
-| 3.0 | Holy Hot Dogs (Dripping Springs)         | 1 / 2 | 90    | 30   | 1  | 65% |
-| 4.0 | S.H.I.N.E (Bethesda AG)                  | 0 / 3 | 70    | 23.3 |    | 69% |
-
-### Individuals
-
-*Ties broken by Average Points then Total Quiz Outs*
-
-| #        | Quizzer           | Team / Church                            | Total | Avg  | QO | Q%   |
-|---------:|-------------------|------------------------------------------|------:|-----:|---:|-----:|
-| 1        | Lilly Jeter       | The Mini Heroes (The Oaks Church)        | 190   | 63.3 | 2  | 100% |
-| 2        | Abigail Lapusan   | The Mini Heroes (The Oaks Church)        | 180   | 60   | 2  | 89%  |
-| 3        | Noah Zeli         | Mission Possible (Mountain Creek church) | 145   | 48.3 | 2  | 75%  |
-| 4        | Ian Linton        | Holy Hot Dogs (Dripping Springs)         | 100   | 33.3 | 1  | 73%  |
-| 5        | Samantha Colley   | The Mini Heroes (The Oaks Church)        | 70    | 23.3 |    | 69%  |
-| 6        | Melody Mora       | S.H.I.N.E (Bethesda AG)                  | 45    | 15   |    | 83%  |
-| 7        | Ethan Fajemirokun | Mission Possible (Mountain Creek church) | 20    | 6.7  |    | 60%  |
-| 8        | Autumn Block      | S.H.I.N.E (Bethesda AG)                  | 15    | 5    |    | 66%  |
-| 9        | Silas Guajardo    | The Mini Heroes (The Oaks Church)        | 10    | 3.3  |    | 99%  |
-| **\*9**  | Sophia Mora       | S.H.I.N.E (Bethesda AG)                  | 10    | 3.3  |    | 50%  |
-| 10       | Genesis Bermudez  | S.H.I.N.E (Bethesda AG)                  | 0     |      |    |      |
-| **\*10** | Ximena Bermudez   | S.H.I.N.E (Bethesda AG)                  | 0     |      |    |      |
-| 11       | Emmy Smith        | Holy Hot Dogs (Dripping Springs)         | -5    | -1.7 |    |      |
-| **\*11** | Kayln Gillis      | Holy Hot Dogs (Dripping Springs)         | -5    | -1.7 |    |      |
-| 12       | Alyssa Gonzales   | Mission Possible (Mountain Creek church) | -10   | -3.3 |    |      |
-| 13       | Joseph Zeli       | Mission Possible (Mountain Creek church) | -25   | -8.3 |    |      |
-
-
 ## Older Division
 
 ### Teams
@@ -94,3 +57,76 @@ menubar_toc_static:
 | **\*17** | Charlotte Smith    | Satan Busters (Dripping Springs)              | 0     |     |    |      |
 | **\*17** | Jaya Gastineau     | Satan Busters (Dripping Springs)              | 0     |     |    |      |
 | **\*17** | Emmett Taylor      | Satan Busters (Dripping Springs)              | 0     |     |    |      |
+
+## Beginner Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                         | W/L   | Total | Avg   | QO | Q%  |
+|----:|-------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Church Mice (First @ Firewheel AG)                    | 6 / 0 | 805   | 134.1 | 7  | 87% |
+| 2.0 | God's Children (The Oaks Church)                      | 4 / 2 | 725   | 120.8 | 7  | 88% |
+| 3.0 | Bible Seekers (First @ Firewheel)                     | 2 / 4 | 430   | 71.7  | 1  | 80% |
+| 4.0 | Christ's Angels(with us in spirit) (Dripping Springs) | 0 / 6 | 0     |       |    |     |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                         | Total | Avg  | QO | Q%   |
+|---------:|-------------------|-------------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Jayden Ramesh     | Church Mice (First @ Firewheel AG)                    | 565   | 94.2 | 6  | 95%  |
+| 2        | Hannah Lapusan    | God's Children (The Oaks Church)                      | 385   | 64.2 | 4  | 94%  |
+| 3        | Sarah Lapusan     | God's Children (The Oaks Church)                      | 310   | 51.7 | 3  | 80%  |
+| 4        | Chika Iwuogaranya | Bible Seekers (First @ Firewheel)                     | 295   | 49.2 | 1  | 90%  |
+| 5        | Christiana Darko  | Church Mice (First @ Firewheel AG)                    | 160   | 26.7 | 1  | 78%  |
+| 6        | Anita Ogiemwonyi  | Bible Seekers (First @ Firewheel)                     | 100   | 16.7 |    | 85%  |
+| 7        | Matthew Leones    | Church Mice (First @ Firewheel AG)                    | 75    | 12.5 |    | 89%  |
+| 8        | Hawi Alem         | Bible Seekers (First @ Firewheel)                     | 35    | 5.8  |    | 57%  |
+| 9        | Reagan Wirth      | God's Children (The Oaks Church)                      | 30    | 5    |    | 100% |
+| 10       | Abigail Yosefe    | Church Mice (First @ Firewheel AG)                    | 5     | .8   |    | 50%  |
+| 11       | Penelope Guajardo | God's Children (The Oaks Church)                      | 0     |      |    |      |
+| **\*11** | Jessa Gastineau   | Christ's Angels(with us in spirit) (Dripping Springs) | 0     |      |    |      |
+| **\*11** | Quizzer-3         | Christ's Angels(with us in spirit) (Dripping Springs) | 0     |      |    |      |
+| **\*11** | Dozie Osuagwu     | Bible Seekers (First @ Firewheel)                     | 0     |      |    |      |
+| **\*11** | Kamsi Osuagwu     | Bible Seekers (First @ Firewheel)                     | 0     |      |    |      |
+
+
+## PeeWee Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                            | W/L   | Total | Avg  | QO | Q%  |
+|----:|------------------------------------------|-------|------:|-----:|---:|----:|
+| 1.0 | The Mini Heroes (The Oaks Church)        | 3 / 0 | 450   | 150  | 4  | 88% |
+| 2.0 | Mission Possible (Mountain Creek church) | 2 / 1 | 130   | 43.3 | 2  | 56% |
+| 3.0 | Holy Hot Dogs (Dripping Springs)         | 1 / 2 | 90    | 30   | 1  | 65% |
+| 4.0 | S.H.I.N.E (Bethesda AG)                  | 0 / 3 | 70    | 23.3 |    | 69% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                            | Total | Avg  | QO | Q%   |
+|---------:|-------------------|------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Lilly Jeter       | The Mini Heroes (The Oaks Church)        | 190   | 63.3 | 2  | 100% |
+| 2        | Abigail Lapusan   | The Mini Heroes (The Oaks Church)        | 180   | 60   | 2  | 89%  |
+| 3        | Noah Zeli         | Mission Possible (Mountain Creek church) | 145   | 48.3 | 2  | 75%  |
+| 4        | Ian Linton        | Holy Hot Dogs (Dripping Springs)         | 100   | 33.3 | 1  | 73%  |
+| 5        | Samantha Colley   | The Mini Heroes (The Oaks Church)        | 70    | 23.3 |    | 69%  |
+| 6        | Melody Mora       | S.H.I.N.E (Bethesda AG)                  | 45    | 15   |    | 83%  |
+| 7        | Ethan Fajemirokun | Mission Possible (Mountain Creek church) | 20    | 6.7  |    | 60%  |
+| 8        | Autumn Block      | S.H.I.N.E (Bethesda AG)                  | 15    | 5    |    | 66%  |
+| 9        | Silas Guajardo    | The Mini Heroes (The Oaks Church)        | 10    | 3.3  |    | 99%  |
+| **\*9**  | Sophia Mora       | S.H.I.N.E (Bethesda AG)                  | 10    | 3.3  |    | 50%  |
+| 10       | Genesis Bermudez  | S.H.I.N.E (Bethesda AG)                  | 0     |      |    |      |
+| **\*10** | Ximena Bermudez   | S.H.I.N.E (Bethesda AG)                  | 0     |      |    |      |
+| 11       | Emmy Smith        | Holy Hot Dogs (Dripping Springs)         | -5    | -1.7 |    |      |
+| **\*11** | Kayln Gillis      | Holy Hot Dogs (Dripping Springs)         | -5    | -1.7 |    |      |
+| 12       | Alyssa Gonzales   | Mission Possible (Mountain Creek church) | -10   | -3.3 |    |      |
+| 13       | Joseph Zeli       | Mission Possible (Mountain Creek church) | -25   | -8.3 |    |      |
+

--- a/_pages/jbq/2021/districts/arkansas.md
+++ b/_pages/jbq/2021/districts/arkansas.md
@@ -12,7 +12,44 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## 3rd & 4th
+## 2nd & Under
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                         | W/L   | Total | Avg   | QO | Q%   |
+|----:|-----------------------------------------------------------------------|-------|------:|------:|---:|-----:|
+| 1.0 | Bethel Assembly of God A (Bethel Assembly of God)                     | 3 / 0 | 445   | 148.3 | 3  | 94%  |
+| 2.0 | McArthur Assembly of God (Jacksonville) #2 (McArthur Assembly of God) | 2 / 1 | 225   | 75    |    | 87%  |
+| 3.0 | McArthur Assembly of God (Jacksonville) #1 (McArthur Assembly of God) | 1 / 2 | 100   | 33.3  |    | 100% |
+| 4.0 | Bethel Assembly of God B (Bethel Assembly of God)                     | 0 / 3 | 45    | 15    |    | 83%  |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                                         | Total | Avg  | QO | Q%   |
+|---------:|-------------------|-----------------------------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Savannah Smith    | Bethel Assembly of God A (Bethel Assembly of God)                     | 205   | 68.3 | 1  | 93%  |
+| 2        | Layne Burton      | Bethel Assembly of God A (Bethel Assembly of God)                     | 195   | 65   | 2  | 94%  |
+| 3        | Daley Kersey      | McArthur Assembly of God (Jacksonville) #2 (McArthur Assembly of God) | 120   | 40   |    | 100% |
+| 4        | Ryleigh Ballard   | McArthur Assembly of God (Jacksonville) #1 (McArthur Assembly of God) | 90    | 30   |    | 100% |
+| 5        | Tucker Ballard    | McArthur Assembly of God (Jacksonville) #2 (McArthur Assembly of God) | 50    | 16.7 |    | 100% |
+| 6        | Bradley Moore     | Bethel Assembly of God A (Bethel Assembly of God)                     | 45    | 15   |    | 100% |
+| **\*6**  | Jaxson Shalter    | McArthur Assembly of God (Jacksonville) #2 (McArthur Assembly of God) | 45    | 15   |    | 70%  |
+| 7        | Leah Ford         | Bethel Assembly of God B (Bethel Assembly of God)                     | 30    | 10   |    | 100% |
+| 8        | Noah Ford         | Bethel Assembly of God B (Bethel Assembly of God)                     | 15    | 5    |    | 66%  |
+| 9        | Addison DeJesus   | McArthur Assembly of God (Jacksonville) #2 (McArthur Assembly of God) | 10    | 3.3  |    | 99%  |
+| **\*9**  | Londen Cotner     | McArthur Assembly of God (Jacksonville) #1 (McArthur Assembly of God) | 10    | 3.3  |    | 99%  |
+| 10       | Emma Shalter      | McArthur Assembly of God (Jacksonville) #1 (McArthur Assembly of God) | 0     |      |    |      |
+| **\*10** | Chloe Smith       | Bethel Assembly of God B (Bethel Assembly of God)                     | 0     |      |    |      |
+| **\*10** | Harper Herbert    | Bethel Assembly of God B (Bethel Assembly of God)                     | 0     |      |    |      |
+| **\*10** | Jaymee Dave       | Bethel Assembly of God B (Bethel Assembly of God)                     | 0     |      |    |      |
+| **\*10** | Kinsley Moore     | Bethel Assembly of God A (Bethel Assembly of God)                     | 0     |      |    |      |
+| **\*10** | Maddie Kate Brady | Bethel Assembly of God A (Bethel Assembly of God)                     | 0     |      |    |      |
+
+## 3rd & 4th Grade
 
 ### Teams
 
@@ -42,4 +79,51 @@ menubar_toc_static:
 | **\*8** | Taylinn Cotner   | McArthur Assembly of God (3-4 B Jacksonville) #4 (McArthur Assembly of God) | 0     |      |    |      |
 | **\*8** | Addison Cotner   | McArthur Assembly of God (3-4 B Jacksonville) #4 (McArthur Assembly of God) | 0     |      |    |      |
 | **\*8** | Alexa King       | Changepoint Assembly of God (Cabot) #2 (Changepoint Assembly of God)        | 0     |      |    |      |
+
+## 5th & 6th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                                      | W/L   | Total | Avg | QO | Q%  |
+|----:|------------------------------------------------------------------------------------|-------|------:|----:|---:|----:|
+| 1.0 | Bethel Assembly of God (Bethel Assembly of God)                                    | 5 / 0 | 1060  | 212 | 7  | 82% |
+| 2.0 | Faith Assembly of God (Harrison) #1 (Faith Assembly of God)                        | 4 / 1 | 780   | 156 | 3  | 92% |
+| 3.0 | McArthur Assembly of God (5-6 gradeJacksonville) #5 (McArthur Assembly of God)     | 3 / 2 | 575   | 115 | 2  | 81% |
+| 4.0 | Crystal Hill Assembly of God (North Little Rock) #1 (Crystal Hill Assembly of God) | 2 / 3 | 470   | 94  | 2  | 76% |
+| 5.0 | Changepoint Assembly of God (Cabot) #1 (Changepoint Assembly of God)               | 1 / 4 | 265   | 53  | 1  | 86% |
+| 6.0 | The Ridge Assembly of Sherwood (Sherwood) #1 (The Ridge Assembly of Sherwood)      | 0 / 5 | 35    | 7   |    | 80% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                                                      | Total | Avg | QO | Q%   |
+|---------:|-------------------|------------------------------------------------------------------------------------|------:|----:|---:|-----:|
+| 1        | Jordyn Smith      | Bethel Assembly of God (Bethel Assembly of God)                                    | 750   | 150 | 5  | 91%  |
+| 2        | Haleigh Griffin   | Faith Assembly of God (Harrison) #1 (Faith Assembly of God)                        | 540   | 108 | 3  | 96%  |
+| 3        | Carly Shalter     | McArthur Assembly of God (5-6 gradeJacksonville) #5 (McArthur Assembly of God)     | 250   | 50  |    | 74%  |
+| 4        | Jasmine Wedgworth | Crystal Hill Assembly of God (North Little Rock) #1 (Crystal Hill Assembly of God) | 235   | 47  | 2  | 79%  |
+| 5        | Clayton Ballard   | McArthur Assembly of God (5-6 gradeJacksonville) #5 (McArthur Assembly of God)     | 230   | 46  | 2  | 92%  |
+| 6        | Jayden Maris      | Changepoint Assembly of God (Cabot) #1 (Changepoint Assembly of God)               | 210   | 42  | 1  | 100% |
+| 7        | Kayden Johnson    | Bethel Assembly of God (Bethel Assembly of God)                                    | 165   | 33  | 2  | 77%  |
+| 8        | Jalynn Wedgworth  | Crystal Hill Assembly of God (North Little Rock) #1 (Crystal Hill Assembly of God) | 160   | 32  |    | 71%  |
+| 9        | Andi Wilson       | Faith Assembly of God (Harrison) #1 (Faith Assembly of God)                        | 150   | 30  |    | 87%  |
+| 10       | Noah Brady        | Bethel Assembly of God (Bethel Assembly of God)                                    | 140   | 28  |    | 83%  |
+| 11       | Joshua Clark      | McArthur Assembly of God (5-6 gradeJacksonville) #5 (McArthur Assembly of God)     | 100   | 20  |    | 75%  |
+| 12       | Audrey Perin      | Crystal Hill Assembly of God (North Little Rock) #1 (Crystal Hill Assembly of God) | 75    | 15  |    | 75%  |
+| 13       | Alli Wiese        | Changepoint Assembly of God (Cabot) #1 (Changepoint Assembly of God)               | 60    | 12  |    | 100% |
+| 14       | Ashleigh Griffin  | Faith Assembly of God (Harrison) #1 (Faith Assembly of God)                        | 50    | 10  |    | 80%  |
+| 15       | Ella Eddings      | Faith Assembly of God (Harrison) #1 (Faith Assembly of God)                        | 40    | 8   |    | 100% |
+| 16       | Skyla Cope        | The Ridge Assembly of Sherwood (Sherwood) #1 (The Ridge Assembly of Sherwood)      | 30    | 6   |    | 100% |
+| 17       | Kirsten Boyer     | The Ridge Assembly of Sherwood (Sherwood) #1 (The Ridge Assembly of Sherwood)      | 5     | 1   |    | 50%  |
+| **\*17** | Kayden Moore      | Bethel Assembly of God (Bethel Assembly of God)                                    | 5     | 1   |    | 40%  |
+| 18       | Arelah Weaver     | The Ridge Assembly of Sherwood (Sherwood) #1 (The Ridge Assembly of Sherwood)      | 0     |     |    |      |
+| **\*18** | Nevaeh Watson     | The Ridge Assembly of Sherwood (Sherwood) #1 (The Ridge Assembly of Sherwood)      | 0     |     |    |      |
+| **\*18** | Karter Ballard    | McArthur Assembly of God (5-6 gradeJacksonville) #5 (McArthur Assembly of God)     | 0     |     |    |      |
+| **\*18** | Stevie Jones      | Faith Assembly of God (Harrison) #1 (Faith Assembly of God)                        | 0     |     |    |      |
+| **\*18** | Mikaela Herbert   | Bethel Assembly of God (Bethel Assembly of God)                                    | 0     |     |    |      |
+| **\*18** | Isaac Dave        | Bethel Assembly of God (Bethel Assembly of God)                                    | 0     |     |    |      |
+| 19       | Liam Wiese        | Changepoint Assembly of God (Cabot) #1 (Changepoint Assembly of God)               | -5    | -1  |    | 25%  |
 

--- a/_pages/jbq/2021/districts/north-texas.md
+++ b/_pages/jbq/2021/districts/north-texas.md
@@ -112,7 +112,45 @@ menubar_toc_static:
 
 ## Beginners
 
-### Teams
+### Tier 1
+
+#### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                            | W/L   | Total | Avg   | QO | Q%  |
+|----:|------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | JBQ Power Kids (Freedom Church)          | 5 / 1 | 585   | 97.5  | 3  | 84% |
+| 2.0 | David's Army (Encounter Church)          | 4 / 2 | 655   | 109.1 | 4  | 87% |
+| 3.0 | Royal Heirs (The Oaks Fellowship)        | 3 / 3 | 580   | 96.7  | 4  | 85% |
+| 4.0 | God's generation (Mountain Creek Church) | 0 / 6 | 255   | 42.5  |    | 86% |
+
+#### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                            | Total | Avg  | QO | Q%   |
+|---------:|----------------------|------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Michael Wirth        | Royal Heirs (The Oaks Fellowship)        | 310   | 51.7 | 3  | 88%  |
+| 2        | Reagan Williamson    | JBQ Power Kids (Freedom Church)          | 295   | 49.2 | 3  | 90%  |
+| 3        | Ariella Fortygin     | David's Army (Encounter Church)          | 285   | 47.5 | 3  | 90%  |
+| 4        | Abigail Lapusan      | Royal Heirs (The Oaks Fellowship)        | 270   | 45   | 1  | 81%  |
+| 5        | Isabella Berlinkskiy | David's Army (Encounter Church)          | 245   | 40.8 | 1  | 79%  |
+| 6        | Victoria Perciado    | God's generation (Mountain Creek Church) | 225   | 37.5 |    | 84%  |
+| 7        | Diana Morland        | JBQ Power Kids (Freedom Church)          | 200   | 33.3 |    | 91%  |
+| 8        | Kaylie Fortygin      | David's Army (Encounter Church)          | 125   | 20.8 |    | 93%  |
+| 9        | Addie Osborn         | JBQ Power Kids (Freedom Church)          | 55    | 9.2  |    | 86%  |
+| 10       | Caleb Mincks         | JBQ Power Kids (Freedom Church)          | 35    | 5.8  |    | 50%  |
+| 11       | Hannah Gonzales      | God's generation (Mountain Creek Church) | 20    | 3.3  |    | 100% |
+| 12       | Irene Ortiz          | God's generation (Mountain Creek Church) | 10    | 1.7  |    | 99%  |
+| 13       | Joel Andrade         | JBQ Power Kids (Freedom Church)          | 0     |      |    |      |
+| **\*13** | Layla Gaston         | David's Army (Encounter Church)          | 0     |      |    |      |
+| **\*13** | Cooper Gaston        | David's Army (Encounter Church)          | 0     |      |    |      |
+| **\*13** | Violet Cano          | Royal Heirs (The Oaks Fellowship)        | 0     |      |    |      |
+
+### Tier 2
+
+#### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points*
 
@@ -125,7 +163,7 @@ menubar_toc_static:
 | 5.0 | The Elected (Mountain Creek Church)      | 1 / 4 | 275   | 55  | 2  | 72%  |
 | 6.0 | The 12 Apostles (Holy Ghost)             | 0 / 5 | 10    | 2   |    | 100% |
 
-### Individuals
+#### Individuals
 
 *Ties broken by Average Points then Total Quiz Outs*
 

--- a/_pages/jbq/2021/districts/northwest.md
+++ b/_pages/jbq/2021/districts/northwest.md
@@ -1,0 +1,92 @@
+---
+layout: page
+title: "2021 Northwest District Finals"
+permalink: /jbq/2021/districts/northwest/
+date: "2021-05-02"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2021 Season
+    link: /jbq/2021/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                     | W/L   | Total | Avg   | QO | Q%  |
+|----:|---------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Cedar Park Church A1 (Cedar Park Assembly of God) | 4 / 0 | 1070  | 267.4 | 4  | 90% |
+| 2.0 | BNC A1 (Bellevue Neighborhood Church)             | 1 / 3 | 245   | 61.2  |    | 82% |
+| 3.0 | BNC A2 (Bellevue Neighborhood Church)             | 1 / 3 | 210   | 52.5  | 1  | 72% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #  | Quizzer           | Team / Church                                     | Total | Avg  | QO | Q%   |
+|---:|-------------------|---------------------------------------------------|------:|-----:|---:|-----:|
+| 1  | Olivia Moses      | Cedar Park Church A1 (Cedar Park Assembly of God) | 390   | 97.5 |    | 94%  |
+| 2  | Jonathan Zuo      | Cedar Park Church A1 (Cedar Park Assembly of God) | 370   | 92.5 | 1  | 82%  |
+| 3  | Daniel Li         | Cedar Park Church A1 (Cedar Park Assembly of God) | 255   | 63.8 | 3  | 96%  |
+| 4  | Micah Gallo       | BNC A1 (Bellevue Neighborhood Church)             | 145   | 36.3 |    | 86%  |
+| 5  | Yavin Mokana      | BNC A2 (Bellevue Neighborhood Church)             | 130   | 32.5 | 1  | 73%  |
+| 6  | Sannidhi Tammala  | BNC A1 (Bellevue Neighborhood Church)             | 100   | 25   |    | 75%  |
+| 7  | Leiah Gries       | Cedar Park Church A1 (Cedar Park Assembly of God) | 55    | 13.8 |    | 86%  |
+| 8  | Jeremy Ubbala     | BNC A2 (Bellevue Neighborhood Church)             | 45    | 11.3 |    | 50%  |
+| 9  | Josiah Raj Kallem | BNC A2 (Bellevue Neighborhood Church)             | 40    | 10   |    | 100% |
+| 10 | Stephen Bandaru   | BNC A1 (Bellevue Neighborhood Church)             | 0     |      |    |      |
+
+## C Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                                | W/L   | Total | Avg   | QO | Q%  |
+|----:|------------------------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Kelso Avengers C1 (Kelso Christian Assembly)                                 | 6 / 0 | 965   | 160.8 | 7  | 89% |
+| 2.0 | Cedar Park Church C1 (Cedar Park Assembly of God)                            | 5 / 1 | 1095  | 182.5 | 7  | 80% |
+| 3.1 | Deeper Church C2 (Deeper Church)                                             | 3 / 3 | 695   | 115.8 | 4  | 84% |
+| 4.0 | BNC C1 (Bellevue Neighborhood Church)                                        | 3 / 3 | 835   | 139.1 | 6  | 95% |
+| 5.0 | Winlock Assembly of God Church (Winlock) #2 (Winlock Assembly of God Church) | 2 / 4 | 555   | 92.5  | 1  | 84% |
+| 6.0 | The Bridge Church C (Belfair Assembly of God)                                | 1 / 5 | 600   | 100   | 1  | 75% |
+| 7.0 | Deeper Church C1 (Deeper Church)                                             | 1 / 5 | 565   | 94.2  | 3  | 78% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                  | Team / Church                                                                | Total | Avg   | QO | Q%   |
+|---------:|--------------------------|------------------------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Stephen Zuo              | Cedar Park Church C1 (Cedar Park Assembly of God)                            | 775   | 129.2 | 5  | 83%  |
+| 2        | Rishi Battagani          | BNC C1 (Bellevue Neighborhood Church)                                        | 600   | 100   | 6  | 95%  |
+| 3        | Silas Nelson             | Deeper Church C1 (Deeper Church)                                             | 550   | 91.7  | 3  | 80%  |
+| 4        | Charlotte Lyons          | Kelso Avengers C1 (Kelso Christian Assembly)                                 | 510   | 85    | 4  | 87%  |
+| 5        | Judah Westcott           | Deeper Church C2 (Deeper Church)                                             | 465   | 77.5  | 3  | 87%  |
+| 6        | Zander Lyons             | Kelso Avengers C1 (Kelso Christian Assembly)                                 | 455   | 75.8  | 3  | 97%  |
+| 7        | Isaiah English           | Cedar Park Church C1 (Cedar Park Assembly of God)                            | 285   | 47.5  | 2  | 76%  |
+| 8        | Daniel Hunt              | Winlock Assembly of God Church (Winlock) #2 (Winlock Assembly of God Church) | 255   | 42.5  | 1  | 90%  |
+| 9        | Zoey Amarelo             | BNC C1 (Bellevue Neighborhood Church)                                        | 235   | 39.2  |    | 94%  |
+| 10       | David Mobley             | Deeper Church C2 (Deeper Church)                                             | 230   | 38.3  | 1  | 79%  |
+| 11       | Carly McKay              | The Bridge Church C (Belfair Assembly of God)                                | 220   | 36.7  |    | 100% |
+| 12       | Haylie Anderson          | Winlock Assembly of God Church (Winlock) #2 (Winlock Assembly of God Church) | 185   | 30.8  |    | 79%  |
+| 13       | Cade Johnson             | The Bridge Church C (Belfair Assembly of God)                                | 165   | 27.5  | 1  | 71%  |
+| 14       | ZoeyJean Johnson         | The Bridge Church C (Belfair Assembly of God)                                | 135   | 22.5  |    | 76%  |
+| 15       | Remington Hill           | Winlock Assembly of God Church (Winlock) #2 (Winlock Assembly of God Church) | 85    | 14.2  |    | 75%  |
+| 16       | Dillon McKay             | The Bridge Church C (Belfair Assembly of God)                                | 80    | 13.3  |    | 64%  |
+| 17       | Elia English             | Cedar Park Church C1 (Cedar Park Assembly of God)                            | 35    | 5.8   |    | 75%  |
+| 18       | Levi Anderson            | Winlock Assembly of God Church (Winlock) #2 (Winlock Assembly of God Church) | 30    | 5     |    | 100% |
+| 19       | Emma Earle               | Kelso Avengers C1 (Kelso Christian Assembly)                                 | 15    | 2.5   |    | 66%  |
+| **\*19** | Joiya Westcott           | Deeper Church C1 (Deeper Church)                                             | 15    | 2.5   |    | 60%  |
+| 20       | Katalina Montes          | Kelso Avengers C1 (Kelso Christian Assembly)                                 | 0     |       |    |      |
+| **\*20** | Eliza Jane Cutie Gunturu | BNC C1 (Bellevue Neighborhood Church)                                        | 0     |       |    |      |
+| **\*20** | Isaac Balli              | BNC C1 (Bellevue Neighborhood Church)                                        | 0     |       |    |      |
+| **\*20** | Adam Kurz                | The Bridge Church C (Belfair Assembly of God)                                | 0     |       |    |      |
+| **\*20** | Riley Nederlander        | Winlock Assembly of God Church (Winlock) #2 (Winlock Assembly of God Church) | 0     |       |    |      |
+| 21       | Paige Dewey              | Kelso Avengers C1 (Kelso Christian Assembly)                                 | -15   | -2.5  |    |      |
+

--- a/_pages/jbq/2021/districts/oklahoma.md
+++ b/_pages/jbq/2021/districts/oklahoma.md
@@ -12,7 +12,9 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## Teams
+## Advanced
+
+### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points*
 
@@ -23,7 +25,7 @@ menubar_toc_static:
 | 3.0 | God Squad (The Link)        | 2 / 4 | 475   | 79.2  | 1  | 81% |
 | 4.0 | Ghost Team (Arcadeland)     | 0 / 6 | 0     |       |    |     |
 
-## Individuals
+### Individuals
 
 *Ties broken by Average Points then Total Quiz Outs*
 
@@ -45,4 +47,42 @@ menubar_toc_static:
 | **\*9** | Josie Dobbs        | God Squad (The Link)        | 0     |       |    |      |
 | **\*9** | Aaliyah Arvizu     | God Squad (The Link)        | 0     |       |    |      |
 | 10      | Jimma Fraley       | God Squad (The Link)        | -5    | -.8   |    |      |
+
+## Beginner
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                             | W/L   | Total | Avg   | QO | Q%  |
+|----:|-------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Woodlake Bixby #2 (Woodlake Church Bixby) | 6 / 0 | 770   | 128.3 | 6  | 95% |
+| 2.0 | Woodlake Bixby #1 (Woodlake Church Bixby) | 4 / 2 | 685   | 114.1 | 4  | 82% |
+| 3.0 | Christian Chapel B (Christian Chapel)     | 2 / 4 | 565   | 94.2  | 5  | 91% |
+| 4.0 | Doers of the Word (Discovery Church)      | 0 / 6 | 255   | 42.5  | 1  | 80% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                             | Total | Avg  | QO | Q%   |
+|---------:|----------------------|-------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Veronica Kwon        | Woodlake Bixby #1 (Woodlake Church Bixby) | 570   | 95   | 4  | 87%  |
+| 2        | Sophia Frescott      | Woodlake Bixby #2 (Woodlake Church Bixby) | 500   | 83.3 | 4  | 91%  |
+| 3        | Zoey Ullrich         | Christian Chapel B (Christian Chapel)     | 440   | 73.3 | 5  | 100% |
+| 4        | Annabelle Frescott   | Woodlake Bixby #2 (Woodlake Church Bixby) | 270   | 45   | 2  | 100% |
+| 5        | Lily Eillott         | Doers of the Word (Discovery Church)      | 250   | 41.7 | 1  | 92%  |
+| 6        | Kaira Haynes         | Woodlake Bixby #1 (Woodlake Church Bixby) | 60    | 10   |    | 75%  |
+| 7        | Matthew Ullrich      | Christian Chapel B (Christian Chapel)     | 50    | 8.3  |    | 100% |
+| **\*7**  | Analise Hite         | Christian Chapel B (Christian Chapel)     | 50    | 8.3  |    | 71%  |
+| 8        | Sam Ramsey           | Woodlake Bixby #1 (Woodlake Church Bixby) | 40    | 6.7  |    | 71%  |
+| 9        | Landon Wedington     | Doers of the Word (Discovery Church)      | 20    | 3.3  |    | 100% |
+| 10       | Avery Hair           | Woodlake Bixby #1 (Woodlake Church Bixby) | 15    | 2.5  |    | 66%  |
+| 11       | Josiah Haynes        | Woodlake Bixby #1 (Woodlake Church Bixby) | 0     |      |    |      |
+| **\*11** | Aarie Jackson        | Christian Chapel B (Christian Chapel)     | 0     |      |    |      |
+| **\*11** | Quizzer-1            | Woodlake Bixby #2 (Woodlake Church Bixby) | 0     |      |    |      |
+| **\*11** | Quizzer-2            | Woodlake Bixby #2 (Woodlake Church Bixby) | 0     |      |    |      |
+| **\*11** | McKinley Hair        | Woodlake Bixby #2 (Woodlake Church Bixby) | 0     |      |    |      |
+| 12       | Beckham Wedington    | Doers of the Word (Discovery Church)      | -5    | -.8  |    | 33%  |
+| 13       | Jenevieve Mellendorf | Doers of the Word (Discovery Church)      | -10   | -1.7 |    |      |
 

--- a/_pages/jbq/2021/districts/peninsular-florida.md
+++ b/_pages/jbq/2021/districts/peninsular-florida.md
@@ -105,3 +105,38 @@ menubar_toc_static:
 | 14       | Daniel Bonilla    | God\'s Army (Faith Assembly of God)                            | -5    | -.8  |    |      |
 
 
+## Flight 3
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                   | W/L   | Total | Avg   | QO | Q%  |
+|----:|-----------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | The Quarantined (LIFE Church AG) (LIFE Church Assembly of God)  | 6 / 0 | 635   | 105.8 | 1  | 89% |
+| 2.0 | Jesus\' Disciples (Faith Assembly of God)                       | 4 / 2 | 690   | 115   | 2  | 77% |
+| 3.0 | Harvest Assembly of God (Lakeland) #1 (Harvest Assembly of God) | 2 / 4 | 230   | 38.3  |    | 78% |
+| 4.0 | KFC (Kids for Christ) (Trinity Assembly of God)                 | 0 / 6 | 145   | 24.2  |    | 76% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                                   | Total | Avg  | QO | Q%   |
+|---------:|-------------------|-----------------------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Cristina Rios     | Jesus\' Disciples (Faith Assembly of God)                       | 325   | 54.2 | 1  | 84%  |
+| 2        | Chloe Averill     | The Quarantined (LIFE Church AG) (LIFE Church Assembly of God)  | 285   | 47.5 |    | 89%  |
+| 3        | Jonathan Williams | The Quarantined (LIFE Church AG) (LIFE Church Assembly of God)  | 230   | 38.3 | 1  | 91%  |
+| 4        | Piper Kramper     | Harvest Assembly of God (Lakeland) #1 (Harvest Assembly of God) | 205   | 34.2 |    | 87%  |
+| 5        | Ethan Cruz        | Jesus\' Disciples (Faith Assembly of God)                       | 175   | 29.2 |    | 86%  |
+| 6        | Benjamin Craddock | KFC (Kids for Christ) (Trinity Assembly of God)                 | 145   | 24.2 |    | 84%  |
+| 7        | Lydia Marrero     | Jesus\' Disciples (Faith Assembly of God)                       | 95    | 15.8 | 1  | 57%  |
+| 8        | Miguel Rios       | Jesus\' Disciples (Faith Assembly of God)                       | 95    | 15.8 |    | 91%  |
+| 9        | Brighton Hill     | The Quarantined (LIFE Church AG) (LIFE Church Assembly of God)  | 70    | 11.7 |    | 100% |
+| 10       | Dalton Crouch     | The Quarantined (LIFE Church AG) (LIFE Church Assembly of God)  | 50    | 8.3  |    | 67%  |
+| 11       | Lorelai Moreno    | Harvest Assembly of God (Lakeland) #1 (Harvest Assembly of God) | 25    | 4.2  |    | 57%  |
+| 12       | Charles Carroll   | KFC (Kids for Christ) (Trinity Assembly of God)                 | 0     |      |    | 50%  |
+| **\*12** | Dale Craddock     | KFC (Kids for Christ) (Trinity Assembly of God)                 | 0     |      |    |      |
+| **\*12** | Kirrah Oaks       | Harvest Assembly of God (Lakeland) #1 (Harvest Assembly of God) | 0     |      |    |      |
+| **\*12** | Jeremiah Mejia    | Harvest Assembly of God (Lakeland) #1 (Harvest Assembly of God) | 0     |      |    |      |
+| **\*12** | Parker Kramper    | Harvest Assembly of God (Lakeland) #1 (Harvest Assembly of God) | 0     |      |    |      |

--- a/_pages/jbq/2021/other/arkansas-districts-qualifying.md
+++ b/_pages/jbq/2021/other/arkansas-districts-qualifying.md
@@ -12,7 +12,44 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## North Central Area - 3rd and 4th Grade
+## North Central Area - 2nd & Under
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church             | W/L   | Total | Avg  | QO | Q%   |
+|----:|---------------------------|-------|------:|-----:|---:|-----:|
+| 1.0 | Awesome Kids (Bethel)     | 3 / 0 | 210   | 70   | 1  | 90%  |
+| 2.0 | Team Dr. Peper (McArthur) | 2 / 1 | 185   | 61.6 | 2  | 86%  |
+| 3.0 | Amazing Kids (Bethel)     | 1 / 2 | 25    | 8.3  |    | 80%  |
+| 4.0 | Team Star Fire (McArthur) | 0 / 3 | 30    | 10   |    | 100% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #       | Quizzer           | Team / Church             | Total | Avg  | QO | Q%   |
+|--------:|-------------------|---------------------------|------:|-----:|---:|-----:|
+| 1       | Layne Burton      | Awesome Kids (Bethel)     | 180   | 60   | 1  | 89%  |
+| 2       | Jaxson Shalter    | Team Dr. Peper (McArthur) | 135   | 45   | 2  | 81%  |
+| 3       | Daley Kersey      | Team Dr. Peper (McArthur) | 40    | 13.3 |    | 100% |
+| 4       | Ryleigh Ballard   | Team Star Fire (McArthur) | 20    | 6.7  |    | 100% |
+| **\*4** | Savannah Smith    | Awesome Kids (Bethel)     | 20    | 6.7  |    | 100% |
+| 5       | Noah Ford         | Amazing Kids (Bethel)     | 15    | 5    |    | 75%  |
+| 6       | Londen Cotner     | Team Star Fire (McArthur) | 10    | 3.3  |    | 99%  |
+| **\*6** | Addison DeJesus   | Team Dr. Peper (McArthur) | 10    | 3.3  |    | 99%  |
+| **\*6** | Bradley Moore     | Awesome Kids (Bethel)     | 10    | 3.3  |    | 99%  |
+| **\*6** | Leah Ford         | Amazing Kids (Bethel)     | 10    | 3.3  |    | 99%  |
+| 7       | Emma Shalter      | Team Star Fire (McArthur) | 0     |      |    |      |
+| **\*7** | Tucker Ballard    | Team Dr. Peper (McArthur) | 0     |      |    |      |
+| **\*7** | Maddie Kate Brady | Awesome Kids (Bethel)     | 0     |      |    |      |
+| **\*7** | Kinsley Moore     | Awesome Kids (Bethel)     | 0     |      |    |      |
+| **\*7** | Chloe Smith       | Amazing Kids (Bethel)     | 0     |      |    |      |
+| **\*7** | Jaymee Dave       | Amazing Kids (Bethel)     | 0     |      |    |      |
+| **\*7** | Harper Herbert    | Amazing Kids (Bethel)     | 0     |      |    |      |
+
+## North Central Area - 3rd & 4th Grade
 
 ### Teams
 
@@ -42,4 +79,48 @@ menubar_toc_static:
 | 8       | Taylinn Cotner   | Team 2 (McArthur)           | 10    | 5     |    | 99%  |
 | **\*8** | Kayleigh Brandon | Team 1 (McArthur)           | 10    | 5     |    | 99%  |
 | 9       | Addison Cotner   | Team 2 (McArthur)           | 0     |       |    |      |
+
+## North Central Area - 5th & 6th Grade
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church               | W/L   | Total | Avg   | QO | Q%   |
+|----:|-----------------------------|-------|------:|------:|---:|-----:|
+| 1.0 | Buzz Hogs (River of Life)   | 4 / 0 | 735   | 183.7 | 5  | 81%  |
+| 2.0 | McArthur (McArthur)         | 3 / 1 | 510   | 127.5 | 1  | 90%  |
+| 3.0 | Change Point (Change Point) | 2 / 2 | 270   | 67.5  | 1  | 83%  |
+| 4.0 | Bethel (Bethel)             | 1 / 3 | 395   | 98.7  | 1  | 86%  |
+| 5.0 | The Ridge (The Ridge)       | 0 / 4 | 60    | 15    |    | 100% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer               | Team / Church               | Total | Avg   | QO | Q%   |
+|---------:|-----------------------|-----------------------------|------:|------:|---:|-----:|
+| 1        | Josiah Minick         | Buzz Hogs (River of Life)   | 555   | 138.8 | 4  | 86%  |
+| 2        | Carly Shalter         | McArthur (McArthur)         | 245   | 61.3  |    | 93%  |
+| 3        | Kayden Johnson        | Bethel (Bethel)             | 200   | 50    | 1  | 94%  |
+| 4        | Noah Brady            | Bethel (Bethel)             | 190   | 47.5  |    | 92%  |
+| 5        | Jayden Maris          | Change Point (Change Point) | 170   | 42.5  |    | 83%  |
+| 6        | Grace Parnell         | Buzz Hogs (River of Life)   | 150   | 37.5  | 1  | 74%  |
+| 7        | Karter Ballard        | McArthur (McArthur)         | 135   | 33.8  | 1  | 79%  |
+| 8        | Joshua Clark          | McArthur (McArthur)         | 130   | 32.5  |    | 100% |
+| 9        | Liam Wiese            | Change Point (Change Point) | 75    | 18.8  | 1  | 87%  |
+| 10       | Skyla Cope            | The Ridge (The Ridge)       | 30    | 7.5   |    | 100% |
+| **\*10** | Bri Rasdon            | Buzz Hogs (River of Life)   | 30    | 7.5   |    | 100% |
+| **\*10** | Kirsten Boyer         | The Ridge (The Ridge)       | 30    | 7.5   |    | 100% |
+| 11       | Allie Wiese           | Change Point (Change Point) | 25    | 6.3   |    | 75%  |
+| 12       | Kayden Moore          | Bethel (Bethel)             | 5     | 1.3   |    | 40%  |
+| 13       | Clayton Ballard       | McArthur (McArthur)         | 0     |       |    |      |
+| **\*13** | Jordyn Smith          | Bethel (Bethel)             | 0     |       |    |      |
+| **\*13** | Isaac Dave            | Bethel (Bethel)             | 0     |       |    |      |
+| **\*13** | Mikaela Herbert       | Bethel (Bethel)             | 0     |       |    |      |
+| **\*13** | Kayden Johnson        | Bethel (Bethel)             | 0     |       |    |      |
+| **\*13** | Nevaeh Watson         | The Ridge (The Ridge)       | 0     |       |    |      |
+| **\*13** | Brooklyn Duggins      | Buzz Hogs (River of Life)   | 0     |       |    |      |
+| **\*13** | Caleb Hoofman         | Buzz Hogs (River of Life)   | 0     |       |    |      |
+| **\*13** | Reece Ann Hall-Folsom | Buzz Hogs (River of Life)   | 0     |       |    |      |
 

--- a/_pages/jbq/2021/regionals/north-central.md
+++ b/_pages/jbq/2021/regionals/north-central.md
@@ -125,3 +125,43 @@ menubar_toc_static:
 | **\*18** | Isabella Millard  | Sparta Salt & Light - New Life Assembly of God (New Life Assembly of God)   | 0     |      |    |      |
 | **\*18** | Eiliyah Millard   | Sparta Salt & Light - New Life Assembly of God (New Life Assembly of God)   | 0     |      |    |      |
 | **\*18** | Libby Meyer       | Sparta Salt & Light - New Life Assembly of God (New Life Assembly of God)   | 0     |      |    |      |
+
+## Silver (Day 2)
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                                  | W/L   | Total | Avg   | QO | Q%  |
+|----:|--------------------------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Burning Hearts Church (Fargo) #1 (Burning Hearts Church)                       | 3 / 0 | 475   | 158.3 | 2  | 76% |
+| 2.0 | Life Assemblies of God Church (Maple Grove) #1 (Life Assemblies of God Church) | 2 / 1 | 530   | 176.6 | 1  | 81% |
+| 3.0 | Oak Creek Assembly of God (Oak Creek) #1 (Oak Creek Assembly of God)           | 1 / 2 | 455   | 151.6 | 1  | 77% |
+| 4.0 | Renew Church (Two Rivers) #1 (Renew Church)                                    | 0 / 3 | 90    | 30    |    | 55% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                                                  | Total | Avg   | QO | Q%   |
+|---------:|-------------------|--------------------------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Preston Caylor    | Life Assemblies of God Church (Maple Grove) #1 (Life Assemblies of God Church) | 275   | 91.7  | 1  | 81%  |
+| 2        | Lucas Mank        | Oak Creek Assembly of God (Oak Creek) #1 (Oak Creek Assembly of God)           | 235   | 78.3  | 1  | 83%  |
+| 3        | Ope Alabi         | Burning Hearts Church (Fargo) #1 (Burning Hearts Church)                       | 220   | 73.3  | 2  | 89%  |
+| 4        | Ty Glanzer        | Burning Hearts Church (Fargo) #1 (Burning Hearts Church)                       | 160   | 53.3  |    | 71%  |
+| 5        | Kai Doboszenski   | Life Assemblies of God Church (Maple Grove) #1 (Life Assemblies of God Church) | 115   | 38.3  |    | 74%  |
+| 6        | Roman Doboszenski | Life Assemblies of God Church (Maple Grove) #1 (Life Assemblies of God Church) | 110   | 36.7  |    | 100% |
+| **\*6**  | Greyson Wootton   | Oak Creek Assembly of God (Oak Creek) #1 (Oak Creek Assembly of God)           | 110   | 36.7  |    | 70%  |
+| 7        | Jason Gleason     | Oak Creek Assembly of God (Oak Creek) #1 (Oak Creek Assembly of God)           | 95    | 31.7  |    | 91%  |
+| 8        | Jacob Wichlacz    | Renew Church (Two Rivers) #1 (Renew Church)                                    | 85    | 28.3  |    | 69%  |
+| 9        | Kyler Hodgson     | Burning Hearts Church (Fargo) #1 (Burning Hearts Church)                       | 60    | 20    |    | 100% |
+| 10       | Tate Glanzer      | Burning Hearts Church (Fargo) #1 (Burning Hearts Church)                       | 40    | 13.3  |    | 50%  |
+| 11       | Lucas Araujo      | Oak Creek Assembly of God (Oak Creek) #1 (Oak Creek Assembly of God)           | 30    | 10    |    | 100% |
+| **\*11** | Daniel McElfresh  | Life Assemblies of God Church (Maple Grove) #1 (Life Assemblies of God Church) | 30    | 10    |    | 100% |
+| 12       | Chloe Siebold     | Renew Church (Two Rivers) #1 (Renew Church)                                    | 25    | 8.3   |    | 66%  |
+| 13       | Natalie Salinas   | Renew Church (Two Rivers) #1 (Renew Church)                                    | 20    | 6.7   |    | 100% |
+| 14       | Mercy Dahlmeier   | Burning Hearts Church (Fargo) #1 (Burning Hearts Church)                       | 0     |       |    |      |
+| **\*14** | Aveah Caylor      | Life Assemblies of God Church (Maple Grove) #1 (Life Assemblies of God Church) | 0     |       |    |      |
+| 15       | Serah Schultes    | Burning Hearts Church (Fargo) #1 (Burning Hearts Church)                       | -5    | -1.7  |    |      |
+| 16       | Ryder Wootton     | Oak Creek Assembly of God (Oak Creek) #1 (Oak Creek Assembly of God)           | -15   | -5    |    |      |
+| 17       | Katelyn Wichlacz  | Renew Church (Two Rivers) #1 (Renew Church)                                    | -40   | -13.3 |    | 25%  |

--- a/_pages/jbq/2021/tournaments/corona-classic.md
+++ b/_pages/jbq/2021/tournaments/corona-classic.md
@@ -1,0 +1,50 @@
+---
+layout: page
+title: "2021 Corona Classic"
+permalink: /jbq/2021/tournaments/corona-classic/
+date: "2021-01-31"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2021 Season
+    link: /jbq/2021/
+    icon: fas fa-home
+---
+
+## Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                 | W/L   | Total | Avg   | QO | Q%  |
+|----:|-----------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Spurs Silver (First AGSA)                     | 7 / 2 | 1540  | 171.1 | 7  | 77% |
+| 2.0 | Keepers of the Command (First @ Firewheel AG) | 6 / 3 | 1430  | 158.9 | 4  | 72% |
+| 3.0 | Super Smash Bros (The Oaks Fellowship)        | 4 / 5 | 1265  | 140.5 | 5  | 86% |
+| 4.0 | Spurs Black (First AGSA)                      | 1 / 8 | 895   | 99.4  | 5  | 67% |
+
+## Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                                 | Total | Avg   | QO | Q%   |
+|---------:|----------------------|-----------------------------------------------|------:|------:|---:|-----:|
+| 1        | Timothy Samuel       | Keepers of the Command (First @ Firewheel AG) | 990   | 110   | 3  | 85%  |
+| 2        | Josiah Lapusan       | Super Smash Bros (The Oaks Fellowship)        | 950   | 105.6 | 5  | 82%  |
+| 3        | Caris Thomas         | Spurs Silver (First AGSA)                     | 845   | 93.9  | 2  | 80%  |
+| 4        | Elizabeth Walker     | Spurs Black (First AGSA)                      | 380   | 42.2  | 2  | 67%  |
+| 5        | Meredith Haley       | Spurs Silver (First AGSA)                     | 370   | 41.1  | 2  | 71%  |
+| 6        | Janessa Walker       | Spurs Black (First AGSA)                      | 330   | 36.7  | 3  | 62%  |
+| 7        | Luke Thomas          | Spurs Silver (First AGSA)                     | 325   | 36.1  | 3  | 79%  |
+| 8        | Jayden Ramesh        | Keepers of the Command (First @ Firewheel AG) | 285   | 31.7  | 1  | 74%  |
+| 9        | Judah Guntle         | Spurs Black (First AGSA)                      | 185   | 20.6  |    | 78%  |
+| 10       | Nathan Colley        | Super Smash Bros (The Oaks Fellowship)        | 160   | 17.8  |    | 100% |
+| 11       | John Colley          | Super Smash Bros (The Oaks Fellowship)        | 145   | 16.1  |    | 88%  |
+| 12       | James Cornish        | Keepers of the Command (First @ Firewheel AG) | 95    | 10.6  |    | 71%  |
+| 13       | Simon Solomon        | Keepers of the Command (First @ Firewheel AG) | 60    | 6.7   |    | 47%  |
+| 14       | Daniel Bartholomew   | Super Smash Bros (The Oaks Fellowship)        | 10    | 1.1   |    | 99%  |
+| 15       | Grace Bartholomew    | Super Smash Bros (The Oaks Fellowship)        | 0     |       |    |      |
+| **\*15** | Chizaram Echefu      | Keepers of the Command (First @ Firewheel AG) | 0     |       |    |      |
+| **\*15** | Chizaram Iwuogaranya | Keepers of the Command (First @ Firewheel AG) | 0     |       |    |      |
+| **\*15** | Isabella Darko       | Keepers of the Command (First @ Firewheel AG) | 0     |       |    |      |
+

--- a/_pages/jbq/2021/tournaments/john-crabtree.md
+++ b/_pages/jbq/2021/tournaments/john-crabtree.md
@@ -1,0 +1,55 @@
+---
+layout: page
+title: "John Crabtree Tournament"
+permalink: /jbq/2021/tournaments/john-crabtree/
+date: "2021-02-27"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2021 Season
+    link: /jbq/2021/
+    icon: fas fa-home
+---
+
+## Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                      | W/L    | Total | Avg   | QO | Q%  |
+|----:|----------------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0 | Naperville, IL (Calvary Church)                    | 12 / 0 | 2405  | 200.4 | 12 | 83% |
+| 2.0 | Shelby Township, MI (R) (Lakeside Assembly of God) | 8 / 4  | 2095  | 174.6 | 11 | 85% |
+| 3.0 | Holt, MI (Young Bereans)                           | 7 / 5  | 1960  | 163.3 | 7  | 81% |
+| 4.0 | Lexington, KY (First Assembly of God)              | 2 / 10 | 1045  | 87.1  | 4  | 66% |
+| 5.0 | Shelby Township, MI (F) (Lakeside Assembly of God) | 1 / 11 | 945   | 78.7  | 2  | 75% |
+
+## Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                                      | Total | Avg   | QO | Q%  |
+|---------:|----------------------|----------------------------------------------------|------:|------:|---:|----:|
+| 1        | Angel Egbendewe      | Holt, MI (Young Bereans)                           | 1405  | 117.1 | 6  | 90% |
+| 2        | Pierce Stevens       | Naperville, IL (Calvary Church)                    | 790   | 65.8  | 2  | 92% |
+| 3        | Roshan Padmanabhan   | Shelby Township, MI (R) (Lakeside Assembly of God) | 735   | 61.3  | 10 | 86% |
+| 4        | James Barney         | Shelby Township, MI (R) (Lakeside Assembly of God) | 685   | 57.1  |    | 86% |
+| 5        | Joshua James         | Shelby Township, MI (R) (Lakeside Assembly of God) | 680   | 56.7  | 1  | 84% |
+| 6        | Jayden Suresh        | Naperville, IL (Calvary Church)                    | 630   | 52.5  | 8  | 86% |
+| 7        | Samantha Householder | Shelby Township, MI (F) (Lakeside Assembly of God) | 565   | 47.1  | 1  | 82% |
+| 8        | Shekinah Biruduganti | Naperville, IL (Calvary Church)                    | 560   | 46.7  | 1  | 76% |
+| 9        | Croston McCracken    | Lexington, KY (First Assembly of God)              | 535   | 44.6  | 3  | 68% |
+| 10       | Amariah Galliers     | Lexington, KY (First Assembly of God)              | 510   | 42.5  | 1  | 63% |
+| 11       | Jaren Stepp          | Holt, MI (Young Bereans)                           | 290   | 24.2  | 1  | 66% |
+| 12       | Ariana Moussa        | Shelby Township, MI (F) (Lakeside Assembly of God) | 245   | 20.4  |    | 67% |
+| 13       | Mariel Parra         | Naperville, IL (Calvary Church)                    | 225   | 18.8  |    | 64% |
+| 14       | Elizabeth Siony      | Naperville, IL (Calvary Church)                    | 205   | 17.1  | 1  | 87% |
+| 15       | Jemma Stepp          | Holt, MI (Young Bereans)                           | 155   | 12.9  |    | 92% |
+| 16       | Luke Householder     | Shelby Township, MI (F) (Lakeside Assembly of God) | 135   | 11.3  | 1  | 79% |
+| 17       | Mara Pinckney        | Holt, MI (Young Bereans)                           | 110   | 9.2   |    | 87% |
+| 18       | Aubrey Salyer        | Lexington, KY (First Assembly of God)              | 0     |       |    |     |
+| **\*18** | Jed Horn             | Lexington, KY (First Assembly of God)              | 0     |       |    |     |
+| **\*18** | Adelaide Blevins     | Holt, MI (Young Bereans)                           | 0     |       |    |     |
+| **\*18** | Evan Pinckney        | Holt, MI (Young Bereans)                           | 0     |       |    |     |
+| 19       | Briana Halley        | Shelby Township, MI (R) (Lakeside Assembly of God) | -5    | -.4   |    |     |
+

--- a/_pages/jbq/2021/tournaments/snow-bowl.md
+++ b/_pages/jbq/2021/tournaments/snow-bowl.md
@@ -12,41 +12,6 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## PeeWee Division
-
-### Teams
-
-*2 way ties broken by head to head, 3+ way ties broken by points*
-
-| #   | Team / Church                                        | W/L   | Total | Avg | QO | Q%   |
-|----:|------------------------------------------------------|-------|------:|----:|---:|-----:|
-| 1.0 | David's Army (Encounter Church)                      | 5 / 0 | 555   | 111 | 5  | 89%  |
-| 2.0 | Merlin Mission (Camelot)                             | 0 / 3 | 240   | 80  |    | 100% |
-| 3.0 | Mission Possible (Mountain Creek Community Church)   | 2 / 3 | 340   | 68  | 4  | 78%  |
-| 4.0 | Mountain Movers #3 (Shepherd's Valley Cowboy Church) | 2 / 3 | 270   | 54  | 1  | 79%  |
-
-### Individuals
-
-*Ties broken by Average Points then Total Quiz Outs*
-
-| #  | Quizzer          | Team / Church                                        | Total | Avg  | QO | Q%   |
-|---:|------------------|------------------------------------------------------|------:|-----:|---:|-----:|
-| 1  | Cooper Gaston    | David's Army (Encounter Church)                      | 325   | 65   | 5  | 86%  |
-| 2  | Joseph Zeli      | Mission Possible (Mountain Creek Community Church)   | 275   | 55   | 3  | 84%  |
-| 3  | Caleb Nesterenko | David's Army (Encounter Church)                      | 165   | 33   |    | 94%  |
-| 4  | Jack             | Merlin Mission (Camelot)                             | 90    | 30   |    | 100% |
-| 5  | Annie            | Merlin Mission (Camelot)                             | 80    | 26.7 |    | 100% |
-| 6  | Rhyder Putman    | Mountain Movers #3 (Shepherd's Valley Cowboy Church) | 125   | 25   | 1  | 92%  |
-| 7  | Arthur           | Merlin Mission (Camelot)                             | 70    | 23.3 |    | 100% |
-| 8  | Austin Thomas    | Mountain Movers #3 (Shepherd's Valley Cowboy Church) | 75    | 15   |    | 75%  |
-| 9  | Issac Rodriguez  | Mission Possible (Mountain Creek Community Church)   | 70    | 14   | 1  | 67%  |
-| 10 | Layla Gaston     | David's Army (Encounter Church)                      | 65    | 13   |    | 87%  |
-| 11 | Colin Bastian    | Mountain Movers #3 (Shepherd's Valley Cowboy Church) | 60    | 12   |    | 67%  |
-| 12 | Bella Bastian    | Mountain Movers #3 (Shepherd's Valley Cowboy Church) | 10    | 2    |    | 99%  |
-| 13 | Hope Zeli        | Mission Possible (Mountain Creek Community Church)   | 0     |      |    |      |
-| 14 | Alyssa Gonzales  | Mission Possible (Mountain Creek Community Church)   | -5    | -1   |    |      |
-
-
 ## Older Division
 
 ### Teams
@@ -86,3 +51,71 @@ menubar_toc_static:
 | 15       | Cymon Bastian      | Mountain Movers #2 (Shepherd's Valley Cowboy Church) | -5    | -.8   |    | 43%  |
 | 16       | Angel Lawson       | Mountain Movers #1 (Shepherd's Valley Cowboy Church) | -20   | -3.3  |    | 40%  |
 
+
+## Beginner Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                     | W/L   | Total | Avg   | QO | Q%   |
+|----:|---------------------------------------------------|-------|------:|------:|---:|-----:|
+| 1.0 | God's Mini Helpers (Oaks Church)                  | 5 / 1 | 680   | 113.3 | 6  | 78%  |
+| 2.0 | Royal Heirs (Oaks Church)                         | 4 / 2 | 830   | 138.3 | 8  | 91%  |
+| 3.0 | The Elected (Mountain Creek Community Church)     | 3 / 3 | 600   | 100   | 5  | 83%  |
+| 4.0 | Ghosts of the Christmas Present (Christmas Carol) | 0 / 6 | 330   | 55    |    | 100% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #  | Quizzer           | Team / Church                                     | Total | Avg  | QO | Q%   |
+|---:|-------------------|---------------------------------------------------|------:|-----:|---:|-----:|
+| 1  | Hannah Lapusan    | Royal Heirs (Oaks Church)                         | 560   | 93.3 | 6  | 92%  |
+| 2  | Noah Zeli         | The Elected (Mountain Creek Community Church)     | 375   | 62.5 | 5  | 85%  |
+| 3  | Raegan Wirth      | God's Mini Helpers (Oaks Church)                  | 375   | 62.5 | 3  | 85%  |
+| 4  | Sarah Lapusan     | God's Mini Helpers (Oaks Church)                  | 270   | 45   | 3  | 70%  |
+| 5  | Abigail Lapusan   | Royal Heirs (Oaks Church)                         | 195   | 32.5 | 1  | 94%  |
+| 6  | Generosity        | Ghosts of the Christmas Present (Christmas Carol) | 140   | 23.3 |    | 100% |
+| 7  | Christmas Cheer   | Ghosts of the Christmas Present (Christmas Carol) | 100   | 16.7 |    | 100% |
+| 8  | Empathy           | Ghosts of the Christmas Present (Christmas Carol) | 90    | 15   |    | 100% |
+| 9  | Ethan Fajemirokun | The Elected (Mountain Creek Community Church)     | 85    | 14.2 |    | 82%  |
+| 10 | Violet Cano       | Royal Heirs (Oaks Church)                         | 75    | 12.5 | 1  | 80%  |
+| 11 | JD Rodriguez      | The Elected (Mountain Creek Community Church)     | 75    | 12.5 |    | 71%  |
+| 12 | Irene Ortiz       | The Elected (Mountain Creek Community Church)     | 70    | 11.7 |    | 100% |
+| 13 | Samantha Colley   | God's Mini Helpers (Oaks Church)                  | 35    | 5.8  |    | 80%  |
+
+
+## PeeWee Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                        | W/L   | Total | Avg | QO | Q%   |
+|----:|------------------------------------------------------|-------|------:|----:|---:|-----:|
+| 1.0 | David's Army (Encounter Church)                      | 5 / 0 | 555   | 111 | 5  | 89%  |
+| 2.0 | Merlin Mission (Camelot)                             | 0 / 3 | 240   | 80  |    | 100% |
+| 3.0 | Mission Possible (Mountain Creek Community Church)   | 2 / 3 | 340   | 68  | 4  | 78%  |
+| 4.0 | Mountain Movers #3 (Shepherd's Valley Cowboy Church) | 2 / 3 | 270   | 54  | 1  | 79%  |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #  | Quizzer          | Team / Church                                        | Total | Avg  | QO | Q%   |
+|---:|------------------|------------------------------------------------------|------:|-----:|---:|-----:|
+| 1  | Cooper Gaston    | David's Army (Encounter Church)                      | 325   | 65   | 5  | 86%  |
+| 2  | Joseph Zeli      | Mission Possible (Mountain Creek Community Church)   | 275   | 55   | 3  | 84%  |
+| 3  | Caleb Nesterenko | David's Army (Encounter Church)                      | 165   | 33   |    | 94%  |
+| 4  | Jack             | Merlin Mission (Camelot)                             | 90    | 30   |    | 100% |
+| 5  | Annie            | Merlin Mission (Camelot)                             | 80    | 26.7 |    | 100% |
+| 6  | Rhyder Putman    | Mountain Movers #3 (Shepherd's Valley Cowboy Church) | 125   | 25   | 1  | 92%  |
+| 7  | Arthur           | Merlin Mission (Camelot)                             | 70    | 23.3 |    | 100% |
+| 8  | Austin Thomas    | Mountain Movers #3 (Shepherd's Valley Cowboy Church) | 75    | 15   |    | 75%  |
+| 9  | Issac Rodriguez  | Mission Possible (Mountain Creek Community Church)   | 70    | 14   | 1  | 67%  |
+| 10 | Layla Gaston     | David's Army (Encounter Church)                      | 65    | 13   |    | 87%  |
+| 11 | Colin Bastian    | Mountain Movers #3 (Shepherd's Valley Cowboy Church) | 60    | 12   |    | 67%  |
+| 12 | Bella Bastian    | Mountain Movers #3 (Shepherd's Valley Cowboy Church) | 10    | 2    |    | 99%  |
+| 13 | Hope Zeli        | Mission Possible (Mountain Creek Community Church)   | 0     |      |    |      |
+| 14 | Alyssa Gonzales  | Mission Possible (Mountain Creek Community Church)   | -5    | -1   |    |      |

--- a/_pages/jbq/2022/districts/georgia.md
+++ b/_pages/jbq/2022/districts/georgia.md
@@ -1,0 +1,120 @@
+---
+layout: page
+title: "2022 Georgia District Finals"
+permalink: /jbq/2022/districts/georgia/
+date: "2022-03-05"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2022 Season
+    link: /jbq/2022/
+    icon: fas fa-home
+---
+
+## X Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                       | W/L   | Total | Avg   | QO | Q%  |
+|----:|---------------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Assembly of God Tabernacle (Assembly of God Tabernacle)             | 7 / 0 | 1445  | 206.4 | 4  | 91% |
+| 2.0 | Calvary Assembly Church of God - X (Calvary Assembly Church of God) | 6 / 1 | 1445  | 206.4 | 11 | 95% |
+| 3.0 | Chosen Generation (Atlanta Indian Prayer Fellowship)                | 5 / 2 | 865   | 123.6 | 8  | 89% |
+| 4.0 | Servants of the Lord (Trinity Church)                               | 3 / 4 | 240   | 34.3  |    | 89% |
+| 5.0 | Classical Conversations Quizzers (Classical Conversations)          | 2 / 5 | 340   | 48.6  | 1  | 90% |
+| 6.0 | Cornerstone Church of Cochran (Cornerstone Church of Cochran)       | 2 / 5 | 310   | 44.3  | 2  | 70% |
+| 7.0 | Stone Edge (Stone Edge Church)                                      | 2 / 5 | 310   | 44.3  | 1  | 68% |
+| 8.0 | God's Warrior's (Trinity Church)                                    | 1 / 6 | 135   | 19.3  |    | 92% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church                                                       | Total | Avg   | QO | Q%   |
+|---------:|--------------------|---------------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Joel Abraham       | Calvary Assembly Church of God - X (Calvary Assembly Church of God) | 750   | 107.1 | 6  | 97%  |
+| 2        | Winner Kpayizoun   | Assembly of God Tabernacle (Assembly of God Tabernacle)             | 730   | 104.3 | 2  | 97%  |
+| 3        | Jessy Stephen      | Chosen Generation (Atlanta Indian Prayer Fellowship)                | 540   | 77.1  | 6  | 97%  |
+| 4        | Jill Copeland      | Assembly of God Tabernacle (Assembly of God Tabernacle)             | 385   | 55    | 1  | 92%  |
+| 5        | Blessy Rajkumar    | Chosen Generation (Atlanta Indian Prayer Fellowship)                | 325   | 46.4  | 2  | 80%  |
+| 6        | Elijah Thomas      | Calvary Assembly Church of God - X (Calvary Assembly Church of God) | 290   | 41.4  | 2  | 96%  |
+| 7        | Benjamin Battaglia | Classical Conversations Quizzers (Classical Conversations)          | 290   | 41.4  | 1  | 95%  |
+| 8        | Joanne Shinu       | Calvary Assembly Church of God - X (Calvary Assembly Church of God) | 285   | 40.7  | 2  | 92%  |
+| 9        | Princess           | Stone Edge (Stone Edge Church)                                      | 235   | 33.6  | 1  | 62%  |
+| 10       | Kobe Roberts       | Cornerstone Church of Cochran (Cornerstone Church of Cochran)       | 215   | 30.7  | 2  | 83%  |
+| 11       | Sophia Fader       | Servants of the Lord (Trinity Church)                               | 185   | 26.4  |    | 92%  |
+| 12       | Carter Copeland    | Assembly of God Tabernacle (Assembly of God Tabernacle)             | 160   | 22.9  | 1  | 100% |
+| 13       | Austin Samuel      | Calvary Assembly Church of God - X (Calvary Assembly Church of God) | 120   | 17.1  | 1  | 92%  |
+| 14       | Karrington Roberts | Cornerstone Church of Cochran (Cornerstone Church of Cochran)       | 110   | 15.7  |    | 63%  |
+| 15       | Eden Beasley       | Stone Edge (Stone Edge Church)                                      | 75    | 10.7  |    | 82%  |
+| 16       | Cameron            | God's Warrior's (Trinity Church)                                    | 65    | 9.3   |    | 83%  |
+| **\*16** | Nile Evans         | Assembly of God Tabernacle (Assembly of God Tabernacle)             | 65    | 9.3   |    | 80%  |
+| 17       | Sam Heilman        | Servants of the Lord (Trinity Church)                               | 55    | 7.9   |    | 86%  |
+| **\*17** | Six Copeland       | Assembly of God Tabernacle (Assembly of God Tabernacle)             | 55    | 7.9   |    | 83%  |
+| 18       | Luke Heilman       | God's Warrior's (Trinity Church)                                    | 30    | 4.3   |    | 100% |
+| **\*18** | Cameron            | God's Warrior's (Trinity Church)                                    | 30    | 4.3   |    | 100% |
+| **\*18** | Kaitlin Dooley     | Classical Conversations Quizzers (Classical Conversations)          | 30    | 4.3   |    | 71%  |
+| **\*18** | Justis Futrell     | Assembly of God Tabernacle (Assembly of God Tabernacle)             | 30    | 4.3   |    | 67%  |
+| 19       | Aniyah Morris      | Assembly of God Tabernacle (Assembly of God Tabernacle)             | 20    | 2.9   |    | 100% |
+| **\*19** | Maggie Wagner      | Classical Conversations Quizzers (Classical Conversations)          | 20    | 2.9   |    | 100% |
+| 20       | Ethan Schatzberg   | God's Warrior's (Trinity Church)                                    | 10    | 1.4   |    | 99%  |
+| **\*20** | Jaiden Jarrell     | Cornerstone Church of Cochran (Cornerstone Church of Cochran)       | 10    | 1.4   |    | 99%  |
+| 21       | Yallarly Stephens  | Stone Edge (Stone Edge Church)                                      | 0     |       |    | 50%  |
+| **\*21** | Joel Abraham       | Calvary Assembly Church of God - X (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*21** | Elisha Santhosh    | Calvary Assembly Church of God - X (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*21** | Rufus Lejo         | Calvary Assembly Church of God - X (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*21** | Johan Harris       | Chosen Generation (Atlanta Indian Prayer Fellowship)                | 0     |       |    |      |
+| **\*21** | Aria Schatzberg    | God's Warrior's (Trinity Church)                                    | 0     |       |    |      |
+| **\*21** | Aria               | Servants of the Lord (Trinity Church)                               | 0     |       |    |      |
+| **\*21** | Cameron            | Servants of the Lord (Trinity Church)                               | 0     |       |    |      |
+| **\*21** | Cameron Fader      | Servants of the Lord (Trinity Church)                               | 0     |       |    |      |
+| **\*21** | Laila Jackson      | Stone Edge (Stone Edge Church)                                      | 0     |       |    |      |
+| **\*21** | Hannah Jarrell     | Cornerstone Church of Cochran (Cornerstone Church of Cochran)       | 0     |       |    |      |
+| **\*21** | Madeline Pitts     | Classical Conversations Quizzers (Classical Conversations)          | 0     |       |    |      |
+| **\*21** | Brody Barcus       | Classical Conversations Quizzers (Classical Conversations)          | 0     |       |    |      |
+| 22       | Jace Jarrell       | Cornerstone Church of Cochran (Cornerstone Church of Cochran)       | -25   | -3.6  |    |      |
+
+## I Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                                        | W/L   | Total | Avg   | QO | Q%   |
+|----:|----------------------------------------------------------------------|-------|------:|------:|---:|-----:|
+| 1.0 | Anointed Ones (Atlanta Indian Prayer Fellowship)                     | 4 / 0 | 1140  | 284.9 | 9  | 92%  |
+| 2.0 | Atlanta Tamil Church (Norcross) - A (Atlanta Tamil Church)           | 3 / 1 | 595   | 148.7 | 5  | 82%  |
+| 3.0 | Signet Ring - B (Atlanta Indian Prayer Fellowship)                   | 2 / 2 | 580   | 145   | 5  | 89%  |
+| 4.0 | Calvary Assembly Church of God - B1 (Calvary Assembly Church of God) | 1 / 3 | 495   | 123.7 | 3  | 96%  |
+| 5.0 | Calvary Assembly Church of God - B2 (Calvary Assembly Church of God) | 0 / 4 | 210   | 52.5  | 2  | 100% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                  | Team / Church                                                        | Total | Avg   | QO | Q%   |
+|---------:|--------------------------|----------------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Adrin Joseph             | Anointed Ones (Atlanta Indian Prayer Fellowship)                     | 510   | 127.5 | 4  | 87%  |
+| 2        | Davis Devadasan          | Atlanta Tamil Church (Norcross) - A (Atlanta Tamil Church)           | 340   | 85    | 3  | 81%  |
+| 3        | Alwin Stephen            | Anointed Ones (Atlanta Indian Prayer Fellowship)                     | 325   | 81.3  | 1  | 89%  |
+| 4        | Johanna Shinu            | Calvary Assembly Church of God - B1 (Calvary Assembly Church of God) | 320   | 80    | 2  | 100% |
+| 5        | Steven Daniel            | Signet Ring - B (Atlanta Indian Prayer Fellowship)                   | 300   | 75    | 3  | 90%  |
+| 6        | Joash Prince             | Signet Ring - B (Atlanta Indian Prayer Fellowship)                   | 280   | 70    | 2  | 87%  |
+| 7        | Harshish Jayakrishnan    | Anointed Ones (Atlanta Indian Prayer Fellowship)                     | 180   | 45    | 3  | 100% |
+| 8        | Olivia Thomas            | Calvary Assembly Church of God - B2 (Calvary Assembly Church of God) | 180   | 45    | 2  | 100% |
+| 9        | Mrithun Renat Sriraman   | Atlanta Tamil Church (Norcross) - A (Atlanta Tamil Church)           | 145   | 36.3  | 1  | 92%  |
+| 10       | Harshine Jayakrishnan    | Anointed Ones (Atlanta Indian Prayer Fellowship)                     | 125   | 31.3  | 1  | 92%  |
+| **\*10** | Joanna Varghese          | Calvary Assembly Church of God - B1 (Calvary Assembly Church of God) | 125   | 31.3  | 1  | 90%  |
+| 11       | Evangelin Grace Sheen    | Atlanta Tamil Church (Norcross) - A (Atlanta Tamil Church)           | 100   | 25    | 1  | 78%  |
+| 12       | Aiden Samuel             | Calvary Assembly Church of God - B1 (Calvary Assembly Church of God) | 50    | 12.5  |    | 100% |
+| 13       | Jeremy Mathew            | Calvary Assembly Church of God - B2 (Calvary Assembly Church of God) | 30    | 7.5   |    | 100% |
+| 14       | Mrinalika Renee Sriraman | Atlanta Tamil Church (Norcross) - A (Atlanta Tamil Church)           | 10    | 2.5   |    | 66%  |
+| 15       | Britney Martin           | Anointed Ones (Atlanta Indian Prayer Fellowship)                     | 0     |       |    |      |
+| **\*15** | Gaius Lejo               | Calvary Assembly Church of God - B1 (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*15** | Hannah                   | Calvary Assembly Church of God - B2 (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*15** | Amy Mathew               | Calvary Assembly Church of God - B2 (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*15** | Pheba Kumar              | Calvary Assembly Church of God - B2 (Calvary Assembly Church of God) | 0     |       |    |      |
+| **\*15** | Jaedon Andrew            | Signet Ring - B (Atlanta Indian Prayer Fellowship)                   | 0     |       |    |      |

--- a/_pages/jbq/2022/districts/kansas.md
+++ b/_pages/jbq/2022/districts/kansas.md
@@ -92,3 +92,35 @@ menubar_toc_static:
 | **\*20** | Gavin MacKinney   | FC Watts (Faith Chapel)         | 0     |      |    |      |
 | 21       | Callie Ochs       | Mac Attack (Great Bend)         | -5    | -.8  |    |      |
 
+
+## B Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church              | W/L   | Total | Avg  | QO | Q%  |
+|----:|----------------------------|-------|------:|-----:|---:|----:|
+| 1.0 | 5 Buzzketeers (Great Bend) | 4 / 0 | 440   | 110  | 7  | 79% |
+| 2.0 | Boom Baby (Chanute)        | 1 / 3 | 175   | 43.7 | 1  | 67% |
+| 3.0 | FC Sparks (Faith Chapel)   | 1 / 3 | 115   | 28.7 |    | 81% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #       | Quizzer           | Team / Church              | Total | Avg  | QO | Q%  |
+|--------:|-------------------|----------------------------|------:|-----:|---:|----:|
+| 1       | Emmett Mawhirter  | 5 Buzzketeers (Great Bend) | 225   | 56.3 | 4  | 87% |
+| 2       | William Moeder    | 5 Buzzketeers (Great Bend) | 185   | 46.3 | 3  | 76% |
+| 3       | Joshua McMahan    | Boom Baby (Chanute)        | 145   | 36.3 | 1  | 93% |
+| 4       | Matthew Voelker   | FC Sparks (Faith Chapel)   | 105   | 26.3 |    | 92% |
+| 5       | Samuel McMahan    | Boom Baby (Chanute)        | 30    | 7.5  |    | 44% |
+| 6       | Rilynn Bennett    | FC Sparks (Faith Chapel)   | 15    | 3.8  |    | 66% |
+| 7       | Autumn Halzle     | 5 Buzzketeers (Great Bend) | 10    | 2.5  |    | 99% |
+| **\*7** | Carter McKiearnan | 5 Buzzketeers (Great Bend) | 10    | 2.5  |    | 66% |
+| **\*7** | Ryker Halzle      | 5 Buzzketeers (Great Bend) | 10    | 2.5  |    | 50% |
+| 8       | Abbie Allen       | Boom Baby (Chanute)        | 0     |      |    |     |
+| **\*8** | Andi Weilert      | Boom Baby (Chanute)        | 0     |      |    |     |
+| 9       | Emersynn Bennett  | FC Sparks (Faith Chapel)   | -5    | -1.3 |    |     |
+

--- a/_pages/jbq/2022/districts/north-carolina.md
+++ b/_pages/jbq/2022/districts/north-carolina.md
@@ -12,8 +12,9 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
+## Experienced Division
 
-## Teams
+### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points*
 
@@ -26,7 +27,7 @@ menubar_toc_static:
 | 5.0 | Wilmington Warriors A (New Hanover Church) | 1 / 4 | 540   | 108 | 1  | 70% |
 | 6.0 | Askewville ( )                             | 0 / 5 | 140   | 28  |    | 73% |
 
-## Individuals
+### Individuals
 
 *Ties broken by Average Points then Total Quiz Outs*
 
@@ -57,3 +58,39 @@ menubar_toc_static:
 | 22       | Leah Salazar       | Greater Life (Greater Life)                | -5    | -1  |    |      |
 | 23       | Olivia Bazemore    | Askewville ( )                             | -10   | -2  |    |      |
 
+## Novice Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church               | W/L   | Total | Avg   | QO | Q%  |
+|----:|-----------------------------|-------|------:|------:|---:|----:|
+| 1.1 | Genesis B (Calvary Church)  | 5 / 1 | 1040  | 173.3 | 9  | 86% |
+| 2.1 | CICF Team Cross (CICF)      | 5 / 1 | 935   | 155.8 | 1  | 81% |
+| 3.0 | CICF Royals (CICF)          | 2 / 4 | 760   | 126.6 | 4  | 82% |
+| 4.0 | Rocky Mount B (Rocky Mount) | 0 / 6 | 230   | 38.3  |    | 80% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer            | Team / Church               | Total | Avg  | QO | Q%   |
+|---------:|--------------------|-----------------------------|------:|-----:|---:|-----:|
+| 1        | Timothy Anandkumar | CICF Team Cross (CICF)      | 495   | 82.5 | 1  | 87%  |
+| 2        | Naysa Rapaka       | Genesis B (Calvary Church)  | 465   | 77.5 | 3  | 91%  |
+| 3        | Jovan Abraham      | CICF Royals (CICF)          | 450   | 75   | 2  | 85%  |
+| 4        | Nikitha Vanguri    | Genesis B (Calvary Church)  | 340   | 56.7 | 4  | 79%  |
+| 5        | Aanya Boopathi     | Genesis B (Calvary Church)  | 235   | 39.2 | 2  | 87%  |
+| 6        | Karunia Thomas     | CICF Royals (CICF)          | 220   | 36.7 | 2  | 79%  |
+| 7        | Jonas Hall         | Rocky Mount B (Rocky Mount) | 210   | 35   |    | 78%  |
+| 8        | Sanay Kantimahanti | CICF Team Cross (CICF)      | 185   | 30.8 |    | 72%  |
+| 9        | Josh Winsley       | CICF Team Cross (CICF)      | 175   | 29.2 |    | 79%  |
+| 10       | Sahas Kantimahanti | CICF Team Cross (CICF)      | 85    | 14.2 |    | 100% |
+| 11       | Jolennah Raj       | CICF Royals (CICF)          | 50    | 8.3  |    | 100% |
+| 12       | Rafael Gershom     | CICF Royals (CICF)          | 45    | 7.5  |    | 75%  |
+| 13       | Simon Hall         | Rocky Mount B (Rocky Mount) | 10    | 1.7  |    | 99%  |
+| **\*13** | Faith Jackson      | Rocky Mount B (Rocky Mount) | 10    | 1.7  |    | 99%  |
+| 14       | Myasia             | Rocky Mount B (Rocky Mount) | 0     |      |    |      |
+| **\*14** | Rufus Joel         | CICF Royals (CICF)          | 0     |      |    |      |
+| **\*14** | Shravya Maddala    | Genesis B (Calvary Church)  | 0     |      |    |      |

--- a/_pages/jbq/2022/districts/northwest.md
+++ b/_pages/jbq/2022/districts/northwest.md
@@ -1,0 +1,141 @@
+---
+layout: page
+title: "2022 Northwest District Finals"
+permalink: /jbq/2022/districts/northwest/
+date: "2022-03-12"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2022 Season
+    link: /jbq/2022/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
+
+| #       | Team / Church                                 | W/L   | W%  | Total | Avg   | QO | Q%  |
+|--------:|-----------------------------------------------|-------|----:|------:|------:|---:|----:|
+| 1       | Cedar Park A1 (Cedar Park Assembly of God)    | 4 / 0 | 67% | 910   | 151.7 | 1  | 80% |
+| 2       | BNC A - Lions (Bellevue Neighborhood Church)  | 1 / 3 | 17% | 365   | 60.8  |    | 72% |
+| **\*2** | BNC A - Eagles (Bellevue Neighborhood Church) | 1 / 3 | 17% | 330   | 55    |    | 67% |
+
+### Individuals
+
+*Ties broken by Average Points then by Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                 | Total | Avg  | QO | Q%   |
+|---------:|-------------------|-----------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Jonathan Zuo      | Cedar Park A1 (Cedar Park Assembly of God)    | 395   | 65.8 |    | 85%  |
+| 2        | Timothy Liu       | Cedar Park A1 (Cedar Park Assembly of God)    | 355   | 59.2 | 1  | 95%  |
+| 3        | Jeremy Ubbala     | BNC A - Eagles (Bellevue Neighborhood Church) | 130   | 21.7 |    | 100% |
+| 4        | Sannidhi Tammala  | BNC A - Lions (Bellevue Neighborhood Church)  | 120   | 20   |    | 70%  |
+| 5        | Stephen Bandaru   | BNC A - Lions (Bellevue Neighborhood Church)  | 115   | 19.2 |    | 64%  |
+| 6        | Yavin Mokana      | BNC A - Eagles (Bellevue Neighborhood Church) | 100   | 16.7 |    | 67%  |
+| 7        | Ethan Bantu       | BNC A - Lions (Bellevue Neighborhood Church)  | 80    | 13.3 |    | 71%  |
+| **\*7**  | Rachel Ranjith    | BNC A - Eagles (Bellevue Neighborhood Church) | 80    | 13.3 |    | 71%  |
+| 8        | Isaiah English    | Cedar Park A1 (Cedar Park Assembly of God)    | 70    | 11.7 |    | 62%  |
+| 9        | Josiah Raj Kallem | BNC A - Lions (Bellevue Neighborhood Church)  | 50    | 8.3  |    | 100% |
+| 10       | Daniel Li         | Cedar Park A1 (Cedar Park Assembly of God)    | 45    | 7.5  |    | 83%  |
+| **\*10** | Stephen Zuo       | Cedar Park A1 (Cedar Park Assembly of God)    | 45    | 7.5  |    | 67%  |
+| 11       | Micah Gallo       | BNC A - Eagles (Bellevue Neighborhood Church) | 20    | 3.3  |    | 50%  |
+
+
+## B Division
+
+### Teams
+
+*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
+
+| # | Team / Church                                 | W/L   | W%   | Total | Avg  | QO | Q%  |
+|--:|-----------------------------------------------|-------|-----:|------:|-----:|---:|----:|
+| 1 | Deeper B1 (Deeper Church)                     | 6 / 0 | 100% | 1140  | 190  | 8  | 83% |
+| 2 | BNC B - Ravens (Bellevue Neighborhood Church) | 4 / 2 | 67%  | 550   | 91.7 | 4  | 82% |
+| 3 | Kelso Bombers (Kelso Christian Assembly)      | 2 / 4 | 33%  | 375   | 62.5 |    | 91% |
+| 4 | Deeper B2 (Deeper Church)                     | 0 / 6 |      | 205   | 34.2 |    | 61% |
+
+### Individuals
+
+*Ties broken by Average Points then by Total Quiz Outs*
+
+| #        | Quizzer         | Team / Church                                 | Total | Avg  | QO | Q%   |
+|---------:|-----------------|-----------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Silas Nelson    | Deeper B1 (Deeper Church)                     | 540   | 90   | 4  | 81%  |
+| 2        | Jessica Amarelo | BNC B - Ravens (Bellevue Neighborhood Church) | 470   | 78.3 | 4  | 80%  |
+| 3        | David Mobley    | Deeper B1 (Deeper Church)                     | 425   | 70.8 | 4  | 93%  |
+| 4        | Charlotte Lyons | Kelso Bombers (Kelso Christian Assembly)      | 235   | 39.2 |    | 92%  |
+| 5        | Judah Westcott  | Deeper B1 (Deeper Church)                     | 175   | 29.2 |    | 73%  |
+| 6        | Zander Lyons    | Kelso Bombers (Kelso Christian Assembly)      | 140   | 23.3 |    | 88%  |
+| 7        | Makayla McAleer | Deeper B2 (Deeper Church)                     | 120   | 20   |    | 89%  |
+| 8        | Emma Gallo      | BNC B - Ravens (Bellevue Neighborhood Church) | 50    | 8.3  |    | 86%  |
+| 9        | Sage Nelson     | Deeper B2 (Deeper Church)                     | 40    | 6.7  |    | 100% |
+| 10       | Zoey Amarelo    | BNC B - Ravens (Bellevue Neighborhood Church) | 30    | 5    |    | 100% |
+| 11       | Joiya Westcott  | Deeper B2 (Deeper Church)                     | 25    | 4.2  |    | 75%  |
+| **\*11** | Josiah Westcott | Deeper B2 (Deeper Church)                     | 25    | 4.2  |    | 44%  |
+| 12       | Ally Larson     | BNC B - Ravens (Bellevue Neighborhood Church) | 0     |      |    |      |
+| **\*12** | Emma Earle      | Kelso Bombers (Kelso Christian Assembly)      | 0     |      |    |      |
+
+
+## C Division
+
+### Teams
+
+*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
+
+| # | Team / Church                                   | W/L   | W%  | Total | Avg   | QO | Q%  |
+|--:|-------------------------------------------------|-------|----:|------:|------:|---:|----:|
+| 1 | Family Life #3 (Family Life Community Church)   | 5 / 1 | 71% | 1070  | 152.9 | 9  | 88% |
+| 2 | Family Life #2 (Family Life Community Church)   | 5 / 1 | 71% | 935   | 133.6 | 7  | 73% |
+| 3 | Cedar Park C1 (Cedar Park Assembly of God)      | 4 / 2 | 57% | 1095  | 156.4 | 6  | 89% |
+| 4 | BCN C - Leopards (Bellevue Neighborhood Church) | 4 / 2 | 57% | 825   | 117.9 | 3  | 73% |
+| 5 | Newhope #1 (Newhope)                            | 3 / 3 | 43% | 805   | 115   | 4  | 77% |
+| 6 | Family Life #1 (Family Life Community Church)   | 4 / 3 | 57% | 1085  | 155   | 6  | 76% |
+| 7 | BNC C - Bears (Bellevue Neighborhood Church)    | 2 / 4 | 29% | 660   | 94.3  | 3  | 95% |
+| 8 | Deeper C1 (Deeper Church)                       | 1 / 5 | 14% | 335   | 47.9  | 1  | 67% |
+| 9 | Kelso Seekers (Kelso Christian Assembly)        | 0 / 7 |     | 75    | 10.7  |    | 65% |
+
+### Individuals
+
+*Ties broken by Average Points then by Total Quiz Outs*
+
+| #        | Quizzer                  | Team / Church                                   | Total | Avg  | QO | Q%   |
+|---------:|--------------------------|-------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Jadon Allen              | Family Life #3 (Family Life Community Church)   | 680   | 97.1 | 5  | 81%  |
+| 2        | Michael Mucheru          | Family Life #1 (Family Life Community Church)   | 665   | 95   | 4  | 78%  |
+| 3        | Daniel Monzon            | Family Life #2 (Family Life Community Church)   | 615   | 87.9 | 4  | 81%  |
+| 4        | Elia English             | Cedar Park C1 (Cedar Park Assembly of God)      | 615   | 87.9 | 3  | 93%  |
+| 5        | Isaac Balli              | BNC C - Bears (Bellevue Neighborhood Church)    | 520   | 74.3 | 3  | 93%  |
+| 6        | Isaac Velasquez          | Newhope #1 (Newhope)                            | 400   | 57.1 | 1  | 83%  |
+| 7        | Rishi Battagani          | BCN C - Leopards (Bellevue Neighborhood Church) | 385   | 55   | 2  | 75%  |
+| 8        | Caleb Day                | Cedar Park C1 (Cedar Park Assembly of God)      | 380   | 54.3 | 3  | 84%  |
+| 9        | Jazlyn Gaytan            | Family Life #3 (Family Life Community Church)   | 330   | 47.1 | 4  | 94%  |
+| 10       | Olivia Allen             | Family Life #1 (Family Life Community Church)   | 320   | 45.7 | 2  | 85%  |
+| 11       | Joel Ankit Bhima         | BCN C - Leopards (Bellevue Neighborhood Church) | 310   | 44.3 | 1  | 79%  |
+| 12       | Malachi Frisinger        | Newhope #1 (Newhope)                            | 230   | 32.9 | 2  | 71%  |
+| 13       | Jeremiah Monzon          | Family Life #2 (Family Life Community Church)   | 225   | 32.1 | 2  | 74%  |
+| 14       | Hannah Elizabeth Bhima   | BCN C - Leopards (Bellevue Neighborhood Church) | 170   | 24.3 |    | 92%  |
+| 15       | Easton Nolten            | Newhope #1 (Newhope)                            | 165   | 23.6 | 1  | 81%  |
+| 16       | Gideon Easter            | Deeper C1 (Deeper Church)                       | 145   | 20.7 | 1  | 62%  |
+| 17       | Romily Woolcott          | Family Life #2 (Family Life Community Church)   | 100   | 14.3 | 1  | 59%  |
+| 18       | Icker Gaytan             | Family Life #1 (Family Life Community Church)   | 100   | 14.3 |    | 60%  |
+| 19       | Emma Bringolf            | Deeper C1 (Deeper Church)                       | 95    | 13.6 |    | 78%  |
+| 20       | Ada Easter               | Deeper C1 (Deeper Church)                       | 80    | 11.4 |    | 75%  |
+| **\*20** | Samara Chepuri           | BNC C - Bears (Bellevue Neighborhood Church)    | 80    | 11.4 |    | 100% |
+| 21       | Luke Baldwin             | Cedar Park C1 (Cedar Park Assembly of God)      | 70    | 10   |    | 88%  |
+| 22       | Abhishikth Chirumamilla  | BNC C - Bears (Bellevue Neighborhood Church)    | 60    | 8.6  |    | 100% |
+| **\*22** | Ana-Lynn Rima            | Family Life #3 (Family Life Community Church)   | 60    | 8.6  |    | 100% |
+| 23       | Kylie Cruz               | Kelso Seekers (Kelso Christian Assembly)        | 45    | 6.4  |    | 64%  |
+| 24       | Katalina Montes          | Kelso Seekers (Kelso Christian Assembly)        | 30    | 4.3  |    | 67%  |
+| **\*24** | Nathan Moses             | Cedar Park C1 (Cedar Park Assembly of God)      | 30    | 4.3  |    | 100% |
+| 25       | Olivia Bringolf          | Deeper C1 (Deeper Church)                       | 15    | 2.1  |    | 67%  |
+| 26       | Micah Boyer              | Newhope #1 (Newhope)                            | 10    | 1.4  |    | 100% |
+| 27       | Eliza Jane Cutie Gunturu | BNC C - Bears (Bellevue Neighborhood Church)    | 0     |      |    |      |
+| **\*27** | Grace Boyer              | Newhope #1 (Newhope)                            | 0     |      |    |      |
+| **\*27** | Harper Scott             | Newhope #1 (Newhope)                            | 0     |      |    |      |
+| **\*27** | Sol Loza                 | Kelso Seekers (Kelso Christian Assembly)        | 0     |      |    |      |
+| 28       | SaKirah Jordan           | Family Life #2 (Family Life Community Church)   | -5    | -.7  |    |      |
+| 29       | Abhishay Tammalla        | BCN C - Leopards (Bellevue Neighborhood Church) | -40   | -5.7 |    | 22%  |

--- a/_pages/jbq/2022/districts/peninsular-florida.md
+++ b/_pages/jbq/2022/districts/peninsular-florida.md
@@ -2,7 +2,7 @@
 layout: page
 title: "2022 Peninsular-Florida District Finals"
 permalink: /jbq/2022/districts/peninsular-florida/
-date: "2023-04-02"
+date: "2022-03-26"
 toc_title: Results
 menubar_toc: true
 menubar_toc_static:
@@ -12,419 +12,307 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## Achiever: Flight of Champions
+## Flight of Champions
 
 ### Teams
 
-*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
+*2 way ties broken by head to head, 3+ way ties broken by points*
 
-**COMPLETE:** All Room(s) Reported.
-
-| #  | Team / Church                                                               | W/L   | W%   | Total | Avg   | QO | Q%  |
-|---:|-----------------------------------------------------------------------------|-------|-----:|------:|------:|---:|----:|
-| 1  | Fruit of the Spirit (Faith Assembly of God)                                 | 9 / 0 | 100% | 1895  | 210.6 | 9  | 85% |
-| 2  | Fire of the Spirit (Haven Worship Center)                                   | 7 / 2 | 78%  | 1595  | 177.2 | 4  | 87% |
-| 3  | Battling Bears (Victory Church)                                             | 7 / 2 | 78%  | 1745  | 193.9 | 13 | 87% |
-| 4  | Candy Quizzers (Faith Assembly of God)                                      | 6 / 3 | 67%  | 1635  | 181.7 | 8  | 75% |
-| 5  | Conquering Warriors (Freedom Christian Fellowship of the Assemblies of God) | 5 / 4 | 56%  | 1355  | 150.6 | 5  | 78% |
-| 6  | Banana Buzzers (Life Church)                                                | 4 / 5 | 44%  | 1405  | 156.1 | 9  | 80% |
-| 7  | Scripture Seekers #1 (First Assembly of God)                                | 3 / 6 | 33%  | 910   | 101.1 | 3  | 81% |
-| 8  | Triple Threat (LIFE Church Assembly of God)                                 | 3 / 6 | 33%  | 1315  | 146.1 | 5  | 76% |
-| 9  | Cool Kidz (LIFE Church A/G-Fruitland Park) (LIFE Church Assembly of God)    | 1 / 8 | 11%  | 975   | 108.3 | 3  | 82% |
-| 10 | Squiggly Worms (Independent)                                                | 0 / 9 |      | -40   | -4.4  |    |     |
+| #   | Team / Church                                                  | W/L   | Total | Avg   | QO | Q%  |
+|----:|----------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Fruit of the Spirit (Faith Assembly of God)                    | 8 / 0 | 2075  | 259.3 | 15 | 93% |
+| 2.0 | Candy Quizzers (Faith Assembly of God)                         | 7 / 1 | 1500  | 187.5 | 8  | 76% |
+| 3.0 | Kids on Fire (Life Church)                                     | 6 / 2 | 1555  | 194.4 | 10 | 84% |
+| 4.0 | The Under Armors of God (LIFE Church Assembly of God)          | 3 / 5 | 1020  | 127.5 | 7  | 80% |
+| 5.0 | Quiz Crew (Breadbreakers Church)                               | 3 / 5 | 950   | 118.7 | 5  | 92% |
+| 6.0 | First Coast Christian Center #1 (First Coast Christian Center) | 3 / 5 | 840   | 105   |    | 92% |
+| 7.0 | Victorious Dragons (Victory Church)                            | 3 / 5 | 705   | 88.1  | 4  | 75% |
+| 8.0 | The Lions of Judah (Winter Haven Worship Center)               | 2 / 6 | 800   | 100   | 4  | 76% |
+| 9.0 | Scripture Seekers Team 1 (First Assembly of God)               | 1 / 7 | 600   | 75    | 3  | 84% |
 
 ### Individuals
 
-*Ties broken by Average Points then by Total Quiz Outs*
+*Ties broken by Average Points then Total Quiz Outs*
 
-| #        | Quizzer           | Team / Church                                                               | Total | Avg   | QO | Q%   |
-|---------:|-------------------|-----------------------------------------------------------------------------|------:|------:|---:|-----:|
-| 1        | Isabella Kirchon  | Battling Bears (Victory Church)                                             | 1095  | 121.7 | 7  | 84%  |
-| 2        | Camden Spence     | Fruit of the Spirit (Faith Assembly of God)                                 | 1070  | 118.9 | 4  | 89%  |
-| 3        | Joel Villalba     | Fire of the Spirit (Haven Worship Center)                                   | 1025  | 113.9 | 3  | 92%  |
-| 4        | Vicente Rivera    | Conquering Warriors (Freedom Christian Fellowship of the Assemblies of God) | 950   | 105.6 | 3  | 88%  |
-| 5        | Ian Victor        | Scripture Seekers #1 (First Assembly of God)                                | 620   | 68.9  | 3  | 83%  |
-| 6        | Benjamin Reilly   | Candy Quizzers (Faith Assembly of God)                                      | 595   | 66.1  | 2  | 76%  |
-| 7        | J.D. Pereira      | Candy Quizzers (Faith Assembly of God)                                      | 580   | 64.4  |    | 74%  |
-| 8        | Jessa LoGiudice   | Cool Kidz (LIFE Church A/G-Fruitland Park) (LIFE Church Assembly of God)    | 560   | 62.2  | 1  | 86%  |
-| 9        | Briella LoGiudice | Triple Threat (LIFE Church Assembly of God)                                 | 510   | 56.7  | 2  | 72%  |
-| 10       | James Groves      | Battling Bears (Victory Church)                                             | 505   | 56.1  | 5  | 90%  |
-| 11       | Leah Manns        | Banana Buzzers (Life Church)                                                | 470   | 52.2  | 2  | 92%  |
-| 12       | Autumn Weiler     | Triple Threat (LIFE Church Assembly of God)                                 | 470   | 52.2  | 1  | 76%  |
-| 13       | Micah Wise        | Candy Quizzers (Faith Assembly of God)                                      | 455   | 50.6  | 6  | 78%  |
-| 14       | Miguel Rios       | Fruit of the Spirit (Faith Assembly of God)                                 | 455   | 50.6  | 5  | 80%  |
-| 15       | Johana Bull       | Banana Buzzers (Life Church)                                                | 430   | 47.8  | 2  | 72%  |
-| 16       | Jordan Cessous    | Banana Buzzers (Life Church)                                                | 380   | 42.2  | 4  | 76%  |
-| 17       | Arie Weiler       | Triple Threat (LIFE Church Assembly of God)                                 | 335   | 37.2  | 2  | 80%  |
-| 18       | Nathan Thompson   | Cool Kidz (LIFE Church A/G-Fruitland Park) (LIFE Church Assembly of God)    | 300   | 33.3  | 2  | 82%  |
-| 19       | Naomi Rivera      | Conquering Warriors (Freedom Christian Fellowship of the Assemblies of God) | 235   | 26.1  | 2  | 70%  |
-| 20       | Lillian Martin    | Fire of the Spirit (Haven Worship Center)                                   | 200   | 22.2  |    | 74%  |
-| **\*20** | Malakai Sifford   | Scripture Seekers #1 (First Assembly of God)                                | 200   | 22.2  |    | 74%  |
-| 21       | Eli Smith         | Fruit of the Spirit (Faith Assembly of God)                                 | 190   | 21.1  |    | 100% |
-| **\*21** | Jesiah Gonzalez   | Fire of the Spirit (Haven Worship Center)                                   | 190   | 21.1  |    | 100% |
-| 22       | Kynlee Hayes      | Fire of the Spirit (Haven Worship Center)                                   | 180   | 20    | 1  | 88%  |
-| 23       | Aila Smith        | Fruit of the Spirit (Faith Assembly of God)                                 | 180   | 20    |    | 67%  |
-| 24       | Claire Kirchon    | Battling Bears (Victory Church)                                             | 145   | 16.1  | 1  | 91%  |
-| 25       | Gabe Thompson     | Cool Kidz (LIFE Church A/G-Fruitland Park) (LIFE Church Assembly of God)    | 120   | 13.3  |    | 78%  |
-| 26       | Gideon Rodriguez  | Banana Buzzers (Life Church)                                                | 115   | 12.8  | 1  | 92%  |
-| 27       | Wyatt Davenport   | Conquering Warriors (Freedom Christian Fellowship of the Assemblies of God) | 110   | 12.2  |    | 70%  |
-| 28       | River Skinner     | Conquering Warriors (Freedom Christian Fellowship of the Assemblies of God) | 60    | 6.7   |    | 80%  |
-| 29       | Cassidy Johnson   | Scripture Seekers #1 (First Assembly of God)                                | 50    | 5.6   |    | 100% |
-| 30       | Aveah Caylor      | Scripture Seekers #1 (First Assembly of God)                                | 40    | 4.4   |    | 100% |
-| 31       | Alicia Johnson    | Candy Quizzers (Faith Assembly of God)                                      | 10    | 1.1   |    | 50%  |
-| **\*31** | Josiah Ojo        | Banana Buzzers (Life Church)                                                | 10    | 1.1   |    | 100% |
-| 32       | Maria Moreira     | Conquering Warriors (Freedom Christian Fellowship of the Assemblies of God) | 0     |       |    |      |
-| **\*32** | Maya Castro       | Squiggly Worms (Independent)                                                | 0     |       |    |      |
-| **\*32** | Zion Castro       | Squiggly Worms (Independent)                                                | 0     |       |    |      |
-| 33       | Caroline Thompson | Cool Kidz (LIFE Church A/G-Fruitland Park) (LIFE Church Assembly of God)    | -5    | -.6   |    |      |
+| #        | Quizzer              | Team / Church                                                  | Total | Avg   | QO | Q%   |
+|---------:|----------------------|----------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Aubrey Spence        | Fruit of the Spirit (Faith Assembly of God)                    | 1175  | 146.9 | 7  | 94%  |
+| 2        | Noah Ringeisen       | Kids on Fire (Life Church)                                     | 895   | 111.9 | 5  | 95%  |
+| 3        | Sydney Antoine       | Quiz Crew (Breadbreakers Church)                               | 630   | 78.8  | 5  | 95%  |
+| 4        | Isabella Kirchon     | Victorious Dragons (Victory Church)                            | 555   | 69.4  | 4  | 76%  |
+| 5        | Aveah Caylor         | Scripture Seekers Team 1 (First Assembly of God)               | 515   | 64.4  | 3  | 80%  |
+| 6        | Autumn Weiler        | The Under Armors of God (LIFE Church Assembly of God)          | 515   | 64.4  | 2  | 83%  |
+| 7        | Miguel Rios          | Fruit of the Spirit (Faith Assembly of God)                    | 505   | 63.1  | 7  | 90%  |
+| 8        | J.D. Pereira         | Candy Quizzers (Faith Assembly of God)                         | 485   | 60.6  | 2  | 67%  |
+| 9        | Joel Villalba        | The Lions of Judah (Winter Haven Worship Center)               | 475   | 59.4  | 1  | 73%  |
+| 10       | Hannah Pereira       | Candy Quizzers (Faith Assembly of God)                         | 475   | 59.4  |    | 74%  |
+| 11       | Leah Manns           | Kids on Fire (Life Church)                                     | 430   | 53.8  | 5  | 79%  |
+| 12       | Aila Smith           | Candy Quizzers (Faith Assembly of God)                         | 420   | 52.5  | 6  | 87%  |
+| 13       | Arie Weiler          | The Under Armors of God (LIFE Church Assembly of God)          | 420   | 52.5  | 5  | 81%  |
+| 14       | Camden Spence        | Fruit of the Spirit (Faith Assembly of God)                    | 395   | 49.4  | 1  | 96%  |
+| 15       | Sarah Beaubrun       | First Coast Christian Center #1 (First Coast Christian Center) | 380   | 47.5  |    | 94%  |
+| 16       | Kynlee Hayes         | The Lions of Judah (Winter Haven Worship Center)               | 330   | 41.3  | 3  | 78%  |
+| 17       | Megan Runge          | First Coast Christian Center #1 (First Coast Christian Center) | 310   | 38.8  |    | 89%  |
+| 18       | Kamse Uzo            | Kids on Fire (Life Church)                                     | 175   | 21.9  |    | 92%  |
+| 19       | Eli Runge            | First Coast Christian Center #1 (First Coast Christian Center) | 140   | 17.5  |    | 94%  |
+| 20       | Micah Wise           | Candy Quizzers (Faith Assembly of God)                         | 120   | 15    |    | 78%  |
+| 21       | Alexander Antoine    | Quiz Crew (Breadbreakers Church)                               | 115   | 14.4  |    | 91%  |
+| 22       | Richard Thomas       | Quiz Crew (Breadbreakers Church)                               | 105   | 13.1  |    | 100% |
+| 23       | Carmia Owens         | Quiz Crew (Breadbreakers Church)                               | 100   | 12.5  |    | 85%  |
+| 24       | Gabe Thompson        | The Under Armors of God (LIFE Church Assembly of God)          | 85    | 10.6  |    | 67%  |
+| 25       | Sarah Ferreira       | Scripture Seekers Team 1 (First Assembly of God)               | 75    | 9.4   |    | 100% |
+| **\*25** | Claire Kirchon       | Victorious Dragons (Victory Church)                            | 75    | 9.4   |    | 89%  |
+| 26       | Johana Bull          | Kids on Fire (Life Church)                                     | 55    | 6.9   |    | 64%  |
+| 27       | Maximus Prokop       | Victorious Dragons (Victory Church)                            | 40    | 5     |    | 100% |
+| 28       | James Groves         | Victorious Dragons (Victory Church)                            | 35    | 4.4   |    | 54%  |
+| 29       | Laura Santos         | Scripture Seekers Team 1 (First Assembly of God)               | 10    | 1.3   |    | 100% |
+| **\*29** | Caleb Arent          | First Coast Christian Center #1 (First Coast Christian Center) | 10    | 1.3   |    | 99%  |
+| 30       | Uriah Skinner        | First Coast Christian Center #1 (First Coast Christian Center) | 0     |       |    |      |
+| **\*30** | John Marshall Thomas | The Lions of Judah (Winter Haven Worship Center)               | 0     |       |    |      |
+| **\*30** | Elliana Martin       | The Lions of Judah (Winter Haven Worship Center)               | 0     |       |    |      |
+| **\*30** | Kinsey Hughes        | The Lions of Judah (Winter Haven Worship Center)               | 0     |       |    |      |
+| **\*30** | Mauricio Crespo      | The Lions of Judah (Winter Haven Worship Center)               | 0     |       |    |      |
 
-## Achiever: Flight 2
+## Achiever Flight 2
 
 ### Teams
 
-*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
+*2 way ties broken by head to head, 3+ way ties broken by points*
 
-**COMPLETE:** All Room(s) Reported.
-
-| # | Team / Church                                                  | W/L   | W%  | Total | Avg   | QO | Q%  |
-|--:|----------------------------------------------------------------|-------|----:|------:|------:|---:|----:|
-| 1 | Sin Stoppers (Haven Worship Center)                            | 5 / 1 | 83% | 1175  | 195.8 | 9  | 88% |
-| 2 | Blazing Buzzers (Haven Worship Center)                         | 4 / 2 | 67% | 615   | 102.5 | 3  | 71% |
-| 3 | Little Evangelists (South Point Church)                        | 4 / 2 | 67% | 925   | 154.2 | 4  | 74% |
-| 4 | First Coast Christian Center #1 (First Coast Christian Center) | 3 / 3 | 50% | 830   | 138.3 | 4  | 85% |
-| 5 | Fighters of the Faith (Faith Assembly of God)                  | 3 / 3 | 50% | 550   | 91.7  | 3  | 67% |
-| 6 | Scripture Seekers #2 (First Assembly of God)                   | 1 / 5 | 17% | 150   | 25    |    | 58% |
-| 7 | Jesus Warriors (Life Church)                                   | 1 / 5 | 17% | 470   | 78.3  | 2  | 69% |
+| #   | Team / Church                                                                                       | W/L   | Total | Avg   | QO | Q%  |
+|----:|-----------------------------------------------------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Freedom Christian Fellowship Wisdom Talkers (Freedom Christian Fellowship of the Assemblies of God) | 7 / 0 | 1320  | 188.5 | 7  | 82% |
+| 2.1 | God's Gang (Life Church)                                                                            | 5 / 2 | 870   | 124.3 | 5  | 82% |
+| 3.0 | God\'s Sanitizers (Faith Assembly of God)                                                           | 5 / 2 | 950   | 135.7 | 8  | 76% |
+| 4.0 | Believers of the Bible (LIFE Church Assembly of God)                                                | 4 / 3 | 940   | 134.3 | 6  | 83% |
+| 5.0 | Jesus Family Ministries #1 (Jesus Family Ministries)                                                | 3 / 4 | 870   | 124.3 | 6  | 86% |
+| 6.1 | One way (First Assembly of God)                                                                     | 2 / 5 | 910   | 130   | 4  | 80% |
+| 7.0 | Keepers of the Command (New Life Assembly)                                                          | 2 / 5 | 565   | 80.7  | 5  | 74% |
+| 8.0 | MZ² (Highpoint Church)                                                                              | 0 / 7 | 0     |       |    |     |
 
 ### Individuals
 
-*Ties broken by Average Points then by Total Quiz Outs*
+*Ties broken by Average Points then Total Quiz Outs*
 
-| #        | Quizzer                | Team / Church                                                  | Total | Avg   | QO | Q%   |
-|---------:|------------------------|----------------------------------------------------------------|------:|------:|---:|-----:|
-| 1        | Jahdiel Gonzalez       | Sin Stoppers (Haven Worship Center)                            | 780   | 130   | 5  | 92%  |
-| 2        | Sarah Beaubrun         | First Coast Christian Center #1 (First Coast Christian Center) | 730   | 121.7 | 4  | 91%  |
-| 3        | Miguel Soriano Batista | Blazing Buzzers (Haven Worship Center)                         | 470   | 78.3  | 3  | 73%  |
-| 4        | Logan Edmonson         | Little Evangelists (South Point Church)                        | 460   | 76.7  | 2  | 89%  |
-| 5        | Ashlyn Olson           | Jesus Warriors (Life Church)                                   | 315   | 52.5  | 2  | 78%  |
-| 6        | Elliana Martin         | Sin Stoppers (Haven Worship Center)                            | 305   | 50.8  | 4  | 81%  |
-| 7        | Jaxton Edmonson        | Little Evangelists (South Point Church)                        | 230   | 38.3  |    | 73%  |
-| 8        | Samuel Espino          | Fighters of the Faith (Faith Assembly of God)                  | 225   | 37.5  | 3  | 74%  |
-| 9        | Camila Espino          | Fighters of the Faith (Faith Assembly of God)                  | 210   | 35    |    | 67%  |
-| 10       | Grayson Mitchell       | Little Evangelists (South Point Church)                        | 165   | 27.5  | 2  | 62%  |
-| 11       | Ethan Olson            | Jesus Warriors (Life Church)                                   | 150   | 25    |    | 63%  |
-| 12       | Evan Whitmire          | Sin Stoppers (Haven Worship Center)                            | 90    | 15    |    | 100% |
-| **\*12** | Misael Soriano Batista | Blazing Buzzers (Haven Worship Center)                         | 90    | 15    |    | 67%  |
-| 13       | Daniel Espino          | Fighters of the Faith (Faith Assembly of God)                  | 70    | 11.7  |    | 62%  |
-| 14       | Spring Santos          | Scripture Seekers #2 (First Assembly of God)                   | 65    | 10.8  |    | 100% |
-| 15       | Bernardo Moreira       | Scripture Seekers #2 (First Assembly of God)                   | 60    | 10    |    | 67%  |
-| **\*15** | Mila Thompson          | Little Evangelists (South Point Church)                        | 60    | 10    |    | 100% |
-| 16       | Quinn Beckham          | Blazing Buzzers (Haven Worship Center)                         | 55    | 9.2   |    | 69%  |
-| 17       | Caleb Arent            | First Coast Christian Center #1 (First Coast Christian Center) | 50    | 8.3   |    | 86%  |
-| **\*17** | Eli Runge              | First Coast Christian Center #1 (First Coast Christian Center) | 50    | 8.3   |    | 64%  |
-| 18       | Titus Trimble          | Fighters of the Faith (Faith Assembly of God)                  | 45    | 7.5   |    | 43%  |
-| 19       | Malachi Miles          | Scripture Seekers #2 (First Assembly of God)                   | 30    | 5     |    | 44%  |
-| 20       | Colby Mitchell         | Little Evangelists (South Point Church)                        | 10    | 1.7   |    | 67%  |
-| 21       | Frankie Lee            | Jesus Warriors (Life Church)                                   | 5     | .8    |    | 40%  |
-| 22       | Khyreonia Williams     | Jesus Warriors (Life Church)                                   | 0     |       |    |      |
-| **\*22** | Marcus Norwood         | Sin Stoppers (Haven Worship Center)                            | 0     |       |    |      |
-| **\*22** | Regan Copeland         | Jesus Warriors (Life Church)                                   | 0     |       |    |      |
-| **\*22** | Tatiana Ray            | Jesus Warriors (Life Church)                                   | 0     |       |    |      |
-| **\*22** | Miguel Alves           | Scripture Seekers #2 (First Assembly of God)                   | 0     |       |    | 43%  |
+| #        | Quizzer            | Team / Church                                                                                       | Total | Avg   | QO | Q%   |
+|---------:|--------------------|-----------------------------------------------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Vicente Rivera     | Freedom Christian Fellowship Wisdom Talkers (Freedom Christian Fellowship of the Assemblies of God) | 1000  | 142.9 | 7  | 93%  |
+| 2        | Alicia Johnson     | God\'s Sanitizers (Faith Assembly of God)                                                           | 610   | 87.1  | 5  | 80%  |
+| 3        | John Benkiruba     | Jesus Family Ministries #1 (Jesus Family Ministries)                                                | 590   | 84.3  | 5  | 100% |
+| 4        | Bethany Enwere     | God's Gang (Life Church)                                                                            | 575   | 82.1  | 4  | 88%  |
+| 5        | Kristopher Jacques | Keepers of the Command (New Life Assembly)                                                          | 535   | 76.4  | 5  | 87%  |
+| 6        | Logan Edmonson     | One way (First Assembly of God)                                                                     | 460   | 65.7  | 2  | 86%  |
+| 7        | Briella LoGiudice  | Believers of the Bible (LIFE Church Assembly of God)                                                | 445   | 63.6  | 5  | 80%  |
+| 8        | Jessa LoGiudice    | Believers of the Bible (LIFE Church Assembly of God)                                                | 440   | 62.9  | 1  | 89%  |
+| 9        | Jaxton Edmonson    | One way (First Assembly of God)                                                                     | 365   | 52.1  | 1  | 72%  |
+| 10       | Muna Uzo           | God's Gang (Life Church)                                                                            | 280   | 40    | 1  | 79%  |
+| 11       | Titus Trimble      | God\'s Sanitizers (Faith Assembly of God)                                                           | 265   | 37.9  | 3  | 70%  |
+| 12       | Andrea Poovairaj   | Jesus Family Ministries #1 (Jesus Family Ministries)                                                | 235   | 33.6  | 1  | 81%  |
+| 13       | Enyichi Ohiaeriaku | Freedom Christian Fellowship Wisdom Talkers (Freedom Christian Fellowship of the Assemblies of God) | 185   | 26.4  |    | 75%  |
+| 14       | Johnny Cagle       | One way (First Assembly of God)                                                                     | 75    | 10.7  | 1  | 86%  |
+| 15       | Andrea Bonilla     | God\'s Sanitizers (Faith Assembly of God)                                                           | 75    | 10.7  |    | 87%  |
+| 16       | river skinner      | Freedom Christian Fellowship Wisdom Talkers (Freedom Christian Fellowship of the Assemblies of God) | 70    | 10    |    | 100% |
+| 17       | Layton Weathington | Freedom Christian Fellowship Wisdom Talkers (Freedom Christian Fellowship of the Assemblies of God) | 45    | 6.4   |    | 54%  |
+| **\*17** | Gabriel Alexander  | Jesus Family Ministries #1 (Jesus Family Ministries)                                                | 45    | 6.4   |    | 54%  |
+| 18       | Caroline Thompson  | Believers of the Bible (LIFE Church Assembly of God)                                                | 30    | 4.3   |    | 100% |
+| 19       | Amari Mathurin     | Keepers of the Command (New Life Assembly)                                                          | 25    | 3.6   |    | 57%  |
+| 20       | Hunter Bowden      | Believers of the Bible (LIFE Church Assembly of God)                                                | 20    | 2.9   |    | 100% |
+| **\*20** | Parker Cannon      | Freedom Christian Fellowship Wisdom Talkers (Freedom Christian Fellowship of the Assemblies of God) | 20    | 2.9   |    | 100% |
+| **\*20** | Ashlyn Olson       | God's Gang (Life Church)                                                                            | 20    | 2.9   |    | 50%  |
+| 21       | Kaden Alicea       | Keepers of the Command (New Life Assembly)                                                          | 15    | 2.1   |    | 60%  |
+| 22       | Jackson Cagle      | One way (First Assembly of God)                                                                     | 10    | 1.4   |    | 99%  |
+| 23       | Allen Crouch       | Believers of the Bible (LIFE Church Assembly of God)                                                | 5     | .7    |    | 50%  |
+| 24       | Evelyn Jeffin      | Jesus Family Ministries #1 (Jesus Family Ministries)                                                | 0     |       |    |      |
+| **\*24** | Zion Castro        | MZ² (Highpoint Church)                                                                              | 0     |       |    |      |
+| **\*24** | Maya Castro        | MZ² (Highpoint Church)                                                                              | 0     |       |    |      |
+| **\*24** | Joseph Bland       | God\'s Sanitizers (Faith Assembly of God)                                                           | 0     |       |    |      |
+| 25       | Daniel Fernandez   | Keepers of the Command (New Life Assembly)                                                          | -5    | -.7   |    | 40%  |
+| **\*25** | Tatiana Ray        | God's Gang (Life Church)                                                                            | -5    | -.7   |    |      |
 
 
-## Achiever: Flight 3
+## Achiever Flight 3
 
 ### Teams
 
-*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
+*2 way ties broken by head to head, 3+ way ties broken by points*
 
-**COMPLETE:** All Room(s) Reported.
-
-| # | Team / Church                                  | W/L   | W%   | Total | Avg   | QO | Q%   |
-|--:|------------------------------------------------|-------|-----:|------:|------:|---:|-----:|
-| 1 | God's Girls (Family First Assembly)            | 6 / 0 | 100% | 950   | 158.3 | 5  | 81%  |
-| 2 | Victorious Warriors (Victory Church)           | 5 / 1 | 83%  | 895   | 149.2 | 7  | 86%  |
-| 3 | The Little Lambs (LIFE Church Assembly of God) | 4 / 2 | 67%  | 565   | 94.2  | 5  | 89%  |
-| 4 | Exalibur (Oxford Assembly of God)              | 3 / 3 | 50%  | 625   | 104.2 | 3  | 82%  |
-| 5 | Mighty Warriors (New Life Assembly)            | 2 / 4 | 33%  | 415   | 69.2  |    | 86%  |
-| 6 | Faith Warriors (Faith Assembly of God)         | 1 / 5 | 17%  | 330   | 55    |    | 100% |
-| 7 | Jesus' Super Gang (New Life Assembly)          | 0 / 6 |      | 370   | 61.7  | 2  | 82%  |
+| #   | Team / Church                                  | W/L   | Total | Avg  | QO | Q%  |
+|----:|------------------------------------------------|-------|------:|-----:|---:|----:|
+| 1.0 | Rising Arrows (Life Church)                    | 5 / 2 | 665   | 95   | 1  | 78% |
+| 2.0 | Family Force Five (Family First Assembly)      | 4 / 3 | 660   | 94.3 | 2  | 71% |
+| 3.0 | Thunderbolts (Faith Assembly of God)           | 4 / 3 | 650   | 92.8 | 3  | 77% |
+| 4.0 | Faith Fighters (LIFE Church Assembly of God)   | 4 / 3 | 580   | 82.8 | 3  | 95% |
+| 5.0 | Super Sharp (Oxford Assembly of God)           | 4 / 3 | 450   | 64.3 |    | 81% |
+| 6.1 | Victorious Dragons² (Victory Church)           | 3 / 4 | 415   | 59.3 | 2  | 80% |
+| 7.0 | Jesus' Warriors (Winter Haven Worship Center)  | 3 / 4 | 555   | 79.3 | 1  | 72% |
+| 8.0 | Scripture Highlighters (Faith Assembly of God) | 1 / 6 | 330   | 47.1 | 1  | 96% |
 
 ### Individuals
 
-*Ties broken by Average Points then by Total Quiz Outs*
+*Ties broken by Average Points then Total Quiz Outs*
 
-| #        | Quizzer             | Team / Church                                  | Total | Avg  | QO | Q%   |
-|---------:|---------------------|------------------------------------------------|------:|-----:|---:|-----:|
-| 1        | Paul Groves         | Victorious Warriors (Victory Church)           | 585   | 97.5 | 6  | 86%  |
-| 2        | Philomena De Pablo  | God's Girls (Family First Assembly)            | 555   | 92.5 | 4  | 85%  |
-| 3        | Emmett Strickland   | Exalibur (Oxford Assembly of God)              | 390   | 65   | 3  | 82%  |
-| 4        | Makya Rivenburg     | The Little Lambs (LIFE Church Assembly of God) | 385   | 64.2 | 5  | 92%  |
-| 5        | Liam McCurdy        | Jesus' Super Gang (New Life Assembly)          | 360   | 60   | 2  | 93%  |
-| 6        | Aliyah Robinson     | God's Girls (Family First Assembly)            | 330   | 55   | 1  | 88%  |
-| 7        | Makayla Weatherholt | Victorious Warriors (Victory Church)           | 250   | 41.7 | 1  | 88%  |
-| 8        | Aviannah Registre   | Mighty Warriors (New Life Assembly)            | 175   | 29.2 |    | 92%  |
-| 9        | Kirra Perry         | The Little Lambs (LIFE Church Assembly of God) | 170   | 28.3 |    | 79%  |
-| **\*9**  | Lizzy Godfrey       | Faith Warriors (Faith Assembly of God)         | 170   | 28.3 |    | 100% |
-| 10       | Isaiah Grevi        | Faith Warriors (Faith Assembly of God)         | 160   | 26.7 |    | 100% |
-| 11       | Hannah Hnilica      | God's Girls (Family First Assembly)            | 95    | 15.8 |    | 70%  |
-| **\*11** | Kamilah Dasmy       | Mighty Warriors (New Life Assembly)            | 95    | 15.8 |    | 80%  |
-| **\*11** | Skylah Freeman      | Mighty Warriors (New Life Assembly)            | 95    | 15.8 |    | 78%  |
-| **\*11** | Yemi Fawole         | Exalibur (Oxford Assembly of God)              | 95    | 15.8 |    | 100% |
-| 12       | Eli Hahn            | Exalibur (Oxford Assembly of God)              | 85    | 14.2 |    | 75%  |
-| 13       | Naomi White         | Victorious Warriors (Victory Church)           | 60    | 10   |    | 83%  |
-| 14       | Josiah Hamblen      | Exalibur (Oxford Assembly of God)              | 55    | 9.2  |    | 83%  |
-| 15       | Payge Voltaire      | Mighty Warriors (New Life Assembly)            | 50    | 8.3  |    | 100% |
-| 16       | Arielle Registre    | Jesus' Super Gang (New Life Assembly)          | 25    | 4.2  |    | 75%  |
-| 17       | Pablo Banda         | The Little Lambs (LIFE Church Assembly of God) | 10    | 1.7  |    | 100% |
-| 18       | Arriya Chaya        | God's Girls (Family First Assembly)            | 0     |      |    |      |
-| **\*18** | Arthur Calderon     | The Little Lambs (LIFE Church Assembly of God) | 0     |      |    |      |
-| **\*18** | Camryn Howard       | Jesus' Super Gang (New Life Assembly)          | 0     |      |    |      |
-| **\*18** | Extra-1             | Victorious Warriors (Victory Church)           | 0     |      |    |      |
-| **\*18** | Extra-2             | Victorious Warriors (Victory Church)           | 0     |      |    |      |
-| **\*18** | Extra-3             | Victorious Warriors (Victory Church)           | 0     |      |    |      |
-| **\*18** | Extra-4             | Victorious Warriors (Victory Church)           | 0     |      |    |      |
-| **\*18** | Kaydence Russell    | Mighty Warriors (New Life Assembly)            | 0     |      |    |      |
-| **\*18** | Lillian Windbish    | Faith Warriors (Faith Assembly of God)         | 0     |      |    |      |
-| **\*18** | Nicolas Johnson     | Faith Warriors (Faith Assembly of God)         | 0     |      |    |      |
-| **\*18** | Rebecca Kebede      | Faith Warriors (Faith Assembly of God)         | 0     |      |    |      |
-| **\*18** | Riley Madak         | The Little Lambs (LIFE Church Assembly of God) | 0     |      |    |      |
-| **\*18** | Tabitha Hursell     | Jesus' Super Gang (New Life Assembly)          | 0     |      |    |      |
-| 19       | Victoria Fernandez  | Jesus' Super Gang (New Life Assembly)          | -5    | -.8  |    |      |
-| 20       | Kallen Alicea       | Jesus' Super Gang (New Life Assembly)          | -10   | -1.7 |    |      |
-| 21       | Alexia Robinson     | God's Girls (Family First Assembly)            | -30   | -5   |    |      |
+| #        | Quizzer            | Team / Church                                  | Total | Avg  | QO | Q%   |
+|---------:|--------------------|------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Benjamin Reilly    | Thunderbolts (Faith Assembly of God)           | 550   | 78.6 | 3  | 79%  |
+| 2        | Aliyah Robinson    | Family Force Five (Family First Assembly)      | 510   | 72.9 | 2  | 79%  |
+| 3        | Sirayah Williams   | Faith Fighters (LIFE Church Assembly of God)   | 420   | 60   | 3  | 93%  |
+| 4        | Cameron Cooper     | Scripture Highlighters (Faith Assembly of God) | 320   | 45.7 | 1  | 96%  |
+| 5        | Paul Groves        | Victorious Dragons² (Victory Church)           | 315   | 45   | 2  | 79%  |
+| 6        | Joshua Wells       | Jesus' Warriors (Winter Haven Worship Center)  | 290   | 41.4 | 1  | 75%  |
+| 7        | Ethan Olson        | Rising Arrows (Life Church)                    | 270   | 38.6 | 1  | 74%  |
+| 8        | Elijah Wells       | Jesus' Warriors (Winter Haven Worship Center)  | 265   | 37.9 |    | 68%  |
+| 9        | Nissi Dunham       | Super Sharp (Oxford Assembly of God)           | 250   | 35.7 |    | 85%  |
+| 10       | Jordan Cessous     | Rising Arrows (Life Church)                    | 230   | 32.9 |    | 90%  |
+| 11       | Kirra Perry        | Faith Fighters (LIFE Church Assembly of God)   | 160   | 22.9 |    | 100% |
+| 12       | Gideon Rodriguez   | Rising Arrows (Life Church)                    | 145   | 20.7 |    | 72%  |
+| 13       | Silas De Pablo     | Family Force Five (Family First Assembly)      | 115   | 16.4 |    | 65%  |
+| 14       | Naomi White        | Victorious Dragons² (Victory Church)           | 100   | 14.3 |    | 80%  |
+| 15       | Yemi Fawole        | Super Sharp (Oxford Assembly of God)           | 95    | 13.6 |    | 80%  |
+| 16       | Lydia Marrero      | Thunderbolts (Faith Assembly of God)           | 60    | 8.6  |    | 67%  |
+| 17       | Madi Spellman      | Thunderbolts (Faith Assembly of God)           | 40    | 5.7  |    | 100% |
+| **\*17** | Eli Hahn           | Super Sharp (Oxford Assembly of God)           | 40    | 5.7  |    | 83%  |
+| 18       | Emma Staton        | Super Sharp (Oxford Assembly of God)           | 35    | 5    |    | 62%  |
+| **\*18** | Alexia Robinson    | Family Force Five (Family First Assembly)      | 35    | 5    |    | 54%  |
+| 19       | Frankie Lee        | Rising Arrows (Life Church)                    | 20    | 2.9  |    | 100% |
+| **\*19** | JB Staton          | Super Sharp (Oxford Assembly of God)           | 20    | 2.9  |    | 100% |
+| 20       | Clayton Clark      | Scripture Highlighters (Faith Assembly of God) | 10    | 1.4  |    | 99%  |
+| **\*20** | Abigail Dunham     | Super Sharp (Oxford Assembly of God)           | 10    | 1.4  |    | 99%  |
+| 21       | Selena Miller      | Jesus' Warriors (Winter Haven Worship Center)  | 0     |      |    |      |
+| **\*21** | Lillian Martin     | Jesus' Warriors (Winter Haven Worship Center)  | 0     |      |    |      |
+| **\*21** | Zoe Thomas         | Jesus' Warriors (Winter Haven Worship Center)  | 0     |      |    |      |
+| **\*21** | Marina Denton      | Jesus' Warriors (Winter Haven Worship Center)  | 0     |      |    |      |
+| **\*21** | Allison Crouch     | Faith Fighters (LIFE Church Assembly of God)   | 0     |      |    |      |
+| **\*21** | Guillermo Diaz     | Faith Fighters (LIFE Church Assembly of God)   | 0     |      |    |      |
+| **\*21** | Madison Bowden     | Faith Fighters (LIFE Church Assembly of God)   | 0     |      |    |      |
+| **\*21** | Jaelynn Martinez   | Family Force Five (Family First Assembly)      | 0     |      |    |      |
+| **\*21** | Philomena De Pablo | Family Force Five (Family First Assembly)      | 0     |      |    |      |
+| **\*21** | Elli White         | Victorious Dragons² (Victory Church)           | 0     |      |    |      |
 
 
-## Achiever: Flight 4
+## Achiever Flight 4
 
 ### Teams
 
-*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
+*2 way ties broken by head to head, 3+ way ties broken by points*
 
-**COMPLETE:** All Room(s) Reported.
-
-| # | Team / Church                                                | W/L   | W%  | Total | Avg  | QO | Q%  |
-|--:|--------------------------------------------------------------|-------|----:|------:|-----:|---:|----:|
-| 1 | FWC Orange (Family Worship Center)                           | 5 / 1 | 83% | 520   | 86.7 | 1  | 84% |
-| 2 | God Squad (First Assembly Deland)                            | 4 / 2 | 67% | 455   | 75.8 | 3  | 78% |
-| 3 | Suncoast Shield Bearers (Suncoast Cathedral Assembly of God) | 4 / 2 | 67% | 465   | 77.5 | 5  | 88% |
-| 4 | Jesus Freaks (LIFE Church Assembly of God)                   | 3 / 3 | 50% | 565   | 94.2 |    | 87% |
-| 5 | Word Warriors (New Life Assembly)                            | 2 / 4 | 33% | 270   | 45   | 1  | 59% |
-| 6 | Suncoast Sword Wielders (Suncoast Cathedral Assembly of God) | 2 / 4 | 33% | 230   | 38.3 |    | 68% |
-| 7 | Shark Attack (Harvest Assembly of God)                       | 1 / 5 | 17% | 190   | 31.7 |    | 87% |
+| #   | Team / Church                                    | W/L   | Total | Avg   | QO | Q%  |
+|----:|--------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.1 | Scripture Seekers Team 2 (First Assembly of God) | 5 / 1 | 540   | 90    | 4  | 67% |
+| 2.0 | Bible Warriors (Family First Assembly)           | 5 / 1 | 670   | 111.6 | 2  | 77% |
+| 3.0 | Seekers of the Kingdom (New Life Assembly)       | 4 / 2 | 640   | 106.6 | 3  | 86% |
+| 4.0 | God Squad (First Assembly Deland)                | 3 / 3 | 260   | 43.3  |    | 76% |
+| 5.1 | The Golden Lions (LIFE Church Assembly of God)   | 2 / 4 | 215   | 35.8  |    | 79% |
+| 6.0 | Devil Destroyers (Harvest Assembly of God)       | 2 / 4 | 210   | 35    |    | 89% |
+| 7.0 | Bananas (Faith Assembly of God)                  | 0 / 6 | 185   | 30.8  |    | 83% |
 
 ### Individuals
 
-*Ties broken by Average Points then by Total Quiz Outs*
+*Ties broken by Average Points then Total Quiz Outs*
 
-| #        | Quizzer               | Team / Church                                                | Total | Avg  | QO | Q%   |
-|---------:|-----------------------|--------------------------------------------------------------|------:|-----:|---:|-----:|
-| 1        | Shendoah Rivenburg    | Jesus Freaks (LIFE Church Assembly of God)                   | 460   | 76.7 |    | 86%  |
-| 2        | Noah Van Hoven        | Suncoast Shield Bearers (Suncoast Cathedral Assembly of God) | 445   | 74.2 | 5  | 92%  |
-| 3        | Titus Blades          | God Squad (First Assembly Deland)                            | 285   | 47.5 | 2  | 79%  |
-| 4        | Amari Mathurin        | Word Warriors (New Life Assembly)                            | 250   | 41.7 |    | 87%  |
-| 5        | Elias Silva           | FWC Orange (Family Worship Center)                           | 185   | 30.8 |    | 90%  |
-| 6        | Bentley Denton        | FWC Orange (Family Worship Center)                           | 165   | 27.5 | 1  | 74%  |
-| 7        | Kindle Blades         | God Squad (First Assembly Deland)                            | 155   | 25.8 | 1  | 78%  |
-| 8        | Larkin Kramper        | Shark Attack (Harvest Assembly of God)                       | 145   | 24.2 |    | 88%  |
-| 9        | Jeremiah Berntsen     | Suncoast Sword Wielders (Suncoast Cathedral Assembly of God) | 105   | 17.5 |    | 78%  |
-| 10       | Elijah Williams       | FWC Orange (Family Worship Center)                           | 100   | 16.7 |    | 89%  |
-| 11       | Kaden Alicea          | Word Warriors (New Life Assembly)                            | 75    | 12.5 | 1  | 50%  |
-| 12       | Elijah Barrett        | Suncoast Sword Wielders (Suncoast Cathedral Assembly of God) | 75    | 12.5 |    | 58%  |
-| 13       | Lindsey Hostetler     | Jesus Freaks (LIFE Church Assembly of God)                   | 65    | 10.8 |    | 80%  |
-| 14       | Elioenai Hoffman      | Suncoast Sword Wielders (Suncoast Cathedral Assembly of God) | 50    | 8.3  |    | 80%  |
-| 15       | Aiden Doyle           | FWC Orange (Family Worship Center)                           | 40    | 6.7  |    | 100% |
-| **\*15** | Jessenia Banda        | Jesus Freaks (LIFE Church Assembly of God)                   | 40    | 6.7  |    | 100% |
-| **\*15** | Parker Kramper        | Shark Attack (Harvest Assembly of God)                       | 40    | 6.7  |    | 100% |
-| 16       | Jolie Denton          | FWC Orange (Family Worship Center)                           | 30    | 5    |    | 100% |
-| 17       | Izzy Fischer          | Suncoast Shield Bearers (Suncoast Cathedral Assembly of God) | 20    | 3.3  |    | 50%  |
-| **\*17** | Jerlyn Pawlak         | God Squad (First Assembly Deland)                            | 20    | 3.3  |    | 100% |
-| 18       | Elijah Ferrari        | Shark Attack (Harvest Assembly of God)                       | 10    | 1.7  |    | 100% |
-| 19       | Alejandro Calderon    | Jesus Freaks (LIFE Church Assembly of God)                   | 0     |      |    |      |
-| **\*19** | Allen MacMillan       | Suncoast Shield Bearers (Suncoast Cathedral Assembly of God) | 0     |      |    |      |
-| **\*19** | Autumn Vestal         | God Squad (First Assembly Deland)                            | 0     |      |    |      |
-| **\*19** | Ava Orrach            | God Squad (First Assembly Deland)                            | 0     |      |    |      |
-| **\*19** | Frantzen Jean Jacques | Word Warriors (New Life Assembly)                            | 0     |      |    |      |
-| **\*19** | Gabriel McCormick     | FWC Orange (Family Worship Center)                           | 0     |      |    |      |
-| **\*19** | Huey Howard           | Word Warriors (New Life Assembly)                            | 0     |      |    |      |
-| **\*19** | Madelynn Knellinger   | Suncoast Shield Bearers (Suncoast Cathedral Assembly of God) | 0     |      |    |      |
-| **\*19** | Matthew Blades        | God Squad (First Assembly Deland)                            | 0     |      |    |      |
-| **\*19** | Patrick Phillips      | God Squad (First Assembly Deland)                            | 0     |      |    |      |
-| **\*19** | Samantha Fischer      | Jesus Freaks (LIFE Church Assembly of God)                   | 0     |      |    |      |
-| 20       | Jazmine Rodriguez     | Shark Attack (Harvest Assembly of God)                       | -5    | -.8  |    |      |
-| **\*20** | Joel Blades           | God Squad (First Assembly Deland)                            | -5    | -.8  |    |      |
-| 21       | Ezekiel Hursell       | Word Warriors (New Life Assembly)                            | -25   | -4.2 |    |      |
-| 22       | Daniel Fernandez      | Word Warriors (New Life Assembly)                            | -30   | -5   |    |      |
+| #        | Quizzer           | Team / Church                                    | Total | Avg  | QO | Q%   |
+|---------:|-------------------|--------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Logan Petrey      | Scripture Seekers Team 2 (First Assembly of God) | 440   | 73.3 | 4  | 71%  |
+| 2        | Aviannah Registre | Seekers of the Kingdom (New Life Assembly)       | 420   | 70   | 3  | 97%  |
+| 3        | Darius Robinson   | Bible Warriors (Family First Assembly)           | 355   | 59.2 | 1  | 68%  |
+| 4        | Hannah Hnilica    | Bible Warriors (Family First Assembly)           | 295   | 49.2 | 1  | 87%  |
+| 5        | Lizzy Godfrey     | Bananas (Faith Assembly of God)                  | 180   | 30   |    | 86%  |
+| 6        | Kamilah Dasmy     | Seekers of the Kingdom (New Life Assembly)       | 150   | 25   |    | 87%  |
+| 7        | Parker Kramper    | Devil Destroyers (Harvest Assembly of God)       | 135   | 22.5 |    | 90%  |
+| 8        | Jazmyne Walters   | God Squad (First Assembly Deland)                | 115   | 19.2 |    | 92%  |
+| 9        | Jonathan Williams | The Golden Lions (LIFE Church Assembly of God)   | 95    | 15.8 |    | 65%  |
+| 10       | Ava Orrach        | God Squad (First Assembly Deland)                | 80    | 13.3 |    | 90%  |
+| 11       | Bernardo Moreira  | Scripture Seekers Team 2 (First Assembly of God) | 70    | 11.7 |    | 100% |
+| 12       | Jerlyn Pawlak     | God Squad (First Assembly Deland)                | 55    | 9.2  |    | 80%  |
+| 13       | Lindsey Hostetler | The Golden Lions (LIFE Church Assembly of God)   | 50    | 8.3  |    | 100% |
+| 14       | Elijah Ferrari    | Devil Destroyers (Harvest Assembly of God)       | 40    | 6.7  |    | 100% |
+| **\*14** | Dalton Crouch     | The Golden Lions (LIFE Church Assembly of God)   | 40    | 6.7  |    | 100% |
+| **\*14** | Larkin Kramper    | Devil Destroyers (Harvest Assembly of God)       | 40    | 6.7  |    | 100% |
+| **\*14** | Payge Voltaire    | Seekers of the Kingdom (New Life Assembly)       | 40    | 6.7  |    | 54%  |
+| 15       | Jessenia Banda    | The Golden Lions (LIFE Church Assembly of God)   | 30    | 5    |    | 100% |
+| **\*15** | Uriel Mones       | Seekers of the Kingdom (New Life Assembly)       | 30    | 5    |    | 99%  |
+| **\*15** | Malakai Sifford   | Scripture Seekers Team 2 (First Assembly of God) | 30    | 5    |    | 47%  |
+| 16       | Titus Blades      | God Squad (First Assembly Deland)                | 25    | 4.2  |    | 40%  |
+| 17       | Arriya Chaya      | Bible Warriors (Family First Assembly)           | 20    | 3.3  |    | 99%  |
+| 18       | Daniel Bonilla    | Bananas (Faith Assembly of God)                  | 5     | .8   |    | 50%  |
+| 19       | Kathleena Chaya   | Bible Warriors (Family First Assembly)           | 0     |      |    |      |
+| **\*19** | Arrow De Pablo    | Bible Warriors (Family First Assembly)           | 0     |      |    |      |
+| **\*19** | Lorelai Moreno    | Devil Destroyers (Harvest Assembly of God)       | 0     |      |    |      |
+| **\*19** | Taylor Harrison   | Devil Destroyers (Harvest Assembly of God)       | 0     |      |    |      |
+| **\*19** | Claire Maricle    | God Squad (First Assembly Deland)                | 0     |      |    |      |
+| **\*19** | Ezekiel Hursell   | Seekers of the Kingdom (New Life Assembly)       | 0     |      |    |      |
+| 20       | Kindle Blades     | God Squad (First Assembly Deland)                | -5    | -.8  |    | 33%  |
+| **\*20** | Jasmine Rodriguez | Devil Destroyers (Harvest Assembly of God)       | -5    | -.8  |    |      |
+| 21       | Matthew Blades    | God Squad (First Assembly Deland)                | -10   | -1.7 |    |      |
 
-
-## Achiever: Flight 5
+## X-League Flight 1
 
 ### Teams
 
-*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
+*2 way ties broken by head to head, 3+ way ties broken by points*
 
-**COMPLETE:** All Room(s) Reported.
-
-| # | Team / Church                                                            | W/L   | W%  | Total | Avg | QO | Q%  |
-|--:|--------------------------------------------------------------------------|-------|----:|------:|----:|---:|----:|
-| 1 | Lightning Bolts (City Church of Orlando)                                 | 4 / 1 | 80% | 425   | 85  | 1  | 82% |
-| 2 | Double Edge (Oxford Assembly of God)                                     | 4 / 1 | 80% | 270   | 54  | 2  | 73% |
-| 3 | Freedom Fighters (Freedom Christian Fellowship of the Assemblies of God) | 3 / 2 | 60% | 235   | 47  |    | 68% |
-| 4 | Redeemers (Faith Assembly of God)                                        | 3 / 2 | 60% | 205   | 41  |    | 82% |
-| 5 | Super Sharp (Oxford Assembly of God)                                     | 1 / 4 | 20% | 180   | 36  |    | 72% |
-| 6 | Bible Crushers (Family First Assembly)                                   | 0 / 5 |     | 100   | 20  |    | 64% |
+| #   | Team / Church                                    | W/L   | Total | Avg   | QO | Q%  |
+|----:|--------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Scripture Seekers Team 3 (First Assembly of God) | 6 / 0 | 810   | 135   | 11 | 97% |
+| 2.0 | Burn the Ships (Faith Assembly of God)           | 4 / 2 | 735   | 122.5 | 10 | 89% |
+| 3.0 | Little Warriors (New Life Assembly)              | 2 / 4 | 555   | 92.5  | 5  | 85% |
+| 4.0 | Sons Of Thunder (Faith Assembly of God)          | 0 / 6 | 360   | 60    | 2  | 95% |
 
 ### Individuals
 
-*Ties broken by Average Points then by Total Quiz Outs*
+*Ties broken by Average Points then Total Quiz Outs*
 
-| #        | Quizzer             | Team / Church                                                            | Total | Avg | QO | Q%   |
-|---------:|---------------------|--------------------------------------------------------------------------|------:|----:|---:|-----:|
-| 1        | Christopher Ayala   | Lightning Bolts (City Church of Orlando)                                 | 280   | 56  | 1  | 81%  |
-| 2        | Emma Staton         | Double Edge (Oxford Assembly of God)                                     | 240   | 48  | 2  | 88%  |
-| 3        | Madi Spellman       | Redeemers (Faith Assembly of God)                                        | 170   | 34  |    | 93%  |
-| 4        | Xander Cullen       | Super Sharp (Oxford Assembly of God)                                     | 160   | 32  |    | 82%  |
-| 5        | Zoey Hill           | Lightning Bolts (City Church of Orlando)                                 | 95    | 19  |    | 75%  |
-| 6        | Kyle Brockman       | Freedom Fighters (Freedom Christian Fellowship of the Assemblies of God) | 80    | 16  |    | 55%  |
-| **\*6**  | Tristan Rosario     | Freedom Fighters (Freedom Christian Fellowship of the Assemblies of God) | 80    | 16  |    | 82%  |
-| 7        | Olachi Ohiaeriaku   | Freedom Fighters (Freedom Christian Fellowship of the Assemblies of God) | 75    | 15  |    | 67%  |
-| 8        | Martin Miles        | Lightning Bolts (City Church of Orlando)                                 | 50    | 10  |    | 100% |
-| **\*8**  | Silas De Pablo      | Bible Crushers (Family First Assembly)                                   | 50    | 10  |    | 64%  |
-| 9        | Andrew Chaya        | Bible Crushers (Family First Assembly)                                   | 40    | 8   |    | 71%  |
-| 10       | JB Staton           | Super Sharp (Oxford Assembly of God)                                     | 35    | 7   |    | 80%  |
-| 11       | Ian Scott           | Redeemers (Faith Assembly of God)                                        | 30    | 6   |    | 100% |
-| **\*11** | Zoe Hahn            | Double Edge (Oxford Assembly of God)                                     | 30    | 6   |    | 50%  |
-| 12       | Christian McElderry | Redeemers (Faith Assembly of God)                                        | 25    | 5   |    | 75%  |
-| 13       | Bentley Carver      | Bible Crushers (Family First Assembly)                                   | 10    | 2   |    | 50%  |
-| 14       | Makayla Jackson     | Super Sharp (Oxford Assembly of God)                                     | 5     | 1   |    | 50%  |
-| 15       | Abby Suro           | Lightning Bolts (City Church of Orlando)                                 | 0     |     |    |      |
-| **\*15** | Abigail Acree       | Super Sharp (Oxford Assembly of God)                                     | 0     |     |    |      |
-| **\*15** | Arrow De Pablo      | Bible Crushers (Family First Assembly)                                   | 0     |     |    |      |
-| **\*15** | Brayden Riggs       | Lightning Bolts (City Church of Orlando)                                 | 0     |     |    |      |
-| **\*15** | Caleb Rivera        | Lightning Bolts (City Church of Orlando)                                 | 0     |     |    |      |
-| **\*15** | Connie Miles        | Lightning Bolts (City Church of Orlando)                                 | 0     |     |    |      |
-| **\*15** | Ethan Wolf          | Lightning Bolts (City Church of Orlando)                                 | 0     |     |    |      |
-| **\*15** | Jaelynn Martinez    | Bible Crushers (Family First Assembly)                                   | 0     |     |    |      |
-| **\*15** | Jaxson Carver       | Bible Crushers (Family First Assembly)                                   | 0     |     |    |      |
-| **\*15** | Lailani Moore       | Redeemers (Faith Assembly of God)                                        | 0     |     |    |      |
-| **\*15** | Laura Moura         | Freedom Fighters (Freedom Christian Fellowship of the Assemblies of God) | 0     |     |    |      |
-| **\*15** | Murphy Newborn      | Double Edge (Oxford Assembly of God)                                     | 0     |     |    |      |
-| **\*15** | Piper Newborn       | Double Edge (Oxford Assembly of God)                                     | 0     |     |    |      |
-| 16       | Braylen Manns       | Super Sharp (Oxford Assembly of God)                                     | -10   | -2  |    |      |
-| **\*16** | Farrah Nemer        | Redeemers (Faith Assembly of God)                                        | -10   | -2  |    |      |
-| **\*16** | Jacksyn Jackson     | Super Sharp (Oxford Assembly of God)                                     | -10   | -2  |    |      |
-| **\*16** | Phillip Chevere     | Redeemers (Faith Assembly of God)                                        | -10   | -2  |    |      |
+| #        | Quizzer         | Team / Church                                    | Total | Avg  | QO | Q%   |
+|---------:|-----------------|--------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Cassidy Johnson | Scripture Seekers Team 3 (First Assembly of God) | 420   | 70   | 6  | 100% |
+| 2        | Eli Smith       | Burn the Ships (Faith Assembly of God)           | 405   | 67.5 | 6  | 90%  |
+| 3        | Destiny Johnson | Scripture Seekers Team 3 (First Assembly of God) | 390   | 65   | 5  | 95%  |
+| 4        | Liam McCurdy    | Little Warriors (New Life Assembly)              | 375   | 62.5 | 5  | 92%  |
+| 5        | Kailyn Spence   | Burn the Ships (Faith Assembly of God)           | 305   | 50.8 | 4  | 90%  |
+| 6        | Bo Mitchell     | Sons Of Thunder (Faith Assembly of God)          | 290   | 48.3 | 2  | 93%  |
+| 7        | Emery Voltaire  | Little Warriors (New Life Assembly)              | 80    | 13.3 |    | 89%  |
+| **\*7**  | Kallen Alicea   | Little Warriors (New Life Assembly)              | 80    | 13.3 |    | 65%  |
+| 8        | Carson Cooper   | Sons Of Thunder (Faith Assembly of God)          | 70    | 11.7 |    | 100% |
+| 9        | Sarmilah Dasmy  | Little Warriors (New Life Assembly)              | 20    | 3.3  |    | 100% |
+| 10       | Maleah Marrero  | Burn the Ships (Faith Assembly of God)           | 10    | 1.7  |    | 99%  |
+| **\*10** | Phillip Chevere | Burn the Ships (Faith Assembly of God)           | 10    | 1.7  |    | 99%  |
+| 11       | Skyleigh Cooper | Burn the Ships (Faith Assembly of God)           | 5     | .8   |    | 50%  |
+| 12       | Maya Sifford    | Scripture Seekers Team 3 (First Assembly of God) | 0     |      |    |      |
 
-## Rising Stars: Flight 1
+
+## X-League Flight 2
 
 ### Teams
 
-*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
+*2 way ties broken by head to head, 3+ way ties broken by points*
 
-**COMPLETE:** All Room(s) Reported.
-
-| # | Team / Church                                                    | W/L   | W%   | Total | Avg   | QO | Q%  |
-|--:|------------------------------------------------------------------|-------|-----:|------:|------:|---:|----:|
-| 1 | Scripture Seekers #3 (First Assembly of God)                     | 6 / 0 | 100% | 755   | 125.8 | 7  | 91% |
-| 2 | Smith Fan Club (Faith Assembly of God)                           | 5 / 1 | 83%  | 995   | 165.8 | 13 | 97% |
-| 3 | Saber of the Spirit (Victory Church)                             | 4 / 2 | 67%  | 620   | 103.3 | 5  | 79% |
-| 4 | Life Church #1 (Life Church)                                     | 2 / 4 | 33%  | 475   | 79.2  | 5  | 77% |
-| 5 | Scripture Seekers #5 (First Assembly of God)                     | 2 / 4 | 33%  | 390   | 65    | 4  | 73% |
-| 6 | Discover (Freedom Christian Fellowship of the Assemblies of God) | 1 / 5 | 17%  | 415   | 69.2  | 5  | 85% |
-| 7 | Princesses of God (New Life Assembly)                            | 1 / 5 | 17%  | 290   | 48.3  | 2  | 76% |
+| #   | Team / Church                                        | W/L   | Total | Avg   | QO | Q%  |
+|----:|------------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Scripture Seekers Team 4 (First Assembly of God)     | 4 / 0 | 490   | 122.5 | 5  | 86% |
+| 2.0 | Jesus Family Ministries #2 (Jesus Family Ministries) | 3 / 1 | 435   | 108.7 | 6  | 89% |
+| 3.0 | Princesses of God (New Life Assembly)                | 2 / 2 | 245   | 61.2  | 2  | 79% |
+| 4.0 | Double Edge (Oxford Assembly of God)                 | 1 / 3 | 300   | 75    | 4  | 68% |
+| 5.0 | Super Gang (New Life Assembly)                       | 0 / 4 | 265   | 66.2  | 2  | 96% |
 
 ### Individuals
 
-*Ties broken by Average Points then by Total Quiz Outs*
+*Ties broken by Average Points then Total Quiz Outs*
 
-| #        | Quizzer            | Team / Church                                                    | Total | Avg  | QO | Q%   |
-|---------:|--------------------|------------------------------------------------------------------|------:|-----:|---:|-----:|
-| 1        | Destiny Johnson    | Scripture Seekers #3 (First Assembly of God)                     | 420   | 70   | 6  | 100% |
-| 2        | Eliah Martinez     | Smith Fan Club (Faith Assembly of God)                           | 405   | 67.5 | 6  | 92%  |
-| 3        | Kailyn Spence      | Smith Fan Club (Faith Assembly of God)                           | 380   | 63.3 | 5  | 100% |
-| 4        | Mateus Rivera      | Discover (Freedom Christian Fellowship of the Assemblies of God) | 360   | 60   | 5  | 85%  |
-| 5        | Josiah Osibodu     | Life Church #1 (Life Church)                                     | 350   | 58.3 | 5  | 81%  |
-| 6        | Joshua Weatherholt | Saber of the Spirit (Victory Church)                             | 315   | 52.5 | 4  | 82%  |
-| 7        | Lilli White        | Saber of the Spirit (Victory Church)                             | 240   | 40   | 1  | 86%  |
-| 8        | Juniper Victor     | Scripture Seekers #3 (First Assembly of God)                     | 225   | 37.5 | 1  | 83%  |
-| 9        | Aria Dianand       | Smith Fan Club (Faith Assembly of God)                           | 210   | 35   | 2  | 100% |
-| 10       | Seamus Dowling     | Scripture Seekers #5 (First Assembly of God)                     | 205   | 34.2 | 3  | 80%  |
-| 11       | Emery Voltaire     | Princesses of God (New Life Assembly)                            | 205   | 34.2 | 2  | 87%  |
-| 12       | Ezra Arthur        | Scripture Seekers #5 (First Assembly of God)                     | 195   | 32.5 | 1  | 72%  |
-| 13       | Evelyn Olson       | Life Church #1 (Life Church)                                     | 100   | 16.7 |    | 68%  |
-| 14       | Olivia Miles       | Scripture Seekers #3 (First Assembly of God)                     | 90    | 15   |    | 83%  |
-| 15       | Kylie Rocha        | Princesses of God (New Life Assembly)                            | 70    | 11.7 |    | 62%  |
-| 16       | Maximus Prokop     | Saber of the Spirit (Victory Church)                             | 65    | 10.8 |    | 64%  |
-| 17       | Benton Shick       | Discover (Freedom Christian Fellowship of the Assemblies of God) | 55    | 9.2  |    | 86%  |
-| 18       | Julissa Philippe   | Life Church #1 (Life Church)                                     | 25    | 4.2  |    | 75%  |
-| 19       | Maya Sifford       | Scripture Seekers #3 (First Assembly of God)                     | 20    | 3.3  |    | 100% |
-| 20       | Ana Grace Brignol  | Princesses of God (New Life Assembly)                            | 15    | 2.5  |    | 67%  |
-| 21       | Elli White         | Saber of the Spirit (Victory Church)                             | 10    | 1.7  |    | 100% |
-| 22       | Alijah Lee         | Life Church #1 (Life Church)                                     | 0     |      |    |      |
-| **\*22** | Joel Osibodu       | Life Church #1 (Life Church)                                     | 0     |      |    |      |
-| 23       | Eleanor Prokop     | Saber of the Spirit (Victory Church)                             | -10   | -1.7 |    |      |
-| **\*23** | Jahleel Miles      | Scripture Seekers #5 (First Assembly of God)                     | -10   | -1.7 |    |      |
-
-
-## Rising Stars: Flight 2
-
-### Teams
-
-*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
-
-**COMPLETE:** All Room(s) Reported.
-
-| # | Team / Church                                | W/L   | W%   | Total | Avg   | QO | Q%  |
-|--:|----------------------------------------------|-------|-----:|------:|------:|---:|----:|
-| 1 | FWC Blue (Family Worship Center)             | 6 / 0 | 100% | 940   | 156.7 | 11 | 88% |
-| 2 | Scripture Seekers #4 (First Assembly of God) | 5 / 1 | 83%  | 530   | 88.3  | 7  | 81% |
-| 3 | The Golden Gems (Haven Worship Center)       | 4 / 2 | 67%  | 665   | 110.8 | 9  | 92% |
-| 4 | Little Warriors (New Life Assembly)          | 3 / 3 | 50%  | 480   | 80    | 4  | 83% |
-| 5 | Firespeed (City Church of Orlando)           | 2 / 4 | 33%  | 330   | 55    | 4  | 72% |
-| 6 | The Oompaloompas (Faith Assembly of God)     | 1 / 5 | 17%  | 220   | 36.7  | 2  | 85% |
-| 7 | Gods Princesses (Harvest Assembly of God)    | 0 / 6 |      | 70    | 11.7  |    | 69% |
-
-### Individuals
-
-*Ties broken by Average Points then by Total Quiz Outs*
-
-| #        | Quizzer                 | Team / Church                                | Total | Avg  | QO | Q%   |
-|---------:|-------------------------|----------------------------------------------|------:|-----:|---:|-----:|
-| 1        | Abigail Soriano Batista | The Golden Gems (Haven Worship Center)       | 405   | 67.5 | 6  | 92%  |
-| 2        | Noah Abraham            | FWC Blue (Family Worship Center)             | 400   | 66.7 | 6  | 90%  |
-| 3        | River Larva             | Scripture Seekers #4 (First Assembly of God) | 390   | 65   | 6  | 86%  |
-| 4        | Lilly Liebl             | FWC Blue (Family Worship Center)             | 370   | 61.7 | 5  | 89%  |
-| 5        | Speck Sullivan          | Firespeed (City Church of Orlando)           | 280   | 46.7 | 4  | 78%  |
-| 6        | Pierce Beckham          | The Golden Gems (Haven Worship Center)       | 230   | 38.3 | 3  | 91%  |
-| 7        | Sarmilah Dasmy          | Little Warriors (New Life Assembly)          | 225   | 37.5 | 2  | 88%  |
-| 8        | Kathleen Mec-El         | Little Warriors (New Life Assembly)          | 215   | 35.8 | 2  | 81%  |
-| 9        | Ezra Trimble            | The Oompaloompas (Faith Assembly of God)     | 205   | 34.2 | 2  | 87%  |
-| 10       | Canyon Larva            | Scripture Seekers #4 (First Assembly of God) | 145   | 24.2 | 1  | 76%  |
-| 11       | Alicia Rodriguez        | Gods Princesses (Harvest Assembly of God)    | 60    | 10   |    | 78%  |
-| 12       | Zoe Lynch               | FWC Blue (Family Worship Center)             | 50    | 8.3  |    | 100% |
-| 13       | Hope Williams           | FWC Blue (Family Worship Center)             | 45    | 7.5  |    | 83%  |
-| **\*13** | Khloe Trivett           | FWC Blue (Family Worship Center)             | 45    | 7.5  |    | 83%  |
-| 14       | Malachi Voltaire        | Little Warriors (New Life Assembly)          | 35    | 5.8  |    | 80%  |
-| 15       | Ava McCormick           | FWC Blue (Family Worship Center)             | 30    | 5    |    | 100% |
-| **\*15** | Bryce Warren            | The Golden Gems (Haven Worship Center)       | 30    | 5    |    | 100% |
-| **\*15** | Liam Garcia             | Firespeed (City Church of Orlando)           | 30    | 5    |    | 100% |
-| 16       | Bryce Garner            | Firespeed (City Church of Orlando)           | 25    | 4.2  |    | 57%  |
-| 17       | Rachel Kalu             | The Oompaloompas (Faith Assembly of God)     | 15    | 2.5  |    | 67%  |
-| 18       | Abby Rodriguez          | Gods Princesses (Harvest Assembly of God)    | 10    | 1.7  |    | 50%  |
-| 19       | Ayden Russell           | Little Warriors (New Life Assembly)          | 5     | .8   |    | 50%  |
-| 20       | Aurora Smith            | The Golden Gems (Haven Worship Center)       | 0     |      |    |      |
-| **\*20** | Briella Gonzalez        | Gods Princesses (Harvest Assembly of God)    | 0     |      |    |      |
-| **\*20** | Elianah Bentley         | The Golden Gems (Haven Worship Center)       | 0     |      |    |      |
-| **\*20** | Extra-1                 | Firespeed (City Church of Orlando)           | 0     |      |    |      |
-| **\*20** | Javin Kupsch            | Firespeed (City Church of Orlando)           | 0     |      |    |      |
-| **\*20** | Joshua Buxton           | The Golden Gems (Haven Worship Center)       | 0     |      |    |      |
-| **\*20** | Karis Wolf              | Firespeed (City Church of Orlando)           | 0     |      |    |      |
-| **\*20** | Paisley Shultz          | FWC Blue (Family Worship Center)             | 0     |      |    |      |
-| **\*20** | Raquel Smith            | The Oompaloompas (Faith Assembly of God)     | 0     |      |    |      |
-| **\*20** | Rylee Chapple           | Firespeed (City Church of Orlando)           | 0     |      |    |      |
-| **\*20** | Sarai Santos            | Scripture Seekers #4 (First Assembly of God) | 0     |      |    |      |
-| **\*20** | Knox Howell             | FWC Blue (Family Worship Center)             | 0     |      |    | 33%  |
-| 21       | Selah Santos            | Scripture Seekers #4 (First Assembly of God) | -5    | -.8  |    |      |
-| **\*21** | Caylee Rivera           | Firespeed (City Church of Orlando)           | -5    | -.8  |    | 25%  |
+| #        | Quizzer                     | Team / Church                                        | Total | Avg  | QO | Q%   |
+|---------:|-----------------------------|------------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Ian Joan                    | Scripture Seekers Team 4 (First Assembly of God)     | 280   | 70   | 4  | 100% |
+| 2        | Nathan Alexander            | Jesus Family Ministries #2 (Jesus Family Ministries) | 230   | 57.5 | 3  | 91%  |
+| 3        | Arielle Registre            | Super Gang (New Life Assembly)                       | 225   | 56.3 | 2  | 95%  |
+| 4        | Josiah Hamblen              | Double Edge (Oxford Assembly of God)                 | 215   | 53.8 | 3  | 87%  |
+| 5        | Anish Roger Prem Raja Singh | Jesus Family Ministries #2 (Jesus Family Ministries) | 205   | 51.3 | 3  | 86%  |
+| 6        | Kylie Rocha                 | Princesses of God (New Life Assembly)                | 190   | 47.5 | 2  | 77%  |
+| 7        | Ezra Arthur                 | Scripture Seekers Team 4 (First Assembly of God)     | 145   | 36.3 | 1  | 83%  |
+| 8        | Xander Cullen               | Double Edge (Oxford Assembly of God)                 | 70    | 17.5 | 1  | 52%  |
+| 9        | River Larva                 | Scripture Seekers Team 4 (First Assembly of God)     | 65    | 16.3 |    | 64%  |
+| 10       | Kaitlande Jacques           | Princesses of God (New Life Assembly)                | 45    | 11.3 |    | 83%  |
+| 11       | Kathleen Mec-El             | Super Gang (New Life Assembly)                       | 30    | 7.5  |    | 100% |
+| 12       | Zoe Hahn                    | Double Edge (Oxford Assembly of God)                 | 15    | 3.8  |    | 50%  |
+| 13       | Victoria Fernandez          | Princesses of God (New Life Assembly)                | 10    | 2.5  |    | 99%  |
+| **\*13** | Tabitha Hursell             | Super Gang (New Life Assembly)                       | 10    | 2.5  |    | 99%  |
+| 14       | Sarah Dunham                | Double Edge (Oxford Assembly of God)                 | 0     |      |    |      |
+| **\*14** | Adalynn Vasquez             | Super Gang (New Life Assembly)                       | 0     |      |    |      |
 

--- a/_pages/jbq/2022/other/arkansas-districts-qualifying.md
+++ b/_pages/jbq/2022/other/arkansas-districts-qualifying.md
@@ -12,7 +12,7 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## 2nd and Under
+## 2nd & Under
 
 ### Teams
 
@@ -66,7 +66,7 @@ menubar_toc_static:
 | **\*17** | Meaganley Steele  | Crystal Hill Assembly of God (North Little Rock) #3 (Crystal Hill Assembly of God) | -10   | -1.7 |    |      |
 
 
-## 3rd and 4th
+## 3rd & 4th Grade
 
 ### Teams
 
@@ -114,7 +114,7 @@ menubar_toc_static:
 | 20       | Scarlett Harrison | McArthur Assembly of God (Jacksonville) #2 - White (McArthur Assembly of God)                        | -45   | -7.5  |    | 12%  |
 
 
-## 5th and 6th
+## 5th & 6th Grade
 
 ### Teams
 

--- a/_pages/jbq/2023/districts/georgia.md
+++ b/_pages/jbq/2023/districts/georgia.md
@@ -1,0 +1,153 @@
+---
+layout: page
+title: "2023 Georgia District Finals"
+permalink: /jbq/2023/districts/georgia/
+date: "2023-03-04"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2023 Season
+    link: /jbq/2023/
+    icon: fas fa-home
+---
+
+## Red Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                       | W/L   | Total | Avg | QO | Q%  |
+|----:|-----------------------------------------------------|-------|------:|----:|---:|----:|
+| 1.0 | The Alabasters (4) (Calvary Assembly Church of God) | 5 / 0 | 1170  | 234 | 8  | 93% |
+| 2.0 | Fish Friends (3) (Calvary Assembly Church of God)   | 4 / 1 | 1125  | 225 | 7  | 91% |
+| 3.0 | Anointed Ones (Atlanta Indian Prayer Fellowship)    | 3 / 2 | 670   | 134 | 1  | 82% |
+| 4.0 | Mighty Warriors of Christ (Atlanta Tamil Church)    | 2 / 3 | 660   | 132 | 2  | 83% |
+| 5.0 | Bible Prodigies (Lifeline Church)                   | 1 / 4 | 500   | 100 | 1  | 81% |
+| 6.0 | Faithful Followers (Lifeline Church)                | 0 / 5 | 425   | 85  |    | 97% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                                       | Total | Avg | QO | Q%   |
+|---------:|------------------------|-----------------------------------------------------|------:|----:|---:|-----:|
+| 1        | Joel Abraham           | Fish Friends (3) (Calvary Assembly Church of God)   | 630   | 126 | 3  | 87%  |
+| 2        | Aiden Samuel           | The Alabasters (4) (Calvary Assembly Church of God) | 580   | 116 | 3  | 90%  |
+| 3        | Davis Devadasan        | Mighty Warriors of Christ (Atlanta Tamil Church)    | 505   | 101 | 2  | 89%  |
+| 4        | Gaius Lejo             | The Alabasters (4) (Calvary Assembly Church of God) | 500   | 100 | 5  | 94%  |
+| 5        | Jessica Vadranam       | Anointed Ones (Atlanta Indian Prayer Fellowship)    | 325   | 65  |    | 78%  |
+| 6        | Rufus Lejo             | Fish Friends (3) (Calvary Assembly Church of God)   | 305   | 61  | 4  | 90%  |
+| 7        | Abhishekth Somepalli   | Bible Prodigies (Lifeline Church)                   | 295   | 59  | 1  | 80%  |
+| 8        | Jessica Neela          | Faithful Followers (Lifeline Church)                | 200   | 40  |    | 100% |
+| 9        | Joanne Shinu           | Fish Friends (3) (Calvary Assembly Church of God)   | 190   | 38  |    | 100% |
+| 10       | Steven Daniel          | Anointed Ones (Atlanta Indian Prayer Fellowship)    | 175   | 35  |    | 82%  |
+| 11       | Niven Vijay            | Anointed Ones (Atlanta Indian Prayer Fellowship)    | 170   | 34  | 1  | 86%  |
+| 12       | Benny Immadisetti      | Faithful Followers (Lifeline Church)                | 155   | 31  |    | 90%  |
+| 13       | Mrithun Renat Sriraman | Mighty Warriors of Christ (Atlanta Tamil Church)    | 115   | 23  |    | 81%  |
+| 14       | Blessy Immadishetti    | Bible Prodigies (Lifeline Church)                   | 110   | 22  |    | 100% |
+| 15       | Prajwal Bhupathi       | Bible Prodigies (Lifeline Church)                   | 95    | 19  |    | 70%  |
+| 16       | Joanna Varghese        | The Alabasters (4) (Calvary Assembly Church of God) | 90    | 18  |    | 100% |
+| 17       | Muktaserah Jayaraj     | Faithful Followers (Lifeline Church)                | 70    | 14  |    | 100% |
+| 18       | Evangelin Grace Sheen  | Mighty Warriors of Christ (Atlanta Tamil Church)    | 40    | 8   |    | 60%  |
+| 19       | Titus Shibu            | Fish Friends (3) (Calvary Assembly Church of God)   | 0     |     |    |      |
+| **\*19** | Joel Karemola          | Faithful Followers (Lifeline Church)                | 0     |     |    |      |
+| **\*19** | Varshita Raavi         | Faithful Followers (Lifeline Church)                | 0     |     |    |      |
+| **\*19** | Enosh Paul Raavi       | Bible Prodigies (Lifeline Church)                   | 0     |     |    |      |
+| **\*19** | Sarah Fiona            | Bible Prodigies (Lifeline Church)                   | 0     |     |    |      |
+| **\*19** | Nitya Neela            | Bible Prodigies (Lifeline Church)                   | 0     |     |    |      |
+| **\*19** | Sanjeet Potunuru       | Bible Prodigies (Lifeline Church)                   | 0     |     |    |      |
+| **\*19** | Jesse Kollabathula     | Bible Prodigies (Lifeline Church)                   | 0     |     |    |      |
+| **\*19** | Joanna Samuel          | The Alabasters (4) (Calvary Assembly Church of God) | 0     |     |    |      |
+
+
+## Orange Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                              | W/L   | Total | Avg   | QO | Q%   |
+|----:|------------------------------------------------------------|-------|------:|------:|---:|-----:|
+| 1.0 | Royal Diadem (Atlanta Indian Prayer Fellowship)            | 2 / 0 | 470   | 234.9 | 2  | 97%  |
+| 2.0 | Blessed Bunch (1) (Calvary Assembly Church of God)         | 2 / 1 | 460   | 153.3 | 3  | 100% |
+| 3.0 | Christ Avengers (Georgia Christian Assembly Church of God) | 2 / 1 | 460   | 153.3 | 2  | 94%  |
+| 4.0 | Believers (Atlanta Tamil Church)                           | 1 / 1 | 170   | 85    | 1  | 100% |
+| 5.0 | Truth Seekers (The Church at the Groves)                   | 1 / 2 | 230   | 76.6  | 1  | 100% |
+| 6.0 | Mountain West (Mountain West)                              | 0 / 3 | 40    | 13.3  |    | 75%  |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                                              | Total | Avg   | QO | Q%   |
+|---------:|------------------------|------------------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Jaron Chris Jeremy     | Royal Diadem (Atlanta Indian Prayer Fellowship)            | 210   | 105   | 1  | 92%  |
+| 2        | Rachel Grace Philip    | Christ Avengers (Georgia Christian Assembly Church of God) | 305   | 101.7 | 1  | 94%  |
+| 3        | Jessy Stephen          | Royal Diadem (Atlanta Indian Prayer Fellowship)            | 190   | 95    | 1  | 100% |
+| 4        | Johan K Stephen        | Believers (Atlanta Tamil Church)                           | 170   | 85    | 1  | 100% |
+| 5        | Austin Samuel          | Blessed Bunch (1) (Calvary Assembly Church of God)         | 240   | 80    | 3  | 100% |
+| 6        | Benjamin Battaglia     | Truth Seekers (The Church at the Groves)                   | 230   | 76.7  | 1  | 100% |
+| 7        | Stephen Abraham        | Christ Avengers (Georgia Christian Assembly Church of God) | 120   | 40    | 1  | 100% |
+| 8        | Blessy Rajkumar        | Royal Diadem (Atlanta Indian Prayer Fellowship)            | 70    | 35    |    | 100% |
+| 9        | Joel M Varghese        | Blessed Bunch (1) (Calvary Assembly Church of God)         | 100   | 33.3  |    | 100% |
+| 10       | Aksah Varghese         | Blessed Bunch (1) (Calvary Assembly Church of God)         | 70    | 23.3  |    | 100% |
+| 11       | jeshuran kurian        | Blessed Bunch (1) (Calvary Assembly Church of God)         | 50    | 16.7  |    | 100% |
+| 12       | Krish Sivaramachandran | Mountain West (Mountain West)                              | 40    | 13.3  |    | 100% |
+| 13       | Zachary Thomas         | Christ Avengers (Georgia Christian Assembly Church of God) | 35    | 11.7  |    | 75%  |
+| 14       | Jonathan Hughey        | Mountain West (Mountain West)                              | 0     |       |    | 50%  |
+| **\*14** | Kylie Surface          | Truth Seekers (The Church at the Groves)                   | 0     |       |    |      |
+| **\*14** | LiviaTate              | Truth Seekers (The Church at the Groves)                   | 0     |       |    |      |
+| **\*14** | Katlyn Dooley          | Truth Seekers (The Church at the Groves)                   | 0     |       |    |      |
+| **\*14** | Quizzer-3              | Mountain West (Mountain West)                              | 0     |       |    |      |
+| **\*14** | Joshua Abraham         | Believers (Atlanta Tamil Church)                           | 0     |       |    |      |
+
+
+## Yellow Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                        | W/L   | Total | Avg  | QO | Q%   |
+|----:|------------------------------------------------------|-------|------:|-----:|---:|-----:|
+| 1.0 | Encounter Kids (Griffin First)                       | 3 / 0 | 390   | 130  | 2  | 89%  |
+| 2.1 | Chosen Generation (Atlanta Indian Prayer Fellowship) | 2 / 1 | 215   | 71.6 | 1  | 87%  |
+| 3.0 | God's Warriors (Trinity Church)                      | 2 / 1 | 125   | 41.7 |    | 62%  |
+| 4.1 | Little Lambs (2) (Calvary Assembly Church of God)    | 1 / 2 | 210   | 70   |    | 100% |
+| 5.0 | Servants of the Lord (Trinity Church)                | 1 / 2 | 290   | 96.6 |    | 92%  |
+| 6.0 | Stone Edge (Stone Edge)                              | 0 / 3 | 35    | 11.7 |    | 67%  |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer           | Team / Church                                        | Total | Avg  | QO | Q%   |
+|---------:|-------------------|------------------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Josiah Speir      | Encounter Kids (Griffin First)                       | 240   | 80   | 2  | 100% |
+| 2        | Jubilee Speir     | Encounter Kids (Griffin First)                       | 125   | 41.7 |    | 83%  |
+| 3        | Jason Daniel      | Chosen Generation (Atlanta Indian Prayer Fellowship) | 115   | 38.3 | 1  | 77%  |
+| 4        | Rhema Abraham     | Little Lambs (2) (Calvary Assembly Church of God)    | 110   | 36.7 |    | 100% |
+| **\*4**  | Sophia Fader      | Servants of the Lord (Trinity Church)                | 110   | 36.7 |    | 100% |
+| 5        | Jeffy Joseph      | Chosen Generation (Atlanta Indian Prayer Fellowship) | 100   | 33.3 |    | 100% |
+| 6        | Ethan Cargile     | Servants of the Lord (Trinity Church)                | 95    | 31.7 |    | 89%  |
+| 7        | Judy Abraham      | Little Lambs (2) (Calvary Assembly Church of God)    | 90    | 30   |    | 100% |
+| 8        | Sam Heilman ..    | Servants of the Lord (Trinity Church)                | 65    | 21.7 |    | 83%  |
+| 9        | Luke Heilman      | God's Warriors (Trinity Church)                      | 50    | 16.7 |    | 67%  |
+| 10       | Roman             | God's Warriors (Trinity Church)                      | 45    | 15   |    | 58%  |
+| 11       | Yallerly Stephens | Stone Edge (Stone Edge)                              | 35    | 11.7 |    | 66%  |
+| 12       | Dakota Jett       | Encounter Kids (Griffin First)                       | 25    | 8.3  |    | 67%  |
+| 13       | Julia Purinton    | Servants of the Lord (Trinity Church)                | 20    | 6.7  |    | 100% |
+| 14       | Jayden Varghese   | Little Lambs (2) (Calvary Assembly Church of God)    | 10    | 3.3  |    | 99%  |
+| 15       | Rayona Riju       | Little Lambs (2) (Calvary Assembly Church of God)    | 0     |      |    |      |
+| **\*15** | Ronel Riju        | Little Lambs (2) (Calvary Assembly Church of God)    | 0     |      |    |      |
+| **\*15** | Eden Beasly       | Stone Edge (Stone Edge)                              | 0     |      |    |      |
+| **\*15** | Justice Beasly    | Stone Edge (Stone Edge)                              | 0     |      |    |      |
+| **\*15** | Marcus Johnson    | Stone Edge (Stone Edge)                              | 0     |      |    |      |
+| **\*15** | Kelsey Erehnede   | Stone Edge (Stone Edge)                              | 0     |      |    |      |
+| **\*15** | Kingsly Erehnede  | Stone Edge (Stone Edge)                              | 0     |      |    |      |
+| **\*15** | Jadon Ruel Jeremy | Chosen Generation (Atlanta Indian Prayer Fellowship) | 0     |      |    |      |
+| **\*15** | Jacob Purinton    | Encounter Kids (Griffin First)                       | 0     |      |    |      |
+| **\*15** | Cameron Fader     | God's Warriors (Trinity Church)                      | 0     |      |    |      |
+

--- a/_pages/jbq/2023/districts/illinois.md
+++ b/_pages/jbq/2023/districts/illinois.md
@@ -56,6 +56,40 @@ menubar_toc_static:
 | **\*20** | Niara Chandler         | Naperville (Calvary Church)            | 0     |       |    |      |
 
 
+## B Level
+
+### Teams
+
+*2-way ties broken by head-to-head matches, 3+-way ties broken by points*
+
+| # | Team / Church                               | W/L   | W%  | Total | Avg   | QO | Q%  |
+|--:|---------------------------------------------|-------|----:|------:|------:|---:|----:|
+| 1 | Normal (First Assembly of God)              | 5 / 1 | 83% | 835   | 139.2 | 3  | 94% |
+| 2 | Naperville (Calvary Church)                 | 3 / 3 | 50% | 780   | 130   | 4  | 80% |
+| 3 | Chicago (Metro Praise International Church) | 1 / 5 | 17% | 470   | 78.3  |    | 63% |
+
+### Individuals
+
+*Ties broken by Average Points then by Total Quiz Outs*
+
+| #        | Quizzer              | Team / Church                               | Total | Avg   | QO | Q%   |
+|---------:|----------------------|---------------------------------------------|------:|------:|---:|-----:|
+| 1        | Dhanya Karthick      | Normal (First Assembly of God)              | 725   | 120.8 | 3  | 92%  |
+| 2        | Jeremy James         | Naperville (Calvary Church)                 | 360   | 60    | 4  | 94%  |
+| 3        | Evan Govea           | Chicago (Metro Praise International Church) | 345   | 57.5  |    | 66%  |
+| 4        | Darian Edward        | Naperville (Calvary Church)                 | 290   | 48.3  |    | 68%  |
+| 5        | Oghenefega Ogbebor   | Naperville (Calvary Church)                 | 115   | 19.2  |    | 74%  |
+| 6        | Joanna Victor        | Normal (First Assembly of God)              | 110   | 18.3  |    | 100% |
+| 7        | Micah Scienski       | Chicago (Metro Praise International Church) | 85    | 14.2  |    | 73%  |
+| 8        | Danielle Scienski    | Chicago (Metro Praise International Church) | 40    | 6.7   |    | 46%  |
+| 9        | Oghenevwegba Ogbebor | Naperville (Calvary Church)                 | 20    | 3.3   |    | 100% |
+| 10       | Isaiah Evans         | Normal (First Assembly of God)              | 0     |       |    |      |
+| **\*10** | Johan Gopikrishnan   | Naperville (Calvary Church)                 | 0     |       |    |      |
+| **\*10** | Lucas Wyrostek       | Chicago (Metro Praise International Church) | 0     |       |    |      |
+| **\*10** | Zoe Wyrostek         | Chicago (Metro Praise International Church) | 0     |       |    |      |
+| 11       | Ruth Elizalde        | Naperville (Calvary Church)                 | -5    | -.8   |    |      |
+
+
 ## C Level
 
 ### Teams

--- a/_pages/jbq/2023/districts/kansas.md
+++ b/_pages/jbq/2023/districts/kansas.md
@@ -12,7 +12,56 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## Teams
+## A Division
+
+### Teams
+
+*Ranked by win/loss record. 2-way ties broken by head-to-head matches and 3+-way ties broken by points.*
+
+| # | Team / Church                                                       | W/L   | W%   | Total | Avg | QO | Q%   |
+|--:|---------------------------------------------------------------------|-------|-----:|------:|----:|---:|-----:|
+| 1 | Arise (Bethel Life Center Assembly of God)                          | 5 / 0 | 100% | 1325  | 265 | 7  | 92%  |
+| 2 | Evangel Assembly of God (Wichita) #1 KBI (Evangel Assembly of God)  | 4 / 1 | 80%  | 1125  | 225 | 7  | 90%  |
+| 3 | Ablaze (Bethel Life Center Assembly of God)                         | 3 / 2 | 60%  | 750   | 150 | 4  | 85%  |
+| 4 | Sword bearers-Living Word Assembly (Chanute) (Living Word Assembly) | 2 / 3 | 40%  | 465   | 93  |    | 92%  |
+| 5 | God Squad (First Assembly of God)                                   | 1 / 4 | 20%  | 210   | 42  |    | 79%  |
+| 6 | Family Worship Center (El Dorado) #1 (Family Worship Center)        | 0 / 5 |      | 70    | 14  |    | 100% |
+
+### Individuals
+
+*Ranked by average points, then by total quiz outs, then by answer success rate.*
+
+| #        | Quizzer           | Team / Church                                                       | Total | Avg | QO | Q%   |
+|---------:|-------------------|---------------------------------------------------------------------|------:|----:|---:|-----:|
+| 1        | Ethan Parker      | Arise (Bethel Life Center Assembly of God)                          | 695   | 139 | 5  | 88%  |
+| 2        | Kenedy Hartzler   | Evangel Assembly of God (Wichita) #1 KBI (Evangel Assembly of God)  | 680   | 136 | 4  | 85%  |
+| 3        | Eve Romero        | Ablaze (Bethel Life Center Assembly of God)                         | 510   | 102 | 3  | 96%  |
+| 4        | Sophia Burkholder | Evangel Assembly of God (Wichita) #1 KBI (Evangel Assembly of God)  | 300   | 60  | 2  | 96%  |
+| 5        | David Romero      | Arise (Bethel Life Center Assembly of God)                          | 270   | 54  | 2  | 93%  |
+| 6        | Nolan Dent        | Sword bearers-Living Word Assembly (Chanute) (Living Word Assembly) | 265   | 53  |    | 83%  |
+| 7        | Izi Logsdon       | Arise (Bethel Life Center Assembly of God)                          | 200   | 40  |    | 91%  |
+| 8        | Damian Romero     | Ablaze (Bethel Life Center Assembly of God)                         | 160   | 32  | 1  | 70%  |
+| 9        | Adalyn Batt       | Arise (Bethel Life Center Assembly of God)                          | 160   | 32  |    | 100% |
+| 10       | Naomi Burkholder  | Evangel Assembly of God (Wichita) #1 KBI (Evangel Assembly of God)  | 145   | 29  | 1  | 93%  |
+| 11       | Honroe Ngam       | God Squad (First Assembly of God)                                   | 125   | 25  |    | 89%  |
+| 12       | Ezra Wheeler      | Sword bearers-Living Word Assembly (Chanute) (Living Word Assembly) | 90    | 18  |    | 100% |
+| 13       | JoJo DeWitt       | Ablaze (Bethel Life Center Assembly of God)                         | 80    | 16  |    | 100% |
+| 14       | Jace Mawhirter    | God Squad (First Assembly of God)                                   | 70    | 14  |    | 69%  |
+| **\*14** | Wyatt Farmer      | Sword bearers-Living Word Assembly (Chanute) (Living Word Assembly) | 70    | 14  |    | 100% |
+| 15       | Hailie Eichman    | Family Worship Center (El Dorado) #1 (Family Worship Center)        | 60    | 12  |    | 100% |
+| 16       | John Housh        | Sword bearers-Living Word Assembly (Chanute) (Living Word Assembly) | 40    | 8   |    | 100% |
+| 17       | Jayden Chestnut   | God Squad (First Assembly of God)                                   | 20    | 4   |    | 100% |
+| 18       | Jaylin Starnes    | Family Worship Center (El Dorado) #1 (Family Worship Center)        | 10    | 2   |    | 100% |
+| 19       | Emily Farmer      | Sword bearers-Living Word Assembly (Chanute) (Living Word Assembly) | 0     |     |    |      |
+| **\*19** | Ian Nelson        | Evangel Assembly of God (Wichita) #1 KBI (Evangel Assembly of God)  | 0     |     |    |      |
+| **\*19** | Rylee Wilson      | Ablaze (Bethel Life Center Assembly of God)                         | 0     |     |    |      |
+| **\*19** | Terra Welker      | Sword bearers-Living Word Assembly (Chanute) (Living Word Assembly) | 0     |     |    |      |
+
+*\* Tie couldn't be broken by tie breaking rules.*
+
+## B Division
+
+### Teams
 
 *Ranked by win/loss record. 2-way ties broken by head-to-head matches and 3+-way ties broken by points.*
 
@@ -24,7 +73,7 @@ menubar_toc_static:
 
 *\* Tie couldn't be broken by tie breaking rules.*
 
-## Individuals
+### Individuals
 
 *Ranked by average points, then by total quiz outs, then by answer success rate.*
 
@@ -40,4 +89,38 @@ menubar_toc_static:
 | 8  | Opal Cordel       | Here comes the Buzzers (First Assembly of God)                 | 15    | 3.8  |    | 67%  |
 | 9  | Everly Batt       | Beloved (Bethel Life Center Assembly of God)                   | 10    | 2.5  |    | 100% |
 | 10 | Aiden Thomas      | Here comes the Buzzers (First Assembly of God)                 | -15   | -3.8 |    |      |
+
+
+## I Division
+
+### Teams
+
+*Ranked by win/loss record. 2-way ties broken by head-to-head matches and 3+-way ties broken by points.*
+
+| # | Team / Church                                                | W/L   | W%   | Total | Avg   | QO | Q%  |
+|--:|--------------------------------------------------------------|-------|-----:|------:|------:|---:|----:|
+| 1 | Illuminate (Bethel Life Center Assembly of God)              | 4 / 0 | 100% | 555   | 138.8 | 2  | 84% |
+| 2 | Puppy Buzzers (First Assembly of God)                        | 2 / 2 | 50%  | 445   | 111.2 | 3  | 89% |
+| 3 | Family Worship Center (El Dorado) #2 (Family Worship Center) | 0 / 4 |      | 45    | 11.2  |    | 62% |
+
+### Individuals
+
+*Ranked by average points, then by total quiz outs, then by answer success rate.*
+
+| #       | Quizzer             | Team / Church                                                | Total | Avg  | QO | Q%   |
+|--------:|---------------------|--------------------------------------------------------------|------:|-----:|---:|-----:|
+| 1       | Hannah Gibson       | Illuminate (Bethel Life Center Assembly of God)              | 290   | 72.5 | 2  | 83%  |
+| 2       | Emmett Mawhirter    | Puppy Buzzers (First Assembly of God)                        | 235   | 58.8 | 3  | 88%  |
+| 3       | William Moeder      | Puppy Buzzers (First Assembly of God)                        | 180   | 45   |    | 100% |
+| 4       | Noah Drake          | Illuminate (Bethel Life Center Assembly of God)              | 145   | 36.2 |    | 74%  |
+| 5       | Zeva Geesaman       | Illuminate (Bethel Life Center Assembly of God)              | 120   | 30   |    | 100% |
+| 6       | Olivia Berkstresser | Family Worship Center (El Dorado) #2 (Family Worship Center) | 60    | 15   |    | 86%  |
+| 7       | Autymn Hazle        | Puppy Buzzers (First Assembly of God)                        | 30    | 7.5  |    | 100% |
+| 8       | Emma King           | Illuminate (Bethel Life Center Assembly of God)              | 0     |      |    |      |
+| **\*8** | Landen Eichman      | Family Worship Center (El Dorado) #2 (Family Worship Center) | 0     |      |    |      |
+| **\*8** | Ryker Hazle         | Puppy Buzzers (First Assembly of God)                        | 0     |      |    | 50%  |
+| 9       | Oakley Berkstresser | Family Worship Center (El Dorado) #2 (Family Worship Center) | -5    | -1.2 |    |      |
+| 10      | Colleen Starnes     | Family Worship Center (El Dorado) #2 (Family Worship Center) | -10   | -2.5 |    | 40%  |
+
+*\* Tie couldn't be broken by tie breaking rules.*
 

--- a/_pages/jbq/2023/districts/north-carolina.md
+++ b/_pages/jbq/2023/districts/north-carolina.md
@@ -1,0 +1,93 @@
+---
+layout: page
+title: "2023 North Carolina District Finals"
+permalink: /jbq/2023/districts/north-carolina/
+date: "2023-04-16"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2023 Season
+    link: /jbq/2023/
+    icon: fas fa-home
+---
+
+## Experienced Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                               | W/L   | Total | Avg   | QO | Q%  |
+|----:|---------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | CICF Conquerors (CICF)                      | 8 / 0 | 2000  | 250   | 4  | 85% |
+| 2.0 | Calvary Church (Calvary Church)             | 5 / 3 | 1605  | 200.6 | 4  | 84% |
+| 3.0 | Askewville (Askewville)                     | 4 / 4 | 1315  | 164.4 | 5  | 91% |
+| 4.0 | Greater Life - A (Greater Life)             | 3 / 5 | 1220  | 152.5 | 4  | 81% |
+| 5.0 | Tabernacle of Praise (Tabernacle of Praise) | 0 / 8 | 615   | 76.9  |    | 80% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer               | Team / Church                               | Total | Avg  | QO | Q%   |
+|---------:|-----------------------|---------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Joel Ertzberger       | Askewville (Askewville)                     | 755   | 94.4 | 3  | 89%  |
+| 2        | Rakshania Thomas      | CICF Conquerors (CICF)                      | 755   | 94.4 | 1  | 97%  |
+| 3        | Aena Merlyn Madhanraj | CICF Conquerors (CICF)                      | 625   | 78.1 | 2  | 87%  |
+| 4        | Andrew Baloga         | Calvary Church (Calvary Church)             | 565   | 70.6 | 1  | 81%  |
+| 5        | Matthew Prakash       | Greater Life - A (Greater Life)             | 480   | 60   |    | 78%  |
+| 6        | Rian Darby            | Calvary Church (Calvary Church)             | 430   | 53.8 | 3  | 84%  |
+| 7        | Dorothy Shepard       | Tabernacle of Praise (Tabernacle of Praise) | 365   | 45.6 |    | 83%  |
+| 8        | Caelyn Pesce          | Askewville (Askewville)                     | 355   | 44.4 | 2  | 97%  |
+| 9        | Katelyn Teeter        | Greater Life - A (Greater Life)             | 335   | 41.9 | 4  | 80%  |
+| 10       | Naysa Rapaka          | Calvary Church (Calvary Church)             | 280   | 35   |    | 100% |
+| 11       | Jonathan Gershom      | CICF Conquerors (CICF)                      | 255   | 31.9 | 1  | 72%  |
+| 12       | Rufus Ebenezer Joel   | CICF Conquerors (CICF)                      | 245   | 30.6 |    | 83%  |
+| 13       | Lilly Wolfe           | Greater Life - A (Greater Life)             | 215   | 26.9 |    | 80%  |
+| 14       | Nikitha Vanguri       | Calvary Church (Calvary Church)             | 170   | 21.3 |    | 76%  |
+| **\*14** | Shammah Shepard       | Tabernacle of Praise (Tabernacle of Praise) | 170   | 21.3 |    | 72%  |
+| 15       | Leah Salazzar         | Greater Life - A (Greater Life)             | 30    | 3.8  |    | 100% |
+| 16       | Abby Bock             | Askewville (Askewville)                     | 20    | 2.5  |    | 100% |
+| 17       | Luke Hoggard          | Askewville (Askewville)                     | 15    | 1.9  |    | 66%  |
+| 18       | Grace Olson           | Askewville (Askewville)                     | 10    | 1.3  |    | 50%  |
+
+
+## Novice Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                   | W/L   | Total | Avg   | QO | Q%  |
+|----:|---------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | CICF-Chosen (CICF)              | 8 / 0 | 2320  | 290   | 23 | 97% |
+| 2.0 | CCA-Novice (CCA)                | 6 / 2 | 1155  | 144.4 | 10 | 95% |
+| 3.0 | Calvary Church (Calvary Church) | 4 / 4 | 795   | 99.4  | 4  | 91% |
+| 4.0 | Beekman (Beekman)               | 2 / 6 | 730   | 91.2  | 1  | 93% |
+| 5.0 | Greater Life (Greater Life)     | 0 / 8 | 470   | 58.7  |    | 86% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                   | Total | Avg   | QO | Q%   |
+|---------:|------------------------|---------------------------------|------:|------:|---:|-----:|
+| 1        | Karunia Thomas         | CICF-Chosen (CICF)              | 1010  | 126.3 | 8  | 94%  |
+| 2        | Joann Elizabeth Sanil  | CCA-Novice (CCA)                | 650   | 81.3  | 5  | 95%  |
+| 3        | Joanna Grace Divyanand | CICF-Chosen (CICF)              | 630   | 78.8  | 8  | 100% |
+| 4        | Raphael Gershom        | CICF-Chosen (CICF)              | 520   | 65    | 7  | 96%  |
+| 5        | Miley Ludwig           | Calvary Church (Calvary Church) | 490   | 61.3  | 4  | 92%  |
+| 6        | Evie Chin              | Beekman (Beekman)               | 460   | 57.5  | 1  | 93%  |
+| 7        | Joshua Sanil Varghese  | CCA-Novice (CCA)                | 430   | 53.8  | 5  | 95%  |
+| 8        | Piper Harrell          | Greater Life (Greater Life)     | 195   | 24.4  |    | 95%  |
+| 9        | Lena Chin              | Beekman (Beekman)               | 175   | 21.9  |    | 95%  |
+| 10       | Ethan Brown            | Calvary Church (Calvary Church) | 145   | 18.1  |    | 83%  |
+| 11       | Ryan Michaud           | Greater Life (Greater Life)     | 60    | 7.5   |    | 100% |
+| 12       | Adelina Heaston        | Greater Life (Greater Life)     | 55    | 6.9   |    | 61%  |
+| 13       | Grace Beekman          | Beekman (Beekman)               | 10    | 1.3   |    | 99%  |
+| 14       | Maddie Beekman         | Beekman (Beekman)               | 5     | .6    |    | 50%  |
+| 15       | Nkunim Nyamekye        | Greater Life (Greater Life)     | 0     |       |    |      |
+| **\*15** | Prajwal Tamang         | Greater Life (Greater Life)     | 0     |       |    |      |
+| **\*15** | Jeeven Paulraj         | CICF-Chosen (CICF)              | 0     |       |    |      |
+| **\*15** | Andrew Abraham         | CCA-Novice (CCA)                | 0     |       |    |      |

--- a/_pages/jbq/2023/other/north-carolina-semi-finals.md
+++ b/_pages/jbq/2023/other/north-carolina-semi-finals.md
@@ -1,0 +1,103 @@
+---
+layout: page
+title: "2023 North Carolina Semi Finals"
+permalink: /jbq/2023/other/north-carolina-semi-finals/
+date: "2023-04-16"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2023 Season
+    link: /jbq/2023/
+    icon: fas fa-home
+---
+
+## Experienced Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                               | W/L    | Total | Avg   | QO | Q%  |
+|----:|---------------------------------------------|--------|------:|------:|---:|----:|
+| 1.0 | CICF Conquerors (CICF)                      | 10 / 0 | 2625  | 262.5 | 9  | 90% |
+| 2.1 | Greater Life - A (Greater Life)             | 7 / 3  | 2255  | 225.5 | 12 | 87% |
+| 3.1 | Calvary Church (Calvary Church)             | 7 / 3  | 2225  | 222.5 | 10 | 83% |
+| 4.0 | Askewville (Askewville)                     | 4 / 6  | 1660  | 166   | 10 | 90% |
+| 5.0 | Tabernacle of Praise (Tabernacle of Praise) | 2 / 8  | 710   | 71    | 3  | 76% |
+| 6.0 | Rise Church - A (Rise Church)               | 0 / 10 | 430   | 43    |    | 88% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer               | Team / Church                               | Total | Avg  | QO | Q%   |
+|---------:|-----------------------|---------------------------------------------|------:|-----:|---:|-----:|
+| 1        | Joel Ertzberger       | Askewville (Askewville)                     | 1070  | 107  | 6  | 84%  |
+| 2        | Aena Merlyn Madhanraj | CICF Conquerors (CICF)                      | 885   | 88.5 | 3  | 92%  |
+| 3        | Matthew Prakash       | Greater Life - A (Greater Life)             | 860   | 86   | 3  | 88%  |
+| 4        | Andrew Baloga         | Calvary Church (Calvary Church)             | 785   | 78.5 | 2  | 80%  |
+| 5        | Rakshania Thomas      | CICF Conquerors (CICF)                      | 715   | 71.5 |    | 94%  |
+| 6        | Rian Darby            | Calvary Church (Calvary Church)             | 675   | 67.5 | 7  | 88%  |
+| 7        | Lilly Wolfe           | Greater Life - A (Greater Life)             | 645   | 64.5 | 3  | 82%  |
+| 8        | Rufus Ebenezer Joel   | CICF Conquerors (CICF)                      | 565   | 56.5 | 5  | 91%  |
+| 9        | Katelyn Teeter        | Greater Life - A (Greater Life)             | 520   | 52   | 6  | 87%  |
+| 10       | Dorothy Shepard       | Tabernacle of Praise (Tabernacle of Praise) | 505   | 50.5 | 2  | 86%  |
+| 11       | Naysa Rapaka          | Calvary Church (Calvary Church)             | 400   | 40   | 1  | 95%  |
+| 12       | Caelyn Pesce          | Askewville (Askewville)                     | 370   | 37   | 4  | 100% |
+| 13       | Jonas Hall            | Rise Church - A (Rise Church)               | 320   | 32   |    | 93%  |
+| 14       | Jonathan Gershom      | CICF Conquerors (CICF)                      | 260   | 26   | 1  | 76%  |
+| 15       | Shammah Shepard       | Tabernacle of Praise (Tabernacle of Praise) | 205   | 20.5 | 1  | 69%  |
+| 16       | Nikitha Vanguri       | Calvary Church (Calvary Church)             | 165   | 16.5 |    | 64%  |
+| 17       | Grace Olson           | Askewville (Askewville)                     | 40    | 4    |    | 100% |
+| 18       | Leah Salazzar         | Greater Life - A (Greater Life)             | 30    | 3    |    | 100% |
+| 19       | Simon Hall            | Rise Church - A (Rise Church)               | 10    | 1    |    | 50%  |
+| 20       | Gavin Stafford        | Rise Church - A (Rise Church)               | 0     |      |    | 50%  |
+| **\*20** | Abby Bock             | Askewville (Askewville)                     | 0     |      |    |      |
+| **\*20** | Luke Hoggard          | Askewville (Askewville)                     | 0     |      |    |      |
+
+
+## Novice Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                   | W/L    | Total | Avg   | QO | Q%  |
+|----:|---------------------------------|--------|------:|------:|---:|----:|
+| 1.0 | CICF-Chosen (CICF)              | 10 / 0 | 3005  | 300.5 | 20 | 97% |
+| 2.1 | Calvary Church (Calvary Church) | 6 / 4  | 1180  | 118   | 8  | 96% |
+| 3.1 | CCA-Novice (CCA)                | 6 / 4  | 1120  | 112   | 6  | 89% |
+| 4.0 | Beekman (Beekman)               | 4 / 6  | 875   | 87.5  | 2  | 91% |
+| 5.0 | Greater Life (Greater Life)     | 2 / 8  | 710   | 71    |    | 80% |
+| 6.0 | Rise Church - B (Rise Church)   | 2 / 8  | 470   | 47    |    | 80% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                   | Total | Avg  | QO | Q%   |
+|---------:|------------------------|---------------------------------|------:|-----:|---:|-----:|
+| 1        | Karunia Thomas         | CICF-Chosen (CICF)              | 780   | 78   | 2  | 95%  |
+| 2        | Jeeven Paulraj         | CICF-Chosen (CICF)              | 740   | 74   | 2  | 100% |
+| 3        | Miley Ludwig           | Calvary Church (Calvary Church) | 700   | 70   | 7  | 98%  |
+| 4        | Joann Elizabeth Sanil  | CCA-Novice (CCA)                | 700   | 70   | 6  | 94%  |
+| 5        | Joanna Grace Divyanand | CICF-Chosen (CICF)              | 675   | 67.5 | 9  | 98%  |
+| 6        | Raphael Gershom        | CICF-Chosen (CICF)              | 610   | 61   | 7  | 93%  |
+| 7        | Evie Chin              | Beekman (Beekman)               | 520   | 52   | 1  | 85%  |
+| 8        | Piper Harrell          | Greater Life (Greater Life)     | 320   | 32   |    | 83%  |
+| 9        | Ethan Brown            | Calvary Church (Calvary Church) | 280   | 28   | 1  | 91%  |
+| 10       | Lena Chin              | Beekman (Beekman)               | 255   | 25.5 | 1  | 96%  |
+| 11       | Ally Rawls             | Rise Church - B (Rise Church)   | 245   | 24.5 |    | 76%  |
+| 12       | Joshua Sanil Varghese  | CCA-Novice (CCA)                | 220   | 22   |    | 86%  |
+| 13       | Adelina Heaston        | Greater Life (Greater Life)     | 160   | 16   |    | 71%  |
+| 14       | Julianna Aubrey        | Rise Church - B (Rise Church)   | 110   | 11   |    | 100% |
+| 15       | Luke Aubrey            | Rise Church - B (Rise Church)   | 105   | 10.5 |    | 100% |
+| 16       | Ryan Michaud           | Greater Life (Greater Life)     | 30    | 3    |    | 75%  |
+| 17       | Grace Beekman          | Beekman (Beekman)               | 10    | 1    |    | 99%  |
+| **\*17** | Ava Sanderson          | Rise Church - B (Rise Church)   | 10    | 1    |    | 43%  |
+| **\*17** | Andrew Abraham         | CCA-Novice (CCA)                | 10    | 1    |    | 40%  |
+| 18       | Maddie Beekman         | Beekman (Beekman)               | 0     |      |    |      |
+| **\*18** | Nkunim Nyamekye        | Greater Life (Greater Life)     | 0     |      |    |      |
+| **\*18** | Prajwal Tamang         | Greater Life (Greater Life)     | 0     |      |    |      |
+

--- a/_pages/jbq/2023/tournaments/snow-bowl.md
+++ b/_pages/jbq/2023/tournaments/snow-bowl.md
@@ -12,6 +12,46 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
+## Older Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                                     | W/L   | Total | Avg   | QO | Q%  |
+|----:|---------------------------------------------------|-------|------:|------:|---:|----:|
+| 1.0 | Keepers of the Command (First @ Firewheel)        | 8 / 0 | 1730  | 216.2 | 11 | 81% |
+| 2.1 | God's Royal Reindeer (Oaks Church)                | 5 / 3 | 1395  | 174.4 | 6  | 86% |
+| 3.1 | Prayer Mountain Explorers (Mountain Creek Church) | 5 / 3 | 1015  | 126.9 | 7  | 70% |
+| 4.0 | The A Team (First @ Firewheel)                    | 2 / 6 | 720   | 90    | 3  | 78% |
+| 5.0 | Maranatha (Mountain Creek Church)                 | 0 / 8 | 405   | 50.6  | 1  | 69% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                  | Team / Church                                     | Total | Avg   | QO | Q%   |
+|---------:|--------------------------|---------------------------------------------------|------:|------:|---:|-----:|
+| 1        | Jayden Ramesh            | Keepers of the Command (First @ Firewheel)        | 1110  | 138.8 | 7  | 94%  |
+| 2        | Hannah Lapusan           | God's Royal Reindeer (Oaks Church)                | 735   | 91.9  | 4  | 92%  |
+| 3        | Caleb Stumper            | Prayer Mountain Explorers (Mountain Creek Church) | 675   | 84.4  | 5  | 71%  |
+| 4        | Jonthan Dawit            | The A Team (First @ Firewheel)                    | 550   | 68.8  | 3  | 79%  |
+| 5        | Chizaram Iwuogaranya     | Keepers of the Command (First @ Firewheel)        | 360   | 45    | 3  | 79%  |
+| 6        | Raegan Wirth             | God's Royal Reindeer (Oaks Church)                | 325   | 40.6  | 1  | 93%  |
+| 7        | Noah Zeli                | Prayer Mountain Explorers (Mountain Creek Church) | 295   | 36.9  | 2  | 67%  |
+| 8        | Sarah Lapusan            | God's Royal Reindeer (Oaks Church)                | 215   | 26.9  | 1  | 79%  |
+| 9        | Victoria Preciado        | Maranatha (Mountain Creek Church)                 | 160   | 20    | 1  | 87%  |
+| 10       | Chizaram Echefu          | Keepers of the Command (First @ Firewheel)        | 150   | 18.8  | 1  | 74%  |
+| 11       | Israel Fajemirokun       | Maranatha (Mountain Creek Church)                 | 140   | 17.5  |    | 100% |
+| 12       | Abigail Lapusan          | God's Royal Reindeer (Oaks Church)                | 120   | 15    |    | 78%  |
+| 13       | Chika Iwuogaranya        | The A Team (First @ Firewheel)                    | 110   | 13.8  |    | 90%  |
+| **\*13** | Dozie Osuagwu            | Keepers of the Command (First @ Firewheel)        | 110   | 13.8  |    | 56%  |
+| 14       | Joseph Daniel Zeli       | Maranatha (Mountain Creek Church)                 | 105   | 13.1  |    | 53%  |
+| 15       | Irene Ortiz              | Prayer Mountain Explorers (Mountain Creek Church) | 45    | 5.6   |    | 83%  |
+| 16       | Munachiso Osuagwu (Muna) | The A Team (First @ Firewheel)                    | 40    | 5     |    | 55%  |
+| 17       | Chinasa Ayozie           | The A Team (First @ Firewheel)                    | 10    | 1.3   |    | 99%  |
+| 18       | Hannah Gonzales          | Prayer Mountain Explorers (Mountain Creek Church) | 0     |       |    |      |
+
 ## Beginner Division
 
 ### Teams
@@ -37,4 +77,47 @@ menubar_toc_static:
 | 5       | Ethan Fajemirokun | MC Prayer Pushers (Mountain Creek Church) | 5     | 1.7  |    | 50%  |
 | **\*5** | Hannah Ye         | Judith's Elves (First @ Firewheel)        | 5     | 1.7  |    | 50%  |
 | **\*5** | Diya Harilal      | Judith's Elves (First @ Firewheel)        | 5     | 1.7  |    | 50%  |
+
+## PeeWee Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points*
+
+| #   | Team / Church                              | W/L   | Total | Avg | QO | Q%  |
+|----:|--------------------------------------------|-------|------:|----:|---:|----:|
+| 1.0 | David's Army (Encounter Church)            | 5 / 0 | 620   | 124 | 6  | 82% |
+| 2.0 | Team Believe (First @ Firewheel)           | 4 / 1 | 560   | 112 | 7  | 87% |
+| 3.0 | Trinity Quiz Kids (Trinity Church)         | 3 / 2 | 400   | 80  | 4  | 83% |
+| 4.0 | God's Sunflowers (Freedom Church)          | 2 / 3 | 345   | 69  | 2  | 75% |
+| 5.0 | Faith, Hope & Love (Mountain Creek Church) | 1 / 4 | 285   | 57  | 3  | 77% |
+| 6.0 | Royal Buzzers (Bethesda AG)                | 0 / 5 | 155   | 31  |    | 94% |
+
+### Individuals
+
+*Ties broken by Average Points then Total Quiz Outs*
+
+| #        | Quizzer                | Team / Church                              | Total | Avg | QO | Q%   |
+|---------:|------------------------|--------------------------------------------|------:|----:|---:|-----:|
+| 1        | Ryan Azubuike          | Team Believe (First @ Firewheel)           | 285   | 57  | 4  | 84%  |
+| 2        | Vincent Rowland        | David's Army (Encounter Church)            | 285   | 57  | 3  | 85%  |
+| 3        | Xavier Azubuike        | Team Believe (First @ Firewheel)           | 275   | 55  | 3  | 90%  |
+| 4        | Hope Zeli              | Faith, Hope & Love (Mountain Creek Church) | 260   | 52  | 3  | 81%  |
+| 5        | Caroline Rowland       | David's Army (Encounter Church)            | 225   | 45  | 3  | 77%  |
+| 6        | Skyler Howard          | Trinity Quiz Kids (Trinity Church)         | 220   | 44  | 3  | 79%  |
+| 7        | Asher Johnson          | Trinity Quiz Kids (Trinity Church)         | 185   | 37  | 1  | 95%  |
+| 8        | Dallas Olivarez-Binion | David's Army (Encounter Church)            | 110   | 22  |    | 86%  |
+| 9        | Autumn Block           | Royal Buzzers (Bethesda AG)                | 90    | 18  |    | 100% |
+| 10       | Kylie DeLeon           | Royal Buzzers (Bethesda AG)                | 65    | 13  |    | 87%  |
+| 11       | Callowaye Burrow       | God's Sunflowers (Freedom Church)          | 60    | 12  |    | 67%  |
+| **\*11** | AnnaMarie Whiston      | God's Sunflowers (Freedom Church)          | 60    | 12  |    | 67%  |
+| 12       | AnnaRose Hodge         | God's Sunflowers (Freedom Church)          | 50    | 10  |    | 100% |
+| 13       | Faith Fajemirokun      | Faith, Hope & Love (Mountain Creek Church) | 25    | 5   |    | 57%  |
+| 14       | Isaiah Tonhorai        | God's Sunflowers (Freedom Church)          | 5     | 1   |    | 40%  |
+| 15       | Brooklyn Herrera       | Trinity Quiz Kids (Trinity Church)         | 0     |     |    |      |
+| **\*15** | Junior Darko           | Team Believe (First @ Firewheel)           | 0     |     |    |      |
+| **\*15** | Norbert Azubuike       | Team Believe (First @ Firewheel)           | 0     |     |    |      |
+| **\*15** | Juliette Mora          | Royal Buzzers (Bethesda AG)                | 0     |     |    |      |
+| **\*15** | Quizzer-3              | Faith, Hope & Love (Mountain Creek Church) | 0     |     |    |      |
+| 16       | Gideon Bennett         | Trinity Quiz Kids (Trinity Church)         | -5    | -1  |    |      |
 


### PR DESCRIPTION
Some JBQ.org meets were missed for certain JBQ events and TBQ tournaments. This change adds the missing data.