### PR TITLE
Add regional scores from the Archive

### DIFF
--- a/_data/imported/2010.yml
+++ b/_data/imported/2010.yml
@@ -20,6 +20,10 @@ tbq:
     scope: region
     scopeLabel: Northwest
     scoresLink: /history/2010/regionals/northwest/
+  - name: "2010 Southwest Regionals"
+    scope: region
+    scopeLabel: Southwest
+    scoresLink: /history/2010/regionals/southwest/
   tournament:
   - name: Berean Family Classic
     scope: tournament

--- a/_data/imported/2010.yml
+++ b/_data/imported/2010.yml
@@ -16,6 +16,10 @@ tbq:
     scope: region
     scopeLabel: Northeast
     scoresLink: /history/2010/regionals/northeast/
+  - name: "2010 Northwest Regionals"
+    scope: region
+    scopeLabel: Northwest
+    scoresLink: /history/2010/regionals/northwest/
   tournament:
   - name: Berean Family Classic
     scope: tournament

--- a/_data/imported/2010.yml
+++ b/_data/imported/2010.yml
@@ -4,6 +4,10 @@ tbq:
     scope: region
     scopeLabel: Great Lakes
     scoresLink: /history/2010/regionals/great-lakes/
+  - name: "2010 Gulf Regionals"
+    scope: region
+    scopeLabel: Gulf
+    scoresLink: /history/2010/regionals/gulf/
   tournament:
   - name: Berean Family Classic
     scope: tournament

--- a/_data/imported/2010.yml
+++ b/_data/imported/2010.yml
@@ -20,6 +20,10 @@ tbq:
     scope: region
     scopeLabel: Northwest
     scoresLink: /history/2010/regionals/northwest/
+  - name: "2010 Southeast Regionals"
+    scope: region
+    scopeLabel: Southeast
+    scoresLink: /history/2010/regionals/southeast/
   - name: "2010 Southwest Regionals"
     scope: region
     scopeLabel: Southwest

--- a/_data/imported/2010.yml
+++ b/_data/imported/2010.yml
@@ -1,4 +1,9 @@
 tbq:
+  regionFinals:
+  - name: "2010 Great Lakes Regionals"
+    scope: region
+    scopeLabel: Great Lakes
+    scoresLink: /history/2010/regionals/great-lakes/
   tournament:
   - name: Berean Family Classic
     scope: tournament

--- a/_data/imported/2010.yml
+++ b/_data/imported/2010.yml
@@ -8,6 +8,10 @@ tbq:
     scope: region
     scopeLabel: Gulf
     scoresLink: /history/2010/regionals/gulf/
+  - name: "2010 North Central Regionals"
+    scope: region
+    scopeLabel: North Central
+    scoresLink: /history/2010/regionals/north-central/
   tournament:
   - name: Berean Family Classic
     scope: tournament

--- a/_data/imported/2010.yml
+++ b/_data/imported/2010.yml
@@ -20,6 +20,10 @@ tbq:
     scope: region
     scopeLabel: Northwest
     scoresLink: /history/2010/regionals/northwest/
+  - name: "2010 South Central Regionals"
+    scope: region
+    scopeLabel: South Central
+    scoresLink: /history/2010/regionals/south-central/
   - name: "2010 Southeast Regionals"
     scope: region
     scopeLabel: Southeast

--- a/_data/imported/2010.yml
+++ b/_data/imported/2010.yml
@@ -12,6 +12,10 @@ tbq:
     scope: region
     scopeLabel: North Central
     scoresLink: /history/2010/regionals/north-central/
+  - name: "2010 Northeast Regionals"
+    scope: region
+    scopeLabel: Northeast
+    scoresLink: /history/2010/regionals/northeast/
   tournament:
   - name: Berean Family Classic
     scope: tournament

--- a/_data/imported/2011.yml
+++ b/_data/imported/2011.yml
@@ -26,6 +26,10 @@ tbq:
     scope: region
     scopeLabel: Northwest
     scoresLink: /history/2011/regionals/northwest/
+  - name: "2011 Southwest Regionals"
+    scope: region
+    scopeLabel: Southwest
+    scoresLink: /history/2011/regionals/southwest/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2011.yml
+++ b/_data/imported/2011.yml
@@ -26,6 +26,10 @@ tbq:
     scope: region
     scopeLabel: Northwest
     scoresLink: /history/2011/regionals/northwest/
+  - name: "2011 Southeast Regionals"
+    scope: region
+    scopeLabel: Southeast
+    scoresLink: /history/2011/regionals/southeast/
   - name: "2011 Southwest Regionals"
     scope: region
     scopeLabel: Southwest

--- a/_data/imported/2011.yml
+++ b/_data/imported/2011.yml
@@ -18,6 +18,10 @@ tbq:
     scope: region
     scopeLabel: North Central
     scoresLink: /history/2011/regionals/north-central/
+  - name: "2011 Northeast Regionals"
+    scope: region
+    scopeLabel: Northeast
+    scoresLink: /history/2011/regionals/northeast/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2011.yml
+++ b/_data/imported/2011.yml
@@ -10,6 +10,10 @@ tbq:
     scope: region
     scopeLabel: Great Lakes
     scoresLink: /history/2011/regionals/great-lakes/
+  - name: "2011 Gulf Regionals"
+    scope: region
+    scopeLabel: Gulf
+    scoresLink: /history/2011/regionals/gulf/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2011.yml
+++ b/_data/imported/2011.yml
@@ -14,6 +14,10 @@ tbq:
     scope: region
     scopeLabel: Gulf
     scoresLink: /history/2011/regionals/gulf/
+  - name: "2011 North Central Regionals"
+    scope: region
+    scopeLabel: North Central
+    scoresLink: /history/2011/regionals/north-central/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2011.yml
+++ b/_data/imported/2011.yml
@@ -26,6 +26,10 @@ tbq:
     scope: region
     scopeLabel: Northwest
     scoresLink: /history/2011/regionals/northwest/
+  - name: "2011 South Central Regionals"
+    scope: region
+    scopeLabel: South Central
+    scoresLink: /history/2011/regionals/south-central/
   - name: "2011 Southeast Regionals"
     scope: region
     scopeLabel: Southeast

--- a/_data/imported/2011.yml
+++ b/_data/imported/2011.yml
@@ -22,6 +22,10 @@ tbq:
     scope: region
     scopeLabel: Northeast
     scoresLink: /history/2011/regionals/northeast/
+  - name: "2011 Northwest Regionals"
+    scope: region
+    scopeLabel: Northwest
+    scoresLink: /history/2011/regionals/northwest/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2011.yml
+++ b/_data/imported/2011.yml
@@ -5,6 +5,11 @@ jbq:
     scopeLabel: Arkansas
     scoresLink: /jbq/2011/districts/arkansas/
 tbq:
+  regionFinals:
+  - name: "2011 Great Lakes Regionals"
+    scope: region
+    scopeLabel: Great Lakes
+    scoresLink: /history/2011/regionals/great-lakes/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2012.yml
+++ b/_data/imported/2012.yml
@@ -51,6 +51,10 @@ tbq:
     scope: region
     scopeLabel: Southeast
     scoresLink: /history/2012/regionals/southeast/
+  - name: "2012 Southwest Regionals"
+    scope: region
+    scopeLabel: Southwest
+    scoresLink: /history/2012/regionals/southwest/
   districtFinals:
   - name: "2012 Oklahoma District Finals"
     scope: district

--- a/_data/imported/2012.yml
+++ b/_data/imported/2012.yml
@@ -23,6 +23,10 @@ jbq:
     scoresLink: /jbq/2012/districts/arkansas/
 tbq:
   regionFinals:
+  - name: "2012 Great Lakes Regionals"
+    scope: region
+    scopeLabel: Great Lakes
+    scoresLink: /history/2012/regionals/great-lakes/
   - name: "2012 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2012.yml
+++ b/_data/imported/2012.yml
@@ -39,6 +39,10 @@ tbq:
     scope: region
     scopeLabel: Northeast
     scoresLink: /history/2012/regionals/northeast/
+  - name: "2012 Northwest Regionals"
+    scope: region
+    scopeLabel: Northwest
+    scoresLink: /history/2012/regionals/northwest/
   - name: "2012 South Central Regionals"
     scope: region
     scopeLabel: South Central

--- a/_data/imported/2012.yml
+++ b/_data/imported/2012.yml
@@ -27,6 +27,10 @@ tbq:
     scope: region
     scopeLabel: Great Lakes
     scoresLink: /history/2012/regionals/great-lakes/
+  - name: "2012 Gulf Regionals"
+    scope: region
+    scopeLabel: Gulf
+    scoresLink: /history/2012/regionals/gulf/
   - name: "2012 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2012.yml
+++ b/_data/imported/2012.yml
@@ -31,6 +31,10 @@ tbq:
     scope: region
     scopeLabel: Gulf
     scoresLink: /history/2012/regionals/gulf/
+  - name: "2012 North Central Regionals"
+    scope: region
+    scopeLabel: North Central
+    scoresLink: /history/2012/regionals/north-central/
   - name: "2012 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2013.yml
+++ b/_data/imported/2013.yml
@@ -24,6 +24,10 @@ tbq:
     scope: region
     scopeLabel: Great Lakes
     scoresLink: /history/2013/regionals/great-lakes/
+  - name: "2013 Gulf Regionals"
+    scope: region
+    scopeLabel: Gulf
+    scoresLink: /history/2013/regionals/gulf/
   - name: "2013 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2013.yml
+++ b/_data/imported/2013.yml
@@ -20,6 +20,10 @@ jbq:
     scoresLink: /jbq/2013/other/arkansas-razorback/
 tbq:
   regionFinals:
+  - name: "2013 Great Lakes Regionals"
+    scope: region
+    scopeLabel: Great Lakes
+    scoresLink: /history/2013/regionals/great-lakes/
   - name: "2013 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2013.yml
+++ b/_data/imported/2013.yml
@@ -48,6 +48,10 @@ tbq:
     scope: region
     scopeLabel: Southeast
     scoresLink: /history/2013/regionals/southeast/
+  - name: "2013 Southwest Regionals"
+    scope: region
+    scopeLabel: Southwest
+    scoresLink: /history/2013/regionals/southwest/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2013.yml
+++ b/_data/imported/2013.yml
@@ -28,6 +28,10 @@ tbq:
     scope: region
     scopeLabel: Gulf
     scoresLink: /history/2013/regionals/gulf/
+  - name: "2013 North Central Regionals"
+    scope: region
+    scopeLabel: North Central
+    scoresLink: /history/2013/regionals/north-central/
   - name: "2013 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2013.yml
+++ b/_data/imported/2013.yml
@@ -36,6 +36,10 @@ tbq:
     scope: region
     scopeLabel: Northeast
     scoresLink: /history/2013/regionals/northeast/
+  - name: "2013 Northwest Regionals"
+    scope: region
+    scopeLabel: Northwest
+    scoresLink: /history/2013/regionals/northwest/
   - name: "2013 South Central Regionals"
     scope: region
     scopeLabel: South Central

--- a/_data/imported/2014.yml
+++ b/_data/imported/2014.yml
@@ -41,6 +41,10 @@ jbq:
     scoresLink: /jbq/2014/other/arkansas-razorback/
 tbq:
   regionFinals:
+  - name: "2014 Great Lakes Regionals"
+    scope: region
+    scopeLabel: Great Lakes
+    scoresLink: /history/2014/regionals/great-lakes/
   - name: "2014 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2014.yml
+++ b/_data/imported/2014.yml
@@ -65,6 +65,10 @@ tbq:
     scope: region
     scopeLabel: Southeast
     scoresLink: /history/2014/regionals/southeast/
+  - name: "2014 Southwest Regionals"
+    scope: region
+    scopeLabel: Southwest
+    scoresLink: /history/2014/regionals/southwest/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2014.yml
+++ b/_data/imported/2014.yml
@@ -57,6 +57,10 @@ tbq:
     scope: region
     scopeLabel: Northeast
     scoresLink: /history/2014/regionals/northeast/
+  - name: "2014 Northwest Regionals"
+    scope: region
+    scopeLabel: Northwest
+    scoresLink: /history/2014/regionals/northwest/
   - name: "2014 Southeast Regionals"
     scope: region
     scopeLabel: Southeast

--- a/_data/imported/2014.yml
+++ b/_data/imported/2014.yml
@@ -45,6 +45,10 @@ tbq:
     scope: region
     scopeLabel: Great Lakes
     scoresLink: /history/2014/regionals/great-lakes/
+  - name: "2014 Gulf Regionals"
+    scope: region
+    scopeLabel: Gulf
+    scoresLink: /history/2014/regionals/gulf/
   - name: "2014 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2014.yml
+++ b/_data/imported/2014.yml
@@ -49,6 +49,10 @@ tbq:
     scope: region
     scopeLabel: Gulf
     scoresLink: /history/2014/regionals/gulf/
+  - name: "2014 North Central Regionals"
+    scope: region
+    scopeLabel: North Central
+    scoresLink: /history/2014/regionals/north-central/
   - name: "2014 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2014.yml
+++ b/_data/imported/2014.yml
@@ -61,6 +61,10 @@ tbq:
     scope: region
     scopeLabel: Northwest
     scoresLink: /history/2014/regionals/northwest/
+  - name: "2014 South Central Regionals"
+    scope: region
+    scopeLabel: South Central
+    scoresLink: /history/2014/regionals/south-central/
   - name: "2014 Southeast Regionals"
     scope: region
     scopeLabel: Southeast

--- a/_data/imported/2015.yml
+++ b/_data/imported/2015.yml
@@ -52,6 +52,10 @@ tbq:
     scope: region
     scopeLabel: Northeast
     scoresLink: /history/2015/regionals/northeast/
+  - name: "2015 Northwest Regionals"
+    scope: region
+    scopeLabel: Northwest
+    scoresLink: /history/2015/regionals/northwest/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2015.yml
+++ b/_data/imported/2015.yml
@@ -36,6 +36,10 @@ jbq:
     scoresLink: /jbq/2015/other/arkansas-razorback/
 tbq:
   regionFinals:
+  - name: "2015 Gulf Regionals"
+    scope: region
+    scopeLabel: Gulf
+    scoresLink: /history/2015/regionals/gulf/
   - name: "2015 Southeast Regionals"
     scope: region
     scopeLabel: Southeast

--- a/_data/imported/2015.yml
+++ b/_data/imported/2015.yml
@@ -44,6 +44,10 @@ tbq:
     scope: region
     scopeLabel: Southeast
     scoresLink: /history/2015/regionals/southeast/
+  - name: "2015 North Central Regionals"
+    scope: region
+    scopeLabel: North Central
+    scoresLink: /history/2015/regionals/north-central/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2015.yml
+++ b/_data/imported/2015.yml
@@ -40,10 +40,6 @@ tbq:
     scope: region
     scopeLabel: Gulf
     scoresLink: /history/2015/regionals/gulf/
-  - name: "2015 Southeast Regionals"
-    scope: region
-    scopeLabel: Southeast
-    scoresLink: /history/2015/regionals/southeast/
   - name: "2015 North Central Regionals"
     scope: region
     scopeLabel: North Central
@@ -56,6 +52,14 @@ tbq:
     scope: region
     scopeLabel: Northwest
     scoresLink: /history/2015/regionals/northwest/
+  - name: "2015 South Central Regionals"
+    scope: region
+    scopeLabel: South Central
+    scoresLink: /history/2015/regionals/south-central/
+  - name: "2015 Southeast Regionals"
+    scope: region
+    scopeLabel: Southeast
+    scoresLink: /history/2015/regionals/southeast/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2015.yml
+++ b/_data/imported/2015.yml
@@ -48,6 +48,10 @@ tbq:
     scope: region
     scopeLabel: North Central
     scoresLink: /history/2015/regionals/north-central/
+  - name: "2015 Northeast Regionals"
+    scope: region
+    scopeLabel: Northeast
+    scoresLink: /history/2015/regionals/northeast/
   tournament:
   - name: River Classic
     scope: tournament

--- a/_data/imported/2016.yml
+++ b/_data/imported/2016.yml
@@ -45,6 +45,10 @@ tbq:
     scope: region
     scopeLabel: Northeast
     scoresLink: /history/2016/regionals/northeast/
+  - name: "2016 Northwest Regionals"
+    scope: region
+    scopeLabel: Northwest
+    scoresLink: /history/2016/regionals/northwest/
   - name: "2016 South Central Regionals"
     scope: region
     scopeLabel: South Central

--- a/_data/imported/2016.yml
+++ b/_data/imported/2016.yml
@@ -37,6 +37,10 @@ tbq:
     scope: region
     scopeLabel: Gulf
     scoresLink: /history/2016/regionals/gulf/
+  - name: "2016 North Central Regionals"
+    scope: region
+    scopeLabel: North Central
+    scoresLink: /history/2016/regionals/north-central/
   - name: "2016 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2016.yml
+++ b/_data/imported/2016.yml
@@ -33,6 +33,10 @@ tbq:
     scope: region
     scopeLabel: Great Lakes
     scoresLink: /history/2016/regionals/great-lakes/
+  - name: "2016 Gulf Regionals"
+    scope: region
+    scopeLabel: Gulf
+    scoresLink: /history/2016/regionals/gulf/
   - name: "2016 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2016.yml
+++ b/_data/imported/2016.yml
@@ -29,6 +29,10 @@ jbq:
     scoresLink: /jbq/2016/other/arkansas-big-buck-memorial/
 tbq:
   regionFinals:
+  - name: "2016 Great Lakes Regionals"
+    scope: region
+    scopeLabel: Great Lakes
+    scoresLink: /history/2016/regionals/great-lakes/
   - name: "2016 Northeast Regionals"
     scope: region
     scopeLabel: Northeast

--- a/_data/imported/2017.yml
+++ b/_data/imported/2017.yml
@@ -59,6 +59,10 @@ tbq:
     scope: region
     scopeLabel: Southeast
     scoresLink: /history/2017/regionals/southeast/
+  - name: "2017 Southwest Regionals"
+    scope: region
+    scopeLabel: Southwest
+    scoresLink: /history/2017/regionals/southwest/
   districtFinals:
   - name: "2017 Northwest District Finals"
     scope: district

--- a/_pages/history/2010/regionals/great-lakes.md
+++ b/_pages/history/2010/regionals/great-lakes.md
@@ -1,0 +1,176 @@
+---
+layout: page
+title: "2010 Great Lakes Regionals"
+permalink: /history/2010/regionals/great-lakes/
+date: "2010-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2010 Season
+    link: /history/2010/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+|    # | Team                                              |   Avg | Total |    W |    L |
+| ---: | ------------------------------------------------- | ----: | ----: | ---: | ---: |
+|    1 | Meadowbrook - Champaign, IL                       | 229.3 |  3210 |   14 |    0 |
+|    2 | Dayspring "Am Herratz" - Bowling Green, OH        |   230 |  3220 |   13 |    1 |
+|   3* | "Running Aimlessly" - White Cloud, MI             |   200 |  2800 |   10 |    4 |
+|   4* | First Assembly #2 - Lexington, KY                 | 181.1 |  2535 |   10 |    4 |
+|   5* | First Assembly Greater Lansing - East Lansing, MI | 148.9 |  2085 |   10 |    4 |
+|  6** | Radiant Life - Elkhart, IN                        | 109.3 |  1530 |    8 |    6 |
+|  7** | First Assembly #1 - Lexington, KY                 | 126.8 |  1775 |    8 |    6 |
+|    8 | The Stone Church - Palos Heights, IL              |   120 |  1680 |    7 |    7 |
+|    9 | Lafayette First Assembly - Lafayette, IN          | 115.7 |  1620 |    7 |    7 |
+|   10 | Calvary Community - Munster, IN                   |  85.4 |  1195 |    5 |    9 |
+|   11 | Lakeview Church - Indianapolis, IN                |  78.2 |  1095 |    5 |    9 |
+|   12 | Franklin Assembly - Franklin, IN                  |  51.5 |   772 |    3 |   10 |
+|   13 | Painesville A/G - Painesville, OH                 |  85.4 |  1195 |    2 |   12 |
+|   14 | "Super Apostles" - White Cloud, MI                |  40.7 |   570 |    2 |   12 |
+|   15 | Trinity Assembly - Georgetown, KY                 |  38.9 |   545 |    1 |   13 |
+
+\*	By points due to no clear head to head winner\
+\*\*	Elkhart defeated Lexington #1 in head to head play off
+
+### Individuals
+
+|    # | Quizzer             | Team                                            |   Avg | Total | QO Fwd | QO Bk |
+| ---: | ------------------- | ----------------------------------------------- | ----: | ----: | -----: | ----: |
+|    1 | Jacob Wyatt         | Meadowbrook - Champaign, IL                     | 130.7 |  1830 |     13 |     1 |
+|    2 | Jeremy Albrecht     | Dayspring "Am Herratz" - Bowling Green, OH      | 129.3 |  1810 |     13 |     0 |
+|    3 | Courtney Walin      | The Stone Church - Palos Heights, IL            | 102.9 |  1440 |     10 |     0 |
+|    4 | Brady Wilson        | "Running Aimlessly" - White Cloud, MI           |  88.2 |  1235 |      8 |     0 |
+|    5 | Hillari Wyatt       | Meadowbrook - Champaign, IL                     |    80 |  1120 |     12 |     1 |
+|    6 | Kristen Austgen     | Calvary Community - Munster, IN                 |  78.6 |  1100 |      8 |     4 |
+|    7 | Ethan Brown         | Painesville A/G - Painesville, OH               |  77.5 |  1085 |      8 |     1 |
+|    8 | Whitney Harr        | First Assembly Greater Lansing-East Lansing, MI |  76.4 |  1070 |      9 |     2 |
+|    9 | Samuel Pryer        | "Running Aimlessly" - White Cloud, MI           |  74.6 |  1045 |      8 |     3 |
+|   10 | Rebekah Kelly       | First Assembly #2 - Lexington, KY               |  71.1 |   995 |     11 |     1 |
+|   11 | Hannah Netherton    | Lafayette First Assembly - Lafayette, IN        |  69.3 |   970 |      9 |     2 |
+|   12 | Christen Smith      | First Assembly #1 - Lexington, KY               |  64.3 |   900 |      9 |     4 |
+|   13 | Caedy Convis        | First Assembly Greater Lansing-East Lansing, MI |  62.9 |   880 |      8 |     0 |
+|   14 | Ryan Albrecht       | Dayspring "Am Herratz" - Bowling Green, OH      |  62.5 |   875 |      7 |     1 |
+|   15 | Hannah Ishikawa     | Lakeview Church - Indianapolis, IN              |  60.7 |   850 |      6 |     0 |
+|   16 | Makena Schrock      | Radiant Life - Elkhart, IN                      |  57.5 |   805 |      6 |     2 |
+|   17 | Billy Laakkonen     | First Assembly #2 - Lexington, KY               |  46.4 |   650 |      6 |     1 |
+|   18 | Nathaniel Winckler  | First Assembly #2 - Lexington, KY               |  43.6 |   610 |      4 |     1 |
+|   19 | Brianna Albrecht    | Dayspring "Am Herratz" - Bowling Green, OH      |  37.5 |   525 |      2 |     1 |
+|   20 | Thomas Pryor        | "Running Aimlessly" - White Cloud, MI           |  37.1 |   520 |      6 |     3 |
+|   21 | Will Turner         | Trinity Assembly - Georgetown, KY               |  37.1 |   520 |      2 |     0 |
+|   22 | James Cary          | Franklin Assembly - Franklin, IN                |  36.4 |   510 |      3 |     4 |
+|   23 | Geddy Walker        | First Assembly #1 - Lexington, KY               |  31.1 |   435 |      4 |     2 |
+|   24 | Olivia Cox          | First Assembly #1 - Lexington, KY               |  31.1 |   435 |      2 |     0 |
+|   25 | Jonathan Utley      | Radiant Life - Elkhart, IN                      |  29.3 |   410 |      2 |     1 |
+|   26 | Tammy Vickerman     | Lafayette First Assembly - Lafayette, IN        |    25 |   350 |      1 |     0 |
+|   27 | Mariel Netherton    | Lafayette First Assembly - Lafayette, IN        |  21.4 |   300 |      0 |     0 |
+|   28 | Kenadee Schrock     | Radiant Life - Elkhart, IN                      |    20 |   280 |      0 |     1 |
+|   29 | David Smith         | First Assembly #2 - Lexington, KY               |  19.3 |   270 |      1 |     1 |
+|   30 | Timothy Pryer       | "Super Apostles" - White Cloud, MI              |  18.6 |   260 |      2 |     6 |
+|   31 | Mitt Wyatt          | Meadowbrook - Champaign, IL                     |  18.6 |   260 |      1 |     2 |
+|   32 | Miriam Thomas       | Lakeview Church - Indianapolis, IN              |  17.9 |   250 |      0 |     0 |
+|   33 | Cody Wolf           | The Stone Church - Palos Heights, IL            |  16.1 |   225 |      0 |     0 |
+|   34 | Andy Wilson         | "Super Apostles" - White Cloud, MI              |  12.9 |   180 |      2 |     1 |
+|   35 | Phillip Furnish     | Franklin Assembly - Franklin, IN                |  12.5 |   175 |      0 |     0 |
+|   36 | David Buffham       | First Assembly Greater Lansing-East Lansing, MI |  10.4 |   145 |      0 |     0 |
+|   37 | David Pryer         | "Super Apostles" - White Cloud, MI              |   8.6 |   120 |      1 |     2 |
+|   38 | Ali Priest          | Franklin Assembly - Franklin, IN                |   6.4 |    90 |      0 |     0 |
+|   39 | David Sears         | Calvary Community - Munster, IN                 |   5.7 |    80 |      0 |     1 |
+|   40 | Emily Brown         | Painesville A/G - Painesville, OH               |   4.3 |    60 |      0 |     0 |
+|   41 | Matt Jerman         | Painesville A/G - Painesville, OH               |   3.2 |    45 |      0 |     0 |
+|   42 | Nicholas Johnson    | Trinity Assembly - Georgetown, KY               |   2.5 |    35 |      0 |     1 |
+|   43 | Lindsay Hershberger | Radiant Life - Elkhart, IN                      |   2.1 |    30 |      0 |     0 |
+|   44 | Brian Austgen       | Calvary Community - Munster, IN                 |   1.4 |    20 |      0 |     0 |
+|   45 | Destiny Robeck      | "Super Apostles" - White Cloud, MI              |   1.4 |    20 |      0 |     0 |
+|   46 | Victoria Kelly      | First Assembly #1 - Lexington, KY               |   0.7 |    10 |      0 |     0 |
+|   47 | Cody Stuart         | The Stone Church - Palos Heights, IL            |   0.7 |    10 |      0 |     0 |
+|   48 | Ray Hein            | Painesville A/G - Painesville, OH               |   0.7 |    10 |      0 |     0 |
+|   49 | Marshall Kobylski   | Dayspring "Am Herratz" - Bowling Green, OH      |   0.7 |    10 |      0 |     0 |
+|   50 | Ian Tinney          | Trinity Assembly - Georgetown, KY               |   0.7 |    10 |      0 |     0 |
+|   51 | Kaitlyn Hong        | The Stone Church - Palos Heights, IL            |   0.7 |    10 |      0 |     0 |
+|   52 | Kendall Facer       | Dayspring "Am Herratz" - Bowling Green, OH      |   0.4 |     5 |      0 |     0 |
+|   53 | Joshua Utley        | Radiant Life - Elkhart, IN                      |     0 |     0 |      0 |     0 |
+|   54 | John Pryer          | "Super Apostles" - White Cloud, MI              |     0 |     0 |      0 |     0 |
+|   55 | Trinity Durham      | First Assembly #1 - Lexington, KY               |  -0.3 |    -5 |      0 |     0 |
+|   56 | Amy Beckberger      | The Stone Church - Palos Heights, IL            |  -0.4 |    -5 |      0 |     0 |
+|   57 | Erin Fahl           | Painesville A/G - Painesville, OH               |  -1.1 |   -15 |      0 |     0 |
+|   58 | Ashley Morris       | Trinity Assembly - Georgetown, KY               |  -1.8 |   -25 |      0 |     0 |
+
+## Novice League
+
+### Teams
+
+|    # | Team                                             |   Avg | Total |    W |    L |
+| ---: | ------------------------------------------------ | ----: | ----: | ---: | ---: |
+|    1 | 1st Assembly Greater Lansing - East Lansing, MI  | 179.2 |  2330 |   12 |    1 |
+|    2 | Rochester 1st Assembly - Rochester Hills, MI     | 115.8 |  1505 |   11 |    2 |
+|    3 | Calvary Assembly - Elkhart, IN                   |  69.6 |   905 |    9 |    4 |
+|   4* | Auburn Hills Christian Center - Auburn Hills, MI |  84.2 |  1095 |    8 |    5 |
+|   5* | Lakeview Church - Indianapolis, IN               |  98.8 |  1285 |    8 |    5 |
+|    6 | First Assembly - Lexington, KY                   | 111.5 |  1450 |    7 |    6 |
+|    7 | Southwest Assembly - Fort Wayne, IN              |  85.8 |  1115 |    7 |    6 |
+|    8 | Living Hope Church - Merrillville, IN            |  76.9 |  1000 |    7 |    6 |
+|    9 | Meadowbrook - Champaign, IL                      |  64.2 |   835 |    6 |    7 |
+|   10 | Trinity Assembly #2 - Georgetown, KY             |  66.9 |   870 |    5 |    8 |
+|   11 | Trinity Assembly #1 - Georgetown, KY             |    65 |   845 |    5 |    8 |
+|   12 | Calvary Assembly - Toledo, OH                    |  46.2 |   600 |    3 |   10 |
+|   13 | The Stone Church - Palos Heights, IL             |  12.3 |   160 |    2 |   11 |
+|   14 | Bethel Temple "Power of One" - Huntington, WV    |  15.8 |   205 |    1 |   12 |
+
+\* Auburn Hills defeated Lakeview head to head
+
+### Individuals
+
+|    # | Quizzer             | Team                                             |  Avg | Total | QO Fwd | QO Bk |
+| ---: | ------------------- | ------------------------------------------------ | ---: | ----: | -----: | ----: |
+|    1 | Brayden Laakkonen   | First Assembly - Lexington, KY                   | 89.6 |  1165 |      9 |     2 |
+|    2 | Lucas Myers         | Rochester 1st Assembly - Rochester Hills, MI     | 86.5 |  1125 |      9 |     1 |
+|    3 | Zachary Clough      | 1st Assembly Greater Lansing - East Lansing, MI  | 70.4 |   915 |     10 |     2 |
+|    4 | Jonathan Burd       | Southwest Assembly - Fort Wayne, IN              | 64.2 |   835 |      6 |     4 |
+|    5 | Daniel Buffham      | 1st Assembly Greater Lansing - East Lansing, MI  | 61.2 |   795 |      5 |     2 |
+|    6 | Grace Ishikawa      | Lakeview Church - Indianapolis, IN               | 56.5 |   735 |      5 |     0 |
+|    7 | Ashley Johnson      | Trinity Assembly #1 - Georgetown, KY             | 52.7 |   685 |      4 |     1 |
+|    8 | Michael Limentato   | Meadowbrook - Champaign, IL                      | 45.4 |   590 |      6 |     1 |
+|    9 | Kameron Sorensen    | Living Hope Church - Merrillville, IN            | 43.8 |   570 |      5 |     4 |
+|   10 | Kathleen Muloma     | Lakeview Church - Indianapolis, IN               | 42.3 |   550 |      4 |     2 |
+|   11 | Shan Antony         | Calvary Assembly - Elkhart, IN                   | 36.5 |   475 |      1 |     0 |
+|   12 | Cody Donovan        | Auburn Hills Christian Center - Auburn Hills, MI | 36.2 |   470 |      2 |     4 |
+|   13 | Seth Imbrunone      | Auburn Hills Christian Center - Auburn Hills, MI | 33.5 |   435 |      0 |     1 |
+|   14 | Josie Gidman        | Calvary Assembly - Elkhart, IN                   | 32.7 |   425 |      1 |     0 |
+|   15 | Sarah Neeper        | Calvary Assembly - Toledo, OH                    | 30.8 |   400 |      1 |     0 |
+|   16 | Courtney Turner     | Trinity Assembly #2 - Georgetown, KY             | 29.6 |   385 |      0 |     0 |
+|   17 | Jonathan Steinbach  | Trinity Assembly #2 - Georgetown, KY             | 26.2 |   340 |      0 |     0 |
+|   18 | Jenna Klein         | 1st Assembly Greater Lansing - East Lansing, MI  | 23.8 |   310 |      0 |     0 |
+|   19 | Austin Harr         | 1st Assembly Greater Lansing - East Lansing, MI  | 23.1 |   300 |      2 |     0 |
+|   20 | Michael Sawczak     | Living Hope Church - Merrillville, IN            | 23.1 |   300 |      0 |     0 |
+|   21 | Alex McCracken      | First Assembly - Lexington, KY                   | 21.9 |   285 |      1 |     0 |
+|   22 | Tyler Snodderly     | Southwest Assembly - Fort Wayne, IN              | 21.5 |   280 |      1 |     0 |
+|   23 | Joey Ufolla         | Rochester 1st Assembly - Rochester Hills, MI     | 18.1 |   235 |      0 |     0 |
+|   24 | Olivia Scott        | Meadowbrook - Champaign, IL                      | 18.1 |   235 |      0 |     2 |
+|   25 | Wesley Wilson       | Calvary Assembly - Toledo, OH                    | 16.5 |   215 |      0 |     1 |
+|   26 | Jessica Lowe        | Bethel Temple "Power of One" - Huntington, WV    | 14.2 |   185 |      1 |     1 |
+|   27 | Max Hamer           | Auburn Hills Christian Center - Auburn Hills, MI | 13.8 |   180 |      0 |     0 |
+|   28 | Marina Tinney       | Trinity Assembly #1 - Georgetown, KY             | 12.3 |   160 |      1 |     0 |
+|   29 | Kelsi Morris        | Trinity Assembly #2 - Georgetown, KY             | 11.2 |   145 |      0 |     0 |
+|   30 | Caroline Dillplane  | Rochester 1st Assembly - Rochester Hills, MI     | 10.4 |   135 |      0 |     0 |
+|   31 | Elena Hutchinson    | Living Hope Church - Merrillville, IN            |  9.2 |   120 |      0 |     0 |
+|   32 | Caleb Harmon        | The Stone Church - Palos Heights, IL             |  8.8 |   115 |      0 |     0 |
+|   33 | Kyle McNamara       | The Stone Church - Palos Heights, IL             |  2.3 |    30 |      0 |     0 |
+|   34 | Madeline Headtke    | Meadowbrook - Champaign, IL                      |  1.5 |    20 |      0 |     0 |
+|   35 | Sam Daniel          | Bethel Temple "Power of One" - Huntington, WV    |  1.2 |    15 |      0 |     1 |
+|   36 | Lisa Andrews        | 1st Assembly Greater Lansing - East Lansing, MI  |  0.8 |    10 |      0 |     0 |
+|   37 | Jake Daniel         | Bethel Temple "Power of One" - Huntington, WV    |  0.8 |    10 |      0 |     0 |
+|   38 | Evan Clements       | The Stone Church - Palos Heights, IL             |  0.8 |    10 |      0 |     0 |
+|   39 | David Beckberger Jr | The Stone Church - Palos Heights, IL             |  0.8 |    10 |      0 |     0 |
+|   40 | Nicholle Robinson   | Rochester 1st Assembly - Rochester Hills, MI     |  0.8 |    10 |      0 |     0 |
+|   41 | Tiffany Wolf        | Southwest Assembly - Fort Wayne, IN              |  0.8 |    10 |      0 |     0 |
+|   42 | Matt Butler         | Calvary Assembly - Elkhart, IN                   |  0.8 |    10 |      0 |     0 |
+|   43 | Ryan Blue           | Auburn Hills Christian Center - Auburn Hills, MI |  0.8 |    10 |      0 |     0 |
+|   44 | Kaylor Sheehy       | Living Hope Church - Merrillville, IN            |  0.8 |    10 |      0 |     0 |
+|   45 | Sobe Anidobu        | The Stone Church - Palos Heights, IL             |  0.4 |     5 |      0 |     0 |
+|   46 | Julie Graham        | Meadowbrook - Champaign, IL                      | -0.8 |   -10 |      0 |     0 |
+|   47 | Brianne Grup        | Calvary Assembly - Toledo, OH                    | -1.2 |   -15 |      0 |     0 |

--- a/_pages/history/2010/regionals/gulf.md
+++ b/_pages/history/2010/regionals/gulf.md
@@ -1,0 +1,75 @@
+---
+layout: page
+title: "2010 Gulf Regionals"
+permalink: /history/2010/regionals/gulf/
+date: "2010-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2010 Season
+    link: /history/2010/
+    icon: fas fa-home
+---
+
+## A Level
+
+### Teams
+
+| Team                    |    W |    L | Total |  Avg |
+| ----------------------- | ---: | ---: | ----: | ---: |
+| JRA Perfect In Weakness |    4 |    2 |  1105 |  184 |
+| JRA Sufficient Grace    |    4 |    2 |  1060 |  176 |
+| Central Those Who Mourn |    2 |    4 |   715 |  119 |
+| West Plains George      |    2 |    4 |   450 |   75 |
+
+### Individuals
+
+|    # | Quizzer            | Team                    | Total |  Avg |   QO | Perfect |
+| ---: | ------------------ | ----------------------- | ----: | ---: | ---: | ------: |
+|    1 | Daniel Clark       | JRA Perfect In Weakness |   595 |   99 |    5 |       0 |
+|    2 | Whitney Garrison   | JRA Sufficient Grace    |   555 |   93 |    4 |       0 |
+|    3 | Joshua George      | West Plains George      |   360 |   60 |    2 |       0 |
+|    4 | Danielle Brozovich | JRA Sufficient Grace    |   330 |   55 |    2 |       0 |
+|    5 | Daniel Quick       | Central Those Who Mourn |   320 |   53 |    3 |       0 |
+|    6 | Autumn Rogers      | JRA Perfect In Weakness |   305 |   51 |    3 |       0 |
+|    7 | Matthew Klika      | West Plains George      |   235 |   40 |    2 |       0 |
+|    8 | Heidi Graves       | JRA Perfect In Weakness |   215 |   36 |    2 |       0 |
+|    9 | Emily Murray       | Central Those Who Mourn |   155 |   26 |    1 |       0 |
+|    9 | Natalie Garrison   | JRA Sufficient Grace    |   155 |   26 |    1 |       0 |
+|   11 | Jeremiah George    | West Plains George      |    85 |   14 |    0 |       0 |
+|   12 | Hayley DePriest    | JRA Sufficient Grace    |    30 |    5 |    0 |       0 |
+|   13 | Sarah Murdy        | West Plains George      |    10 |    2 |    0 |       0 |
+|   13 | Brianna Riley      | Central Those Who Mourn |    10 |    2 |    0 |       0 |
+
+## Novice Level
+
+### Teams
+
+| Team                    |    W |    L | Total |  Avg |
+| ----------------------- | ---: | ---: | ----: | ---: |
+| Central Clanging Cymbal |    7 |    1 |  1635 |  204 |
+| JRA Defeated Already    |    6 |    2 |  1510 |  188 |
+| JRA Hungry & Thirsty    |    5 |    3 |  1340 |  167 |
+| JRA Knowledge Puffs     |    2 |    6 |   525 |   65 |
+| JRA Members of Christ   |    0 |    8 |   155 |   19 |
+
+### Individuals
+
+|    # | Quizzer        | Team                    | Total |  Avg |   QO | Perfect |
+| ---: | -------------- | ----------------------- | ----: | ---: | ---: | ------: |
+|    1 | Jason Good     | JRA Defeated Already    |   830 |  104 |    6 |       1 |
+|    2 | Emily Klika    | Central Clanging Cymbal |   720 |   90 |    5 |       0 |
+|    3 | Kacie Garrison | JRA Hungry & Thirsty    |   625 |   79 |    4 |       0 |
+|    4 | Brianna Silvey | JRA Hungry & Thirsty    |   615 |   77 |    5 |       0 |
+|    5 | Josiah Klassen | JRA Defeated Already    |   590 |   74 |    6 |       0 |
+|    6 | Trevor Gaffery | Central Clanging Cymbal |   480 |   60 |    5 |       0 |
+|    7 | Ashley Klika   | Central Clanging Cymbal |   435 |   55 |    3 |       0 |
+|    8 | Hope Rogers    | JRA Knowledge Puffs     |   390 |   49 |    3 |       0 |
+|    9 | Jenna DePriest | JRA Knowledge Puffs     |   170 |   22 |    1 |       0 |
+|   10 | Paige Rogers   | JRA Hungry & Thirsty    |   100 |   13 |    0 |       0 |
+|   11 | Mike Whitlatch | JRA Defeated Already    |    90 |   12 |    0 |       0 |
+|   12 | Luke Cockroft  | JRA Members of Christ   |    75 |   10 |    0 |       0 |
+|   13 | Spencer Graves | JRA Members of Christ   |    50 |    6 |    0 |       0 |
+|   14 | Steven Aubry   | JRA Members of Christ   |    30 |    4 |    0 |       0 |
+|   15 | Tessa Ward     | JRA Hungry & Thirsty    |     0 |    0 |    0 |       0 |

--- a/_pages/history/2010/regionals/north-central.md
+++ b/_pages/history/2010/regionals/north-central.md
@@ -1,0 +1,87 @@
+---
+layout: page
+title: "2010 North Central Regionals"
+permalink: /history/2010/regionals/north-central/
+date: "2010-05-18"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2010 Season
+    link: /history/2010/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team              | Church            |    W |    L | Total |   Avg |
+| ---: | ----------------- | ----------------- | ---: | ---: | ----: | ----: |
+|   1* | Pleasant Hill, IA | Berean AG         |   10 |    1 |  2080 | 189.1 |
+|   2* | Portage, WI #1    | Crosspoint AG     |   10 |    1 |  1420 | 129.1 |
+|    3 | Cedar Rapids, IA  | First AG          |    9 |    2 |  1660 | 150.9 |
+|  4** | Grand Island, NE  | Abundant Life AG  |    8 |    3 |  1460 | 132.7 |
+|  5** | Racine, WI        | Racine AG         |    8 |    3 |  1490 | 135.5 |
+|    6 | Omaha, NE         | Glad Tidings AG   |    6 |    5 |   880 |  80.0 |
+|    7 | Rapid City, SD    | Bethel AG         |    4 |    7 |   760 |  69.1 |
+|    8 | Moberly, MO       | Moberly First AG  |    4 |    7 |   645 |  58.6 |
+|    9 | Fergus Fall, MN   | Abundant Life AG  |    4 |    7 |   380 |  34.5 |
+|   10 | Portage WI #2     | Crosspoint AG     |    2 |    9 |   385 |  35.0 |
+|   11 | Albert Lea, MN    | Albert Lea AG     |    1 |   10 |    85 |   7.7 |
+|   12 | Plymouth, WI      | Christian Life AG |    0 |   11 |    70 |   6.4 |
+
+\* Pleasant Hill, IA beat Portage, WI #1 in playoff.\
+\*\* Racine, WI beat Grand Island, NE in playoff.
+
+### Individuals (Top 10)
+
+|    # | Quizzer        | Team              | Total |   Avg |
+| ---: | -------------- | ----------------- | ----: | ----: |
+|    1 | Tori Beye      | Grand Island, NE  |  1340 | 121.8 |
+|    2 | Jonathan Plank | Pleasant Hill, IA |  1245 | 113.2 |
+|    3 | Josiah Coder   | Cedar Rapids, IA  |  1200 | 109.1 |
+|    4 | Alex Firari    | Portage, WI #1    |   925 |  84.1 |
+|    5 | Nathan Dahlin  | Racine, WI        |   645 |  58.6 |
+|    6 | Faith Oygaard  | Rapid City, SD    |   630 |  57.3 |
+|    7 | Mikeala Plank  | Pleasant Hill, IA |   505 |  45.9 |
+|    8 | Ryan Toeller   | Racine, WI        |   465 |  42.3 |
+|    9 | Denver Rogers  | Omaha, NE         |   400 |  36.4 |
+|   10 | Ross Toeller   | Racine, WI        |   380 |  34.5 |
+
+## MSQ Division
+
+### Teams
+
+|    # | Team              | Church           |    W |    L | Total |   Avg |
+| ---: | ----------------- | ---------------- | ---: | ---: | ----: | ----: |
+|   1* | Cedar Rapids, IA  | First AG         |    7 |    3 |  1090 |   109 |
+|   2* | Pleasant Hill, IA | Berean AG        |    7 |    3 |  1295 | 129.5 |
+|   3* | Racine, WI        | Racine AG        |    7 |    3 |   995 |  99.5 |
+|    4 | Des Moines, IA    | First AG         |    5 |    5 |  1205 | 120.5 |
+|    5 | Grand Island, NE  | Abundant Life AG |    4 |    6 |   615 |  61.5 |
+|    6 | Rapid City, SD    | Bethel AG        |    0 |   10 |   445 |  44.5 |
+
+\* Cedar Rapids, IA beat Pleasant Hill, IA and Racine, WI in playoffs. Pleasant Hill, IA beat Racine, WI in playoff.
+
+### Individuals
+
+|    # | Quizzer            | Team              | Total |  Avg |
+| ---: | ------------------ | ----------------- | ----: | ---: |
+|    1 | Aimee Logeski      | Racine, WI        |   850 |   85 |
+|    2 | Mathias Plank      | Pleasant Hill, IA |   690 |   69 |
+|    3 | Katrina Bopp       | Des Moines, IA    |   650 |   65 |
+|    4 | Anna Plank         | Pleasant Hill, IA |   610 |   61 |
+|    5 | Alexis Freydenfelt | Cedar Rapids, IA  |   465 | 46.5 |
+|    6 | Isaiah Sherman     | Cedar Rapids, IA  |   440 |   44 |
+|    7 | Caleb Beliel       | Des Moines, IA    |   430 |   43 |
+|    8 | Brianna Harris     | Grand Island, NE  |   390 |   39 |
+|    9 | len Oygaard        | Rapid City, SD    |   350 |   35 |
+|   10 | Trask Freydenfelt  | Cedar Rapids, IA  |   185 | 18.5 |
+|   11 | Adrian Epp         | Grand Island, NE  |   170 |   17 |
+|   12 | Natalie Ridgway    | Des Moines, IA    |   125 | 12.5 |
+|   13 | Gabriella Belmares | Racine, WI        |    90 |    9 |
+|   14 | Christina Belmares | Racine, WI        |    60 |    6 |
+|   15 | Ashley Tarnick     | Grand Island, NE  |    60 |    6 |
+|   16 | Charlie Wilhelm    | Rapid City, SD    |    55 |  5.5 |
+|   17 | Zach Putt          | Rapid City, SD    |    40 |    4 |

--- a/_pages/history/2010/regionals/northeast.md
+++ b/_pages/history/2010/regionals/northeast.md
@@ -1,0 +1,146 @@
+---
+layout: page
+title: "2010 Northeast Regionals"
+permalink: /history/2010/regionals/northeast/
+date: "2010-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2010 Season
+    link: /history/2010/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team                                                 |    W |    L | Total |    Avg |
+| ---: | ---------------------------------------------------- | ---: | ---: | ----: | -----: |
+|    1 | Praise A/G, Garfield, NJ                             |   13 |    0 |  3375 | 259.62 |
+|    2 | First A/G, Binghamton, NY                            |   11 |    2 |  2740 | 210.77 |
+|   3* | Manassas A/G, Bristow, VA                            |   10 |    3 |  2525 | 194.23 |
+|   4* | Word of Life A/G, Springfield, VA #1                 |   10 |    3 |  1960 | 150.77 |
+|  5** | Living Hope Worship Center, Swedesboro, NJ           |    9 |    4 |  2760 | 212.31 |
+|  6** | Bethlehem Church, Richmond Hill, NY                  |    9 |    4 |  1495 |    115 |
+|    7 | Bethany Church, Wyckoff, NJ                          |    7 |    6 |   945 |  72.69 |
+|    8 | Faith Community Church, Martha's Vineyard, MA        |    4 |    9 |   665 |  51.15 |
+|    9 | Word of Life, Springfield, VA #2                     |    4 |    9 |   430 |  33.08 |
+|   10 | Reamstown Church of God, Reamstown "Aimless Runners" |    4 |    9 |   315 |  24.23 |
+|   11 | Journey Church, Bridgeville "Sauce the Knees"        |    3 |   10 |  1060 |  81.54 |
+|   12 | New Covenant Tabernacle, Buffalo, NY                 |    3 |   10 |   655 |  50.38 |
+|   13 | Newport A/G, Newport, PA "Certainly Not!"            |    3 |   10 |   465 |  35.77 |
+|   14 | First A/G, Elkton, MD                                |    2 |   11 |   360 |  27.69 |
+
+\* Manassas beat Springfield head to head\
+\*\* Sweedsboro beat Richmond Hill head to head
+
+### Individuals
+
+|    # | Quizzer               | Team                                                 | Total |   QO |    Avg |
+| ---: | --------------------- | ---------------------------------------------------- | ----: | ---: | -----: |
+|    1 | Isaac Ward            | First A/G, Binghamton, NY                            |  1645 |   13 | 126.54 |
+|    2 | Catherine Hains       | Manassas A/G, Bristow, VA                            |  1525 |   12 | 117.31 |
+|    3 | Justin Czubkowski     | Praise A/G, Garfield, NJ                             |  1350 |   10 | 103.85 |
+|    4 | Kyler Sederwall       | Praise A/G, Garfield, NJ                             |  1215 |   11 |  93.46 |
+|    5 | Kayla Hill            | Living Hope Worship Center, Swedesboro, NJ           |  1105 |   10 |     85 |
+|    6 | Santosh Mathews       | Word of Life A/G, Springfield, VA #1                 |  1105 |    7 |     85 |
+|    7 | Kaitlyn Dobbins       | Living Hope Worship Center, Swedesboro, NJ           |   965 |   10 |  74.23 |
+|    8 | Katie Stephens        | First A/G, Binghamton, NY                            |   905 |   10 |  69.62 |
+|    9 | Dana Warnock          | Journey Church, Bridgeville "Sauce the Knees"        |   860 |    7 |  66.15 |
+|   10 | Brandon Ford          | Bethlehem Church, Richmond Hill, NY                  |   815 |    7 |  62.69 |
+|   11 | Chris Galea           | Praise A/G, Garfield, NJ                             |   810 |    8 |  62.31 |
+|   12 | Cara Brower           | Manassas A/G, Bristow, VA                            |   740 |    8 |  56.92 |
+|   13 | Miranda Hill          | Living Hope Worship Center, Swedesboro, NJ           |   630 |    3 |  48.46 |
+|   14 | Kaija Nivala          | Faith Community Church, Martha's Vineyard, MA        |   585 |    5 |     45 |
+|   15 | Jessica Dispenza      | New Covenant Tabernacle, Buffalo, NY                 |   565 |    3 |  43.46 |
+|   16 | Robbie Mitchell       | Bethany Church, Wyckoff, NJ                          |   550 |    7 |  42.31 |
+|   17 | Vincent Okafor        | Bethlehem Church, Richmond Hill, NY                  |   510 |    3 |  39.23 |
+|   18 | Sam York              | Word of Life A/G, Springfield, VA #1                 |   415 |    1 |  31.92 |
+|   19 | Natasha Conerly       | Word of Life, Springfield, VA #2                     |   385 |    2 |  29.62 |
+|   20 | Kelsey Moses          | First A/G, Elkton, MD                                |   370 |    1 |  28.46 |
+|   21 | Abhishek Mathews      | Word of Life A/G, Springfield, VA #1                 |   350 |    3 |  26.92 |
+|   22 | Philip Sproull        | Newport A/G, Newport, PA "Certainly Not!"            |   345 |    2 |  26.54 |
+|   23 | Rachael Stewart       | Bethany Church, Wyckoff, NJ                          |   320 |    0 |  24.62 |
+|   24 | Ashleigh Weatherholtz | Manassas A/G, Bristow, VA                            |   260 |    2 |     20 |
+|   25 | Rebekah Welesko       | Journey Church, Bridgeville "Sauce the Knees"        |   205 |    0 |  15.77 |
+|   26 | Victoria Myrick       | First A/G, Binghamton, NY                            |   190 |    0 |  14.62 |
+|   27 | John Langel           | Newport A/G, Newport, PA "Certainly Not!"            |   180 |    1 |  13.85 |
+|   28 | Nathan Kiner          | Reamstown Church of God, Reamstown "Aimless Runners" |   180 |    0 |  13.85 |
+|   29 | Brian Haimchand       | Bethlehem Church, Richmond Hill, NY                  |   170 |    0 |  13.08 |
+|   30 | Joshua Inyangson      | Word of Life A/G, Springfield, VA #1                 |    90 |    0 |   6.92 |
+|   31 | Brock Rutt            | Reamstown Church of God, Reamstown "Aimless Runners" |    90 |    0 |   6.92 |
+|   32 | Andrew Dispenza       | New Covenant Tabernacle, Buffalo, NY                 |    90 |    0 |   6.92 |
+|   33 | Maryann Rauschenbach  | Bethany Church, Wyckoff, NJ                          |    80 |    0 |   6.15 |
+|   34 | Benjamin Nivala       | Faith Community Church, Martha's Vineyard, MA        |    80 |    0 |   6.15 |
+|   35 | Kyra Fontaine         | Word of Life, Springfield, VA #2                     |    75 |    0 |   5.77 |
+|   36 | Jared Hill            | Living Hope Worship Center, Swedesboro, NJ           |    60 |    0 |   4.62 |
+|   37 | Melody Asper          | Reamstown Church of God, Reamstown "Aimless Runners" |    45 |    0 |   3.46 |
+|   38 | Jacob Giesing         | First A/G, Elkton, MD                                |    15 |    0 |   1.15 |
+|   39 | Shaniqua Conerly      | Word of Life A/G, Springfield, VA #1                 |     0 |    1 |      0 |
+|   40 | Victoria Matiasz      | New Covenant Tabernacle, Buffalo, NY                 |     0 |    0 |      0 |
+|   41 | Raeanne Watkins       | Manassas A/G, Bristow, VA                            |     0 |    0 |      0 |
+|   42 | Megan Steves          | Living Hope Worship Center, Swedesboro, NJ           |     0 |    0 |      0 |
+|   43 | Luke White            | New Covenant Tabernacle, Buffalo, NY                 |     0 |    0 |      0 |
+|   44 | Kristyn Jones         | Manassas A/G, Bristow, VA                            |     0 |    0 |      0 |
+|   45 | Jordan Prime          | Bethlehem Church, Richmond Hill, NY                  |     0 |    0 |      0 |
+|   46 | Alex Cheski           | Praise A/G, Garfield, NJ                             |     0 |    0 |      0 |
+|   47 | Shane Warnock         | Journey Church, Bridgeville "Sauce the Knees"        |    -5 |    0 |  -0.38 |
+|   48 | Ben Springer          | First A/G, Elkton, MD                                |   -25 |    0 |  -1.92 |
+|   49 | Zerubabbel Tessema    | Word of Life, Springfield, VA #2                     |   -30 |    0 |  -2.31 |
+|   50 | Vicki Hertzler        | Newport A/G, Newport, PA "Certainly Not!"            |   -60 |    0 |  -4.62 |
+
+## Novice Division
+
+### Teams
+
+|    # | Team                                                 |    W |    L | Total |    Avg |
+| ---: | ---------------------------------------------------- | ---: | ---: | ----: | -----: |
+|    1 | South Hills A/G, Bethel Park "Batch of Dough"        |    8 |    1 |  1795 | 199.44 |
+|    2 | Journey Church, Bridgeville, PA "R U Married"        |    7 |    2 |  1520 | 168.89 |
+|    3 | First A/G, Binghamton, NY                            |    6 |    3 |  1320 | 146.67 |
+|    4 | Living Hope Worship Center, Swedesboro, NJ           |    6 |    3 |  1215 |    135 |
+|    5 | Grace Bible Church, Marshall, VA                     |    5 |    4 |   730 |  81.11 |
+|    6 | Bethlehem Church, Richmond Hill, NY                  |    4 |    5 |   990 |    110 |
+|    7 | Praise A/G, Elkton, MD                               |    4 |    5 |   875 |  97.22 |
+|    8 | South Hills A/G, Bethel Park, PA "Fool's for Christ" |    3 |    6 |   445 |  49.44 |
+|    9 | Praise A/G, Garfield, NJ                             |    2 |    7 |   625 |  69.44 |
+|   10 | Curtis Lake Christian Church, Sanford, ME            |    0 |    9 |   335 |  37.22 |
+
+### Individuals
+
+|    # | Quizzer            | Team                                                 | Total |   QO |    Avg |
+| ---: | ------------------ | ---------------------------------------------------- | ----: | ---: | -----: |
+|    1 | Aaron Scarinzi     | First A/G, Binghamton, NY                            |   950 |    6 | 105.56 |
+|    2 | Emily Beazley      | Praise A/G, Elkton, MD                               |   835 |    7 |  92.78 |
+|    3 | Isabelle Stasenko  | South Hills A/G, Bethel Park "Batch of Dough"        |   815 |    7 |  90.56 |
+|    4 | Colton Bononi      | Journey Church, Bridgeville, PA "R U Married"        |   790 |    5 |  87.78 |
+|    5 | Connor O'Keefe     | Journey Church, Bridgeville, PA "R U Married"        |   720 |    7 |     80 |
+|    6 | Chase Hill         | Living Hope Worship Center, Swedesboro, NJ           |   610 |    6 |  67.78 |
+|    7 | Isaac Kandavalli   | Living Hope Worship Center, Swedesboro, NJ           |   605 |    5 |  67.22 |
+|    8 | Jordan Wiltanger   | South Hills A/G, Bethel Park "Batch of Dough"        |   585 |    2 |     65 |
+|    9 | A.J. Songsong      | Praise A/G, Garfield, NJ                             |   500 |    3 |  55.56 |
+|   10 | Sequoia Poths      | Grace Bible Church, Marshall, VA                     |   465 |    4 |  51.67 |
+|   11 | Rebecca Ford       | Bethlehem Church, Richmond Hill, NY                  |   450 |    4 |     50 |
+|   12 | Rachael Singh      | Bethlehem Church, Richmond Hill, NY                  |   405 |    3 |     45 |
+|   13 | Elizabeth Beachy   | South Hills A/G, Bethel Park "Batch of Dough"        |   395 |    3 |  43.89 |
+|   14 | Zachary Berthiaume | Curtis Lake Christian Church, Sanford, ME            |   305 |    2 |  33.89 |
+|   15 | Kevin Sanders      | First A/G, Binghamton, NY                            |   290 |    1 |  32.22 |
+|   16 | Joey Lemley        | South Hills A/G, Bethel Park, PA "Fool's for Christ" |   190 |    0 |  21.11 |
+|   17 | Joshua Henderson   | South Hills A/G, Bethel Park, PA "Fool's for Christ" |   165 |    1 |  18.33 |
+|   18 | Abby Weatherholtz  | Grace Bible Church, Marshall, VA                     |   160 |    0 |  17.78 |
+|   19 | Zack Wisz          | Praise A/G, Garfield, NJ                             |   140 |    1 |  15.56 |
+|   20 | Cougar Poths       | Grace Bible Church, Marshall, VA                     |   105 |    1 |  11.67 |
+|   21 | Elaine Emaly Singh | Bethlehem Church, Richmond Hill, NY                  |   100 |    0 |  11.11 |
+|   22 | Brandon Congdon    | First A/G, Binghamton, NY                            |    80 |    0 |   8.89 |
+|   23 | Joshua Anischenko  | South Hills A/G, Bethel Park, PA "Fool's for Christ" |    75 |    0 |   8.33 |
+|   24 | Sarah Chaffee      | Praise A/G, Elkton, MD                               |    45 |    0 |      5 |
+|   25 | Christina Okafor   | Bethlehem Church, Richmond Hill, NY                  |    35 |    0 |   3.89 |
+|   26 | Emily Bacon        | Curtis Lake Christian Church, Sanford, ME            |    30 |    0 |   3.33 |
+|   27 | Luke Hatfield      | South Hills A/G, Bethel Park, PA "Fool's for Christ" |    15 |    0 |   1.67 |
+|   28 | Glory Warnock      | Journey Church, Bridgeville, PA "R U Married"        |    10 |    0 |   1.11 |
+|   29 | Katherine Marra    | Journey Church, Bridgeville, PA "R U Married"        |     0 |    0 |      0 |
+|   30 | Isabella Chitumuri | Bethlehem Church, Richmond Hill, NY                  |     0 |    0 |      0 |
+|   31 | Ross Thorp         | Praise A/G, Elkton, MD                               |    -5 |    0 |  -0.56 |
+|   32 | Trey Sederwall     | Praise A/G, Garfield, NJ                             |   -15 |    0 |  -1.67 |

--- a/_pages/history/2010/regionals/northwest.md
+++ b/_pages/history/2010/regionals/northwest.md
@@ -1,0 +1,95 @@
+---
+layout: page
+title: "2010 Northwest Regionals"
+permalink: /history/2010/regionals/northwest/
+date: "2010-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2010 Season
+    link: /history/2010/
+    icon: fas fa-home
+---
+
+## Senior Division
+
+### Teams
+
+|    # | Team                            |    W |    L | Total |  Avg |
+| ---: | ------------------------------- | ---: | ---: | ----: | ---: |
+|    1 | CP "Far Outweighs"              |    8 |    2 | 1,960 |  196 |
+|    2 | Nyssa "Unveiled Faces"          |    6 |    4 | 1,355 |  136 |
+|    3 | Belgrade "Sanctified in Christ" |    6 |    4 | 1,130 |  113 |
+|    4 | BNC "Camel Lords"               |    5 |    5 | 1,050 |  105 |
+|    5 | Meridian "Wild Beasts"          |    3 |    7 |   650 |   65 |
+|    6 | Kuna "Dying & Yet We Live On"   |    2 |    8 |   820 |   82 |
+
+### Individuals
+
+|    # | Quizzer         | Team                            | Total |  Avg |
+| ---: | --------------- | ------------------------------- | ----: | ---: |
+|    1 | Heather Karnes  | CP "Far Outweighs"              | 1,145 |  115 |
+|    2 | Melissa Larson  | Nyssa "Unveiled Faces"          | 1,090 |  109 |
+|    3 | Katie Godfrey   | Belgrade "Sanctified in Christ" |   930 |   93 |
+|    4 | Kara Gallo      | BNC "Camel Lords"               |   580 |   58 |
+|    5 | Ivy Jensen      | Meridian "Wild Beasts"          |   525 |   53 |
+|    6 | Flynn Spicer    | CP "Far Outweighs"              |   515 |   52 |
+|    7 | Keaton Gillihan | Kuna "Dying & Yet We Live On"   |   440 |   44 |
+|    8 | Joshua Gallo    | BNC "Camel Lords"               |   325 |   33 |
+|    9 | Missa Quintana  | Kuna "Dying & Yet We Live On"   |   275 |   28 |
+|   10 | Rachel Preston  | CP "Far Outweighs"              |   215 |   22 |
+|   11 | Christina Burns | Nyssa "Unveiled Faces"          |   185 |   19 |
+|   12 | Ian Godfrey     | Belgrade "Sanctified in Christ" |   180 |   18 |
+|   13 | Sreya Santhosh  | BNC "Camel Lords"               |   140 |   14 |
+|   14 | Rachael Budahl  | Meridian "Wild Beasts"          |   115 |   12 |
+|   15 | Trevor Olson    | Kuna "Dying & Yet We Live On"   |   115 |   12 |
+|   16 | Seth Larson     | Nyssa "Unveiled Faces"          |    80 |    8 |
+|   17 | Adi Purohith    | CP "Far Outweighs"              |    65 |    7 |
+|   18 | Ani Purohith    | CP "Far Outweighs"              |    20 |    2 |
+|   19 | Karley Doty     | Belgrade "Sanctified in Christ" |    20 |    2 |
+|   20 | Link Patrick    | Meridian "Wild Beasts"          |    20 |    2 |
+|   21 | Thomas Borja    | BNC "Camel Lords"               |    10 |    1 |
+|   22 | Adam Grosjean   | Kuna "Dying & Yet We Live On"   |     - |    - |
+|   23 | Anita Jagonath  | CP "Far Outweighs"              |     - |    - |
+|   24 | Anna Gallo      | BNC "Camel Lords"               |     - |    - |
+|   25 | Ashley Mendiola | Kuna "Dying & Yet We Live On"   |     - |    - |
+|   26 | Mason Lickey    | BNC "Camel Lords"               |    -5 |   -1 |
+
+## Novice Division
+
+### Teams
+
+|    # | Team                            |    W |    L | Total |  Avg |
+| ---: | ------------------------------- | ---: | ---: | ----: | ---: |
+|    1 | CP "Tomorrow We Die"            |    8 |    2 | 1,020 |  102 |
+|    2 | Redmond Assembly                |    7 |    3 |   555 |   56 |
+|    3 | Nyssa "Mere Infants"            |    6 |    4 |   635 |   64 |
+|    4 | Meridian "Raised in Glory"      |    4 |    6 |   575 |   58 |
+|    5 | TLC "In Deadly Peril"           |    3 |    7 |   405 |   41 |
+|    6 | Kalispell "A Light in Darkness" |    2 |    8 |   270 |   27 |
+
+### Individuals
+
+|    # | Quizzer           | Team                            | Total |  Avg |
+| ---: | ----------------- | ------------------------------- | ----: | ---: |
+|    1 | Isaac Moore       | CP "Tomorrow We Die"            |   825 |   83 |
+|    2 | Marissa Emerson   | Meridian "Raised in Glory"      |   550 |   55 |
+|    3 | Adam Smalley      | Redmond Assembly                |   495 |   50 |
+|    4 | Verna Spicer      | TLC "In Deadly Peril"           |   390 |   39 |
+|    5 | Elijah Larson     | Nyssa "Mere Infants"            |   365 |   37 |
+|    6 | Caleb Burns       | Nyssa "Mere Infants"            |   270 |   27 |
+|    7 | Michaela Murer    | Kalispell "A Light in Darkness" |   215 |   22 |
+|    8 | Andre' Nicolov    | CP "Tomorrow We Die"            |   195 |   20 |
+|    9 | Joshua Smalley    | Redmond Assembly                |    90 |    9 |
+|   10 | Meredith Wilson   | Kalispell "A Light in Darkness" |    60 |    6 |
+|   11 | Aaron Graff       | Redmond Assembly                |    50 |    5 |
+|   12 | Sarah Jimenez     | Meridian "Raised in Glory"      |    25 |    3 |
+|   13 | Gabby Umphenour   | TLC "In Deadly Peril"           |    15 |    2 |
+|   14 | Anna Kirchner     | Kalispell "A Light in Darkness" |     - |    - |
+|   15 | Cole Wagner       | TLC "In Deadly Peril"           |     - |    - |
+|   16 | Maddie Williamson | TLC "In Deadly Peril"           |     - |    - |
+|   17 | Naomi Larsen      | Meridian "Raised in Glory"      |     - |    - |
+|   18 | Selena Valcro     | Nyssa "Mere Infants"            |     - |    - |
+|   19 | Sam Agafonore     | Kalispell "A Light in Darkness" |    -5 |   -1 |
+|   20 | Caleb Kelley      | Redmond Assembly                |   -80 |   -8 |

--- a/_pages/history/2010/regionals/south-central.md
+++ b/_pages/history/2010/regionals/south-central.md
@@ -1,0 +1,111 @@
+---
+layout: page
+title: "2010 South Central Regionals"
+permalink: /history/2010/regionals/south-central/
+date: "2022-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2010 Season
+    link: /history/2010/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+|    # | Team                        | Church            | W\L | Total |    Avg |
+| ---: | --------------------------- | ----------------- | --- | ----: | -----: |
+|    1 | Owasso First                | Owasso, OK        | 8\0 |  2115 | 264.38 |
+|    2 | Christian Temple #1         | Houston, TX       | 6\2 |  1175 | 146.88 |
+|    3 | Overland Park A/G           | Overland Park, KS | 5\3 |  1425 | 178.13 |
+|    4 | Braeswood A/G               | Houston, TX       | 5\3 |  1225 | 153.13 |
+|    5 | Muskogee First              | Muskogee, OK      | 5\3 |   995 | 124.38 |
+|    6 | HighPointe - Super Apostles | OKC, OK           | 4\4 |  1125 | 140.63 |
+|    7 | Oaks Fellowship             | Red Oak, TX       | 2\6 |   495 |  61.88 |
+|    8 | Lakeshore Assembly          | Dallas, TX        | 1\7 |   120 |     15 |
+|    9 | Christian Temple #2         | Houston, TX       | 0\8 |    85 |  10.63 |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+|    # | Quizzer         | Team                        | Church            | Total |    Avg |   QO |
+| ---: | --------------- | --------------------------- | ----------------- | ----: | -----: | ---: |
+|    1 | Daniel Wagner   | Owasso First                | Owasso, OK        |   875 | 109.38 |    8 |
+|    2 | Micah Samuelson | HighPointe - Super Apostles | OKC, OK           |   850 | 106.25 |    6 |
+|    3 | Andrew Forsman  | Christian Temple #1         | Houston, TX       |   790 |  98.75 |    7 |
+|    4 | Ariel Brookbank | Overland Park A/G           | Overland Park, KS |   740 |   92.5 |    6 |
+|    5 | Jesse Wagner    | Owasso First                | Owasso, OK        |   700 |   87.5 |    5 |
+|    6 | Josh Echebiri   | Braeswood A/G               | Houston, TX       |   585 |  73.13 |    4 |
+|    7 | David Meddaugh  | Muskogee First              | Muskogee, OK      |   580 |   72.5 |    5 |
+|    8 | Luke Wagner     | Owasso First                | Owasso, OK        |   450 |  56.25 |    4 |
+|    9 | Paul Meddaugh   | Muskogee First              | Muskogee, OK      |   410 |  51.25 |    3 |
+|   10 | Obi Kpando      | Braeswood A/G               | Houston, TX       |   355 |  44.38 |    4 |
+|   11 | Zach Brookbank  | Overland Park A/G           | Overland Park, KS |   355 |  44.38 |    3 |
+|   12 | Jed Brookbank   | Overland Park A/G           | Overland Park, KS |   355 |  44.38 |    2 |
+|   13 | Sara Pursell    | Oaks Fellowship             | Red Oak, TX       |   315 |  39.38 |    2 |
+|   14 | David Kpando    | Braeswood A/G               | Houston, TX       |   275 |  34.38 |    2 |
+|   15 | Joey Urbina     | HighPointe - Super Apostles | OKC, OK           |   265 |  33.13 |    3 |
+|   16 | Matthew kirby   | Christian Temple #1         | Houston, TX       |   240 |     30 |    3 |
+|   17 | Emily Pursell   | Oaks Fellowship             | Red Oak, TX       |   180 |   22.5 |      |
+|   18 | Mitchell Barker | Lakeshore Assembly          | Dallas, TX        |   105 |  13.13 |      |
+|   19 | Aaron Jackson   | Owasso First                | Owasso, OK        |    90 |  11.25 |      |
+|   20 | Tim Pyle        | Christian Temple #1         | Houston, TX       |    80 |     10 |      |
+|   20 | Sean Pyle       | Christian Temple #2         | Houston, TX       |    80 |     10 |      |
+|   21 | Brianna Forsman | Christian Temple #1         | Houston, TX       |    60 |    7.5 |      |
+|   22 | Kelli Guinn     | Lakeshore Assembly          | Dallas, TX        |    25 |   3.13 |      |
+|   23 | Arinze Onyenezi | Braeswood A/G               | Houston, TX       |    15 |   1.88 |      |
+|   24 | Seth Urbina     | HighPointe - Super Apostles | OKC, OK           |    10 |   1.25 |      |
+|   25 | Sarak Phillips  | Christian Temple #2         | Houston, TX       |     5 |   0.63 |      |
+|   25 | Anna Kirby      | Christian Temple #1         | Houston, TX       |     5 |   0.63 |      |
+|   25 | Caleb Byers     | Oaks Fellowship             | Red Oak, TX       |     5 |   0.63 |      |
+|   25 | Ryley Nutt      | Muskogee First              | Muskogee, OK      |     5 |   0.63 |      |
+
+## Novice League
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+|    # | Team                         | Church       | W\L  | Total |   Avg |
+| ---: | ---------------------------- | ------------ | ---- | ----: | ----: |
+|    1 | Harvest A/G                  | Ft Worth, TX | 10\0 |  2975 | 297.5 |
+|    2 | Braeswood                    | Houston, TX  | 7\3  |  1245 | 124.5 |
+|    3 | Owasso First                 | Owasso, OK   | 6\4  |  1380 |   138 |
+|    4 | HighPointe - Minds of Christ | OKC, OK      | 5\5  |  1470 |   147 |
+|    5 | Christian Chapel             | Tulsa, OK    | 1\9  |   500 |    50 |
+|    6 | Harvest Church               | Tulsa, OK    | 1\9  |   475 |  47.5 |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+|    # | Quizzer           | Team                         | Church       | Total |   Avg |   QO |
+| ---: | ----------------- | ---------------------------- | ------------ | ----: | ----: | ---: |
+|    1 | Austin Lovekamp   | Harvest A/G                  | Ft Worth, TX |  1315 | 131.5 |   10 |
+|    2 | Kaleigh Lovekamp  | Harvest A/G                  | Ft Worth, TX |  1115 | 111.5 |    9 |
+|    3 | Matthew Samuelson | HighPointe - Minds of Christ | OKC, OK      |  1005 | 100.5 |    8 |
+|    4 | Tyler Snavely     | Owasso First                 | Owasso, OK   |   670 |    67 |    5 |
+|    5 | Wayne Elkins      | Harvest A/G                  | Ft Worth, TX |   515 |  51.5 |    6 |
+|    6 | Rachel Wix        | Braeswood                    | Houston, TX  |   485 |  48.5 |    3 |
+|    7 | Connor McGraw     | HighPointe - Minds of Christ | OKC, OK      |   465 |  46.5 |    2 |
+|    8 | Philip Kamletz    | Owasso First                 | Owasso, OK   |   440 |    44 |    4 |
+|    9 | Uzondu Okoro      | Braeswood                    | Houston, TX  |   425 |  42.5 |    3 |
+|   10 | Rebekah Byrd      | Harvest Church               | Tulsa, OK    |   400 |    40 |    2 |
+|   11 | Ben Ofomata       | Braeswood                    | Houston, TX  |   305 |  30.5 |    1 |
+|   12 | Cherokee Hill     | Christian Chapel             | Tulsa, OK    |   290 |    29 |    1 |
+|   13 | Joseph Batista    | Owasso First                 | Owasso, OK   |   260 |    26 |    3 |
+|   14 | Ben Craig         | Christian Chapel             | Tulsa, OK    |   120 |    12 |      |
+|   15 | Michael Woods     | Christian Chapel             | Tulsa, OK    |    45 |   4.5 |      |
+|   15 | Amy Van           | Christian Chapel             | Tulsa, OK    |    45 |   4.5 |      |
+|   16 | Jessica Darden    | Harvest Church               | Tulsa, OK    |    40 |     4 |      |
+|   17 | Bradley Leander   | Harvest Church               | Tulsa, OK    |    35 |   3.5 |      |
+|   18 | Ginika Znenwa     | Braeswood                    | Houston, TX  |    30 |     3 |      |
+|   19 | Courtney Thrasher | Harvest A/G                  | Ft Worth, TX |    20 |     2 |      |
+|   20 | Jimmy Greger      | Harvest A/G                  | Ft Worth, TX |    10 |     1 |      |
+|   20 | Dylan Wills       | Owasso First                 | Owasso, OK   |    10 |     1 |      |

--- a/_pages/history/2010/regionals/southeast.md
+++ b/_pages/history/2010/regionals/southeast.md
@@ -1,0 +1,99 @@
+---
+layout: page
+title: "2010 Southeast Regionals"
+permalink: /history/2010/regionals/southeast/
+date: "2010-05-18"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2010 Season
+    link: /history/2010/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+|    # | Team                   | Church                                     | W\L | Total |    Avg |
+| ---: | ---------------------- | ------------------------------------------ | --- | ----: | -----: |
+|    1 | Compelled!             | Northside Family Worship Ctr - Cumming, GA | 8\0 |  1965 | 245.63 |
+|    2 | A New ERA              | Victorious Life Church - Wesley Chapel, FL | 6\2 |  1770 | 221.25 |
+|    3 | Orlando Faith          | Faith A/G - Orlando, FL                    | 6\2 |  1605 | 200.63 |
+|    4 | Montgomery             | 1st A/G - Montgomery, AL                   | 6\2 |  1255 | 156.88 |
+|    5 | Snellville             | Evangel Comm Church - Snellville, GA       | 3\5 |   610 |  76.25 |
+|    6 | Ashland                | Ashland 1st A/G - Ashland, AL              | 3\5 |   725 |  90.63 |
+|    7 | Team #2--EJ is Awesome | Victorious Life Church                     | 3\5 |   530 |  66.25 |
+|    8 | Burlington             | Burlington A/G - Burlington, NC            | 1\7 |   555 |  69.38 |
+|    9 | Toccoa GA              | Rehoboth A/G - Toccoa, GA                  | 0\8 |   680 |     85 |
+
+### Individuals
+
+*Ties broken by Quiz Outs. Scores sorted by Total.*
+
+|    # | Quizzer            | Team                   | Church                                     | Total |    Avg |   QO |
+| ---: | ------------------ | ---------------------- | ------------------------------------------ | ----: | -----: | ---: |
+|    1 | Abby Rogers        | A New ERA              | Victorious Life Church - Wesley Chapel, FL |  1075 | 134.38 |    7 |
+|    2 | James Lex          | Compelled!             | Northside Family Worship Ctr - Cumming, GA |  1060 |  132.5 |    8 |
+|    3 | Tamera Burkhalter  | Orlando Faith          | Faith A/G - Orlando, FL                    |   960 |    120 |    8 |
+|    4 | Hudson Kelley      | Montgomery             | 1st A/G - Montgomery, AL                   |   820 |  102.5 |    6 |
+|    5 | Lindsay Cowan      | Toccoa GA              | Rehoboth A/G - Toccoa, GA                  |   670 |  83.75 |    5 |
+|    6 | Katie Willis       | Ashland                | Ashland 1st A/G - Ashland, AL              |   605 |  75.63 |    5 |
+|    7 | Errin Wolf         | A New ERA              | Victorious Life Church - Wesley Chapel, FL |   585 |  73.13 |    5 |
+|    8 | EJ Mintah          | Team #2--EJ is Awesome | Victorious Life Church                     |   530 |  66.25 |    4 |
+|    9 | Sabrina Burkhalter | Orlando Faith          | Faith A/G - Orlando, FL                    |   490 |  61.25 |    5 |
+|   10 | Anna Rice          | Compelled!             | Northside Family Worship Ctr - Cumming, GA |   445 |  55.63 |    3 |
+|   11 | Ceiran Beasley     | Snellville             | Evangel Comm Church - Snellville, GA       |   440 |     55 |    3 |
+|   12 | Silas Mims         | Montgomery             | 1st A/G - Montgomery, AL                   |   330 |  41.25 |    4 |
+|   13 | Rachel Rice        | Compelled!             | Northside Family Worship Ctr - Cumming, GA |   240 |     30 |    2 |
+|   14 | Sarah Rice         | Compelled!             | Northside Family Worship Ctr - Cumming, GA |   220 |   27.5 |    1 |
+|   15 | Nancy Munoz        | Burlington             | Burlington A/G - Burlington, NC            |   215 |  26.88 |    1 |
+|   16 | Alberto Munoz      | Burlington             | Burlington A/G - Burlington, NC            |   205 |  25.63 |      |
+|   17 | Jonice Grant       | Orlando Faith          | Faith A/G - Orlando, FL                    |   155 |  19.38 |      |
+|   18 | Marvin Hernandez   | Burlington             | Burlington A/G - Burlington, NC            |   135 |  16.88 |      |
+|   19 | Reesie Owens       | A New ERA              | Victorious Life Church - Wesley Chapel, FL |   110 |  13.75 |    1 |
+|   20 | Yoki Belay         | Snellville             | Evangel Comm Church - Snellville, GA       |    95 |  11.88 |      |
+|   21 | Rodney Brown       | Snellville             | Evangel Comm Church - Snellville, GA       |    80 |     10 |    1 |
+|   22 | Joshua Hester      | Ashland                | Ashland 1st A/G - Ashland, AL              |    65 |   8.13 |      |
+|   23 | Lacey Cowan        | Toccoa GA              | Rehoboth A/G - Toccoa, GA                  |    20 |    2.5 |      |
+|   24 | Abbey Willis       | Ashland                | Ashland 1st A/G - Ashland, AL              |    15 |   1.88 |      |
+|   25 | Sidney Mims        | Montgomery             | 1st A/G - Montgomery, AL                   |    10 |   1.25 |      |
+
+## Novice League
+
+### Teams
+
+|    # | Team                 | Church                                     | W\L  | Total |   Avg |
+| ---: | -------------------- | ------------------------------------------ | ---- | ----: | ----: |
+|    1 | Raleigh              | Raleigh 1st A/G - Raleigh, NC              | 9\1  |  1210 |   121 |
+|    2 | Starship Corinthians | Calvary Church - Greensboro, NC            | 7\3  |  1125 | 112.5 |
+|    3 | TCA Jets             | Treasure Coast - Vero Beach, FL            | 7\3  |   760 |    76 |
+|    4 | Warner Robbins       | 1st A/G - Warner Robbins, GA               | 4\6  |   640 |    64 |
+|    5 | Orlando Faith        | Faith A/G - Orlando, FL                    | 3\7  |   545 |  54.5 |
+|    6 | Kings and Queens     | Victorious Life Church - Wesley Chapel, FL | 0\10 |    65 |   6.5 |
+
+
+### Individuals
+
+*Ties broken by Quiz Outs. Scores sorted by Total.*
+
+|    # | Quizzer            | Team                 | Church                                     | Total |  Avg |   QO |
+| ---: | ------------------ | -------------------- | ------------------------------------------ | ----: | ---: | ---: |
+|    1 | David Barnes       | Starship Corinthians | Calvary Church - Greensboro, NC            |   740 |   74 |    6 |
+|    2 | Ben Coleman        | Raleigh              | Raleigh 1st A/G - Raleigh, NC              |   655 | 65.5 |    5 |
+|    3 | Angela Magditch    | Warner Robbins       | 1st A/G - Warner Robbins, GA               |   560 |   56 |    4 |
+|    4 | Rahul George       | Starship Corinthians | Calvary Church - Greensboro, NC            |   385 | 38.5 |    3 |
+|    5 | Sydrena Dockery    | Raleigh              | Raleigh 1st A/G - Raleigh, NC              |   350 |   35 |    2 |
+|    6 | Joel Keva          | Orlando Faith        | Faith A/G - Orlando, FL                    |   340 |   34 |      |
+|    7 | Emilee Fitzjurls   | TCA Jets             | Treasure Coast - Vero Beach, FL            |   330 |   33 |    1 |
+|    8 | Jasmine Brown      | TCA Jets             | Treasure Coast - Vero Beach, FL            |   215 | 21.5 |      |
+|    8 | Ty Fitzjurls       | TCA Jets             | Treasure Coast - Vero Beach, FL            |   215 | 21.5 |      |
+|    9 | Joseph Vuke        | Raleigh              | Raleigh 1st A/G - Raleigh, NC              |   205 | 20.5 |    1 |
+|   10 | Dakarai Cherefant  | Orlando Faith        | Faith A/G - Orlando, FL                    |   135 | 13.5 |      |
+|   11 | Jaquonn Rios-Riley | Orlando Faith        | Faith A/G - Orlando, FL                    |    70 |    7 |      |
+|   12 | Logan Gregory      | Warner Robbins       | 1st A/G - Warner Robbins, GA               |    60 |    6 |      |
+|   13 | Hannah Hendrix     | Kings and Queens     | Victorious Life Church - Wesley Chapel, FL |    30 |    3 |      |
+|   14 | Samuel Parker      | Warner Robbins       | 1st A/G - Warner Robbins, GA               |    25 |  2.5 |      |
+|   15 | Jordan Hendrix     | Kings and Queens     | Victorious Life Church - Wesley Chapel, FL |    20 |    2 |      |
+|   16 | Daniel Olatunji    | Kings and Queens     | Victorious Life Church - Wesley Chapel, FL |    15 |  1.5 |

--- a/_pages/history/2010/regionals/southwest.md
+++ b/_pages/history/2010/regionals/southwest.md
@@ -1,0 +1,55 @@
+---
+layout: page
+title: "2010 Southwest Regionals"
+permalink: /history/2010/regionals/southwest/
+date: "2010-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2010 Season
+    link: /history/2010/
+    icon: fas fa-home
+---
+
+## Teams
+
+|    # | Team                                 | Church              | W\L  | Total |    Avg |
+| ---: | ------------------------------------ | ------------------- | ---- | ----: | -----: |
+|    1 | Perfection                           | Church At Briargate | 12\2 |  2280 | 162.86 |
+|    2 | A-Gladiators                         | Timberline          | 11\3 |  2365 | 168.93 |
+|    3 | A-Tomorrow We Die Living Hope Church | OCFA                | 11\3 |  2190 | 156.43 |
+|    4 | A-Not A Matter Of Talk               | OCFA                | 9\5  |  2435 | 173.93 |
+|    5 | A-Strong To The End                  | Paradise Hills      | 7\7  |  1895 | 135.36 |
+|    6 | A-One Body Many 6 Parts              | OCCEC               | 4\10 |  1415 | 101.07 |
+|    7 | A-Strong Weaklings                   | PCC                 | 2\12 |  1395 |  99.64 |
+|    8 | A-Dough                              | Scottsdale          | 0\14 |   425 |  30.36 |
+
+## Individuals
+
+|    # | Quizzer            | Team                    | Church              | Total |    Avg |   QO |
+| ---: | ------------------ | ----------------------- | ------------------- | ----: | -----: | ---: |
+|    1 | Zach Mang          | A-Not A Matter Of Talk  | OCFA                |  1720 | 122.86 |   11 |
+|    2 | Kory Witter        | A-Gladiators            | Timberline          |  1430 | 102.14 |    9 |
+|    3 | Meg Pace           | A-Tomorrow We Die       | Living Hope Church  |  1240 |  88.57 |   10 |
+|    4 | Joanna Duka        | A-Strong To The End     | Paradise Hills      |  1225 |   87.5 |    8 |
+|    5 | Tatianna Kufferath | A-Strong Weaklings      | PCC                 |  1190 |     85 |    7 |
+|    6 | Ellen Oss          | A-Aiming for Perfection | Church At Briargate |  1075 |  76.79 |    5 |
+|    7 | Tiffany Wu         | A-One Body Many Parts   | OCCEC               |   880 |  62.86 |    4 |
+|    8 | Caitlin Pace       | A-Tomorrow We Die       | Living Hope Church  |   780 |  55.71 |    3 |
+|    9 | Kyle Witter        | A-Gladiators            | Timberline          |   690 |  49.29 |    2 |
+|   10 | Amie Oss           | A-Aiming for Perfection | Church At Briargate |   680 |  48.57 |    1 |
+|   11 | Caroline Oss       | A-Aiming for Perfection | Church At Briargate |   530 |  37.86 |    2 |
+|   12 | Chad Stogner       | A-Strong To The End     | Paradise Hills      |   515 |  36.79 |    4 |
+|   13 | JayDee Hooton      | A-Not A Matter Of Talk  | OCFA                |   465 |  33.21 |      |
+|   14 | David Zheng        | A-One Body Many Parts   | OCCEC               |   460 |  32.86 |    1 |
+|   15 | Rachel Moses       | A-Dough                 | Scottsdale          |   290 |  20.71 |    1 |
+|   16 | Chris Majeski      | A-Not A Matter Of Talk  | OCFA                |   280 |     20 |      |
+|   17 | Madison Laughlin   | A-Gladiators            | Timberline          |   245 |   17.5 |      |
+|   18 | Armando Sapien     | A-Tomorrow We Die       | Living Hope Church  |   180 |  12.86 |      |
+|   19 | Josiah Duka        | A-Strong To The End     | Paradise Hills      |   165 |  11.79 |      |
+|   20 | Andrew Byron       | A-Dough                 | Scottsdale          |   135 |   9.64 |      |
+|   21 | Josh Tuttle        | A-Strong Weaklings      | PCC                 |   120 |   8.57 |      |
+|   22 | Caleb Allen        | A-Strong Weaklings      | PCC                 |    85 |   6.07 |      |
+|   23 | Grace Xu           | A-One Body Many Parts   | OCCEC               |    80 |   5.71 |      |
+|   24 | Corrie Garrett     | A-Dough                 | Scottsdale          |    10 |   0.71 |      |

--- a/_pages/history/2011/regionals/great-lakes.md
+++ b/_pages/history/2011/regionals/great-lakes.md
@@ -1,0 +1,70 @@
+---
+layout: page
+title: "2011 Great Lakes Regionals"
+permalink: /history/2011/regionals/great-lakes/
+date: "2011-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2011 Season
+    link: /history/2011/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+|    # | Team                                           |   Avg | Total |    W |    L |
+| ---: | ---------------------------------------------- | ----: | ----: | ---: | ---: |
+|    1 | Dayspring, Bowling Green, OH                   | 199.6 |  2595 |   13 |    0 |
+|    2 | Newlife Assembly #1, White Cloud, MI           | 204.6 |  2660 |   12 |    1 |
+|   3* | First Assembly of God #2, Lexington, KY        | 181.2 |  2355 |    9 |    4 |
+|   4* | Harvest Christian Center, Mount Vernon, OH     | 149.6 |  1945 |    9 |    4 |
+|   5* | Radiant Life, Elkhart, IN                      | 144.2 |  1875 |    9 |    4 |
+|    6 | First A/G of Greater Lansing, East Lansing, MI | 110.8 |  1440 |    8 |    5 |
+|    7 | Lakeview Church, Indianapolis, IN              | 117.7 |  1530 |    7 |    6 |
+|  8** | Southwest Community Church, Joliet, IL         | 101.5 |  1320 |    6 |    7 |
+|  9** | First Assembly of God #1, Lexington, KY        | 105.4 |  1370 |    6 |    7 |
+|   10 | Southwest Youth Ablaze #1, Ft. Wayne, IN       |  68.1 |   885 |    4 |    9 |
+| 11** | Covenant Life Fellowship, Hubbard, OH          |  56.9 |   740 |    3 |   10 |
+| 12** | Meadowbrook Community Church, Champaign, IL    |  43.1 |   560 |    3 |   10 |
+|   13 | Newlife Assembly #2, White Cloud, MI           |  38.1 |   495 |    2 |   11 |
+|   14 | Victory Temple, Muncie, IN                     |  63.8 |   830 |    1 |   12 |
+
+### Individuals
+
+|    # | Quizzer         | Team                                           |   Avg | Total | QO Fwd | QO Bk |
+| ---: | --------------- | ---------------------------------------------- | ----: | ----: | -----: | ----: |
+|    1 | Jeremy Albrecht | Dayspring, Bowling Green, OH                   | 123.1 |  1600 |     13 |     0 |
+|    2 | Samuel Pryer    | Newlife Assembly #1, White Cloud, MI           | 119.2 |  1550 |     10 |     3 |
+|    3 | Rebekah Kelly   | First Assembly of God #2, Lexington, KY        | 108.1 |  1405 |     11 |     2 |
+|    4 | Courtney Walin  | Southwest Community Church, Joliet, IL         |  92.3 |  1200 |      8 |     1 |
+|    5 | Laura Roller    | Harvest Christian Center, Mount Vernon, OH     |  87.3 |  1135 |     12 |     1 |
+|    6 | Makena Schrock  | Radiant Life, Elkhart, IN                      |  71.5 |   930 |      7 |     4 |
+|    7 | Daniel Buffham  | First A/G of Greater Lansing, East Lansing, MI |  68.5 |   890 |      6 |     1 |
+|    8 | Susie Bowen     | Victory Temple, Muncie, IN                     |  64.2 |   835 |      8 |     1 |
+|    9 | Jonathan Burd   | Southwest Youth Ablaze #1, Ft. Wayne, IN       |  63.8 |   830 |      5 |     1 |
+|   10 | Rachel Roller   | Harvest Christian Center, Mount Vernon, OH     |  61.5 |   800 |      7 |     3 |
+
+## Novice League
+
+### Teams
+
+|    # | Team                                            |   Avg | Total |    W |    L |
+| ---: | ----------------------------------------------- | ----: | ----: | ---: | ---: |
+|    1 | Dayspring, Bowling Green, OH                    | 209.5 |  2095 |   10 |    0 |
+|    2 | First A/G of Greater Lansing, East Lansing, MI  |   156 |  1560 |    9 |    1 |
+|    3 | Auburn Hills Christian Center, Auburn Hills, MI |    57 |   570 |    7 |    3 |
+|    4 | Rockford First A/G, Rockford, IL                |    67 |   670 |    6 |    4 |
+|   5* | Southwest Youth Ablaze #2, Ft. Wayne, IN        |  77.5 |   775 |    5 |    5 |
+|  6** | First A/G, Lexington, KY                        | 111.5 |  1115 |    5 |    5 |
+|    7 | Stone Church, Orland Park, IL                   |    72 |   720 |    5 |    5 |
+|    8 | Trinity A/G, Georgetown, KY                     |  48.5 |   485 |    3 |    7 |
+|  9** | Calvary Temple, Indianapolis, IN                |  38.5 |   385 |    2 |    8 |
+|   10 | Lakeview Church, Indianapolis, IN               |    42 |   420 |    2 |    8 |
+|   11 | Southwest Youth Ablaze #3, Ft. Wayne, IN        |    15 |   150 |    1 |    9 |
+
+\* Defeated 6th and 7th place teams head to head.\
+\*\* Decided by head to head

--- a/_pages/history/2011/regionals/gulf.md
+++ b/_pages/history/2011/regionals/gulf.md
@@ -1,0 +1,84 @@
+---
+layout: page
+title: "2011 Gulf Regionals"
+permalink: /history/2011/regionals/gulf/
+date: "2011-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2011 Season
+    link: /history/2011/
+    icon: fas fa-home
+---
+
+## A Level
+
+### Teams
+
+|    # | Team                      |    W |    L | Total |
+| ---: | ------------------------- | ---: | ---: | ----: |
+|    1 | James River Bread of Life |    7 |    1 |  1630 |
+|    2 | Central Without Limit     |    6 |    2 |  1365 |
+|    3 | James River Nothing False |    4 |    4 |  1005 |
+|    4 | Faith West Plains         |    2 |    6 |   795 |
+|    5 | Determined To Kill        |    1 |    7 |   700 |
+
+### Individuals
+
+|    # | Quizzer          | Total |   QO |
+| ---: | ---------------- | ----: | ---: |
+|    1 | Daniel Clark     |   745 |    7 |
+|    2 | Joshua George    |   740 |    5 |
+|    3 | Daniel Quick     |   575 |    6 |
+|    4 | Matthew Klika    |   565 |    3 |
+|    5 | Natalie Garrison |   485 |    3 |
+|    6 | Whitney Garrison |   460 |    2 |
+|    7 | Devon Colegrove  |   405 |    4 |
+|    8 | Kacie Garrison   |   365 |    2 |
+|    9 | Ellen Oss        |   315 |    2 |
+|   10 | Aime Oss         |   225 |    1 |
+|   11 | Emily Murray     |   220 |    1 |
+|   12 | Brianna Riley    |   165 |    0 |
+|   13 | Brianna Silvey   |   150 |    1 |
+|   14 | Jeremiah George  |    60 |    0 |
+|   15 | Jason Good       |    25 |    0 |
+|   16 | Ashley Klika     |    20 |    0 |
+|   17 | Heidi Graves     |    10 |    0 |
+|   18 | Lauren Aubry     |     0 |    0 |
+|   19 | Haley DePriest   |     0 |    0 |
+|   20 | Trevor Gaffery   |     0 |    0 |
+
+## Novice Level
+
+### Teams
+
+|    # | Team                            |    W |    L | Total |
+| ---: | ------------------------------- | ---: | ---: | ----: |
+|    1 | Central Expensive Perfume       |    8 |    0 |  1835 |
+|    2 | Central Widespread Whispering   |    5 |    3 |  1055 |
+|    3 | James River Five Barley Loaves  |    4 |    4 |   680 |
+|    4 | James River Lambs of God        |    2 |    6 |   520 |
+|    5 | James River Shining In Darkness |    1 |    7 |   300 |
+
+### Individuals
+
+|    # | Quizzer          | Total |   QO |
+| ---: | ---------------- | ----: | ---: |
+|    1 | Emily Klika      |   955 |    8 |
+|    2 | Hannah Quick     |   675 |    7 |
+|    3 | Jacob Zorehkey   |   435 |    5 |
+|    4 | Nate Loper       |   400 |    4 |
+|    5 | Christina Burks  |   395 |    2 |
+|    6 | Jillian Griffith |   350 |    2 |
+|    7 | Hope Rogers      |   230 |    1 |
+|    8 | Justin Polley    |   225 |    0 |
+|    9 | Caroline Oss     |   205 |    2 |
+|   10 | Jaron Klassen    |   140 |    0 |
+|   11 | Abby O'Connell   |   140 |    2 |
+|   12 | Jenna DePriest   |    75 |    0 |
+|   13 | Danielle Aubry   |    75 |    0 |
+|   14 | Sarah Roberts    |    50 |    0 |
+|   15 | Acacia Graves    |    50 |    0 |
+|   16 | Elizabeth Loftis |     0 |    0 |
+|   17 | Megan Silvey     |    -5 |    0 |

--- a/_pages/history/2011/regionals/north-central.md
+++ b/_pages/history/2011/regionals/north-central.md
@@ -1,0 +1,74 @@
+---
+layout: page
+title: "2011 North Central Regionals"
+permalink: /history/2011/regionals/north-central/
+date: "2011-05-18"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2011 Season
+    link: /history/2011/
+    icon: fas fa-home
+---
+
+## Teams
+
+|    # | Team              | Church                   | W\L | Total |    Avg |
+| ---: | ----------------- | ------------------------ | --- | ----: | -----: |
+|    1 | Racine, WI        | Racine Assembly          | 8\1 |  1780 | 197.78 |
+|    2 | Cedar Rapids, IA  | First Assembly           | 7\2 |  1565 | 173.89 |
+|    3 | Gering, NE        | Northfield Church        | 7\2 |  1355 | 150.56 |
+|    4 | Sioux Falls, SD   | First Assembly           | 7\2 |  1350 |    150 |
+|    5 | Newton, IA        | Newton First Assembly    | 5\4 |   940 | 104.44 |
+|    6 | Hastings, NE      | North Shore Assembly     | 4\5 |   780 |  86.67 |
+|    7 | Fergus Falls, MN  | Life Church              | 3\6 |   630 |     70 |
+|    8 | Brookfield, WI    | Victory Int'l Fellowship | 2\7 |   565 |  62.78 |
+|    9 | Orange City, IA   | New Hope Ev. Free        | 2\7 |   540 |     60 |
+|   10 | Detroit Lakes, MN | Detroit Lakes Assembly   | 0\9 |   135 |     15 |
+
+## Individuals
+
+|    # | Quizzer               | Team              | Church                   | Total |    Avg |
+| ---: | --------------------- | ----------------- | ------------------------ | ----: | -----: |
+|    1 | Nathan Dahlin         | Racine, WI        | Racine Assembly          |  1090 | 121.11 |
+|    2 | Luke Hamilton         | Gering, NE        | Northfield Church        |  1045 | 116.11 |
+|    3 | Josiah Coder          | Cedar Rapids, IA  | First Assembly           |  1040 | 115.56 |
+|    4 | Jennifer Maki         | Newton, IA        | Newton First Assembly    |   935 | 103.89 |
+|    5 | Faith Oygaard         | Sioux Falls, SD   | First Assembly           |   810 |     90 |
+|    6 | Tori Beye             | Hastings, NE      | North Shore Assembly     |   765 |     85 |
+|    7 | Renee Toeller         | Racine, WI        | Racine Assembly          |   535 |  59.44 |
+|    8 | Hannah May            | Cedar Rapids, IA  | First Assembly           |   425 |  47.22 |
+|    9 | Leo Oygard            | Sioux Falls, SD   | First Assembly           |   415 |  46.11 |
+|   10 | Aliya Cotton          | Brookfield, WI    | Victory Int'l Fellowship |   415 |  46.11 |
+|   11 | Trevor Seidel         | Fergus Falls, MN  | Life Church              |   405 |     45 |
+|   12 | Kierstyn Marker       | Orange City, IA   | New Hope Ev. Free        |   400 |  44.44 |
+|   13 | Melissa Parker        | Gering, NE        | Northfield Church        |   170 |  18.89 |
+|   14 | Luke Troxel           | Brookfield, WI    | Victory Int'l Fellowship |   160 |  17.78 |
+|   15 | Aimee Lojeski         | Racine, WI        | Racine Assembly          |   155 |  17.22 |
+|   16 | Carrie Veer           | Fergus Falls, MN  | Life Church              |   145 |  16.11 |
+|   17 | Larissa Friesen       | Sioux Falls, SD   | First Assembly           |   105 |  11.67 |
+|   18 | Leah May              | Cedar Rapids, IA  | First Assembly           |   100 |  11.11 |
+|   19 | Elizabeth Rankin      | Orange City, IA   | New Hope Ev. Free        |   100 |  11.11 |
+|   20 | Nathan Converse       | Gering, NE        | Northfield Church        |    90 |     10 |
+|   21 | April Stevenson       | Detroit Lakes, MN | Detroit Lakes Assembly   |    70 |   7.78 |
+|   22 | Josiah Burkhardsmeier | Fergus Falls, MN  | Life Church              |    70 |   7.78 |
+|   23 | Kaleb Anderson        | Orange City, IA   | New Hope Ev. Free        |    60 |   6.67 |
+|   24 | Micki Stevenson       | Detroit Lakes, MN | Detroit Lakes Assembly   |    45 |      5 |
+|   25 | Jennifer Lowery       | Gering, NE        | Northfield Church        |    40 |   4.44 |
+|   26 | Stefan Culver         | Detroit Lakes, MN | Detroit Lakes Assembly   |    20 |   2.22 |
+|   27 | Andrea Conteras       | Hastings, NE      | North Shore Assembly     |    20 |   2.22 |
+|   28 | Rachel Schoon         | Sioux Falls, SD   | First Assembly           |    20 |   2.22 |
+|   29 | Jacob Lowery          | Gering, NE        | Northfield Church        |    10 |   1.11 |
+|   30 | Travis Seidel         | Fergus Falls, MN  | Life Church              |    10 |   1.11 |
+|   31 | Alexis Maki           | Newton, IA        | Newton First Assembly    |     5 |   0.56 |
+|   32 | Rachel Maki           | Newton, IA        | Newton First Assembly    |       |      0 |
+|   33 | Alexis Freydenfelt    | Cedar Rapids, IA  | First Assembly           |       |      0 |
+|   34 | Micah Bilby           | Orange City, IA   | New Hope Ev. Free        |       |      0 |
+|   35 | Katie Schoon          | Sioux Falls, SD   | First Assembly           |       |      0 |
+|   36 | Rachel Seidel         | Fergus Falls, MN  | Life Church              |       |      0 |
+|   37 | Gabby Burkhardsmeier  | Fergus Falls, MN  | Life Church              |       |      0 |
+|   38 | Sarah Erickon         | Brookfield, WI    | Victory Int'l Fellowship |       |      0 |
+|   39 | Nick Rens             | Sioux Falls, SD   | First Assembly           |       |      0 |
+|   40 | Carlee Tullar         | Orange City, IA   | New Hope Ev. Free        |   -20 |  -2.22 |
+|   41 | Elizabeth Erickson    | Brookfield, WI    | Victory Int'l Fellowship |   -10 |  -1.11 |

--- a/_pages/history/2011/regionals/northeast.md
+++ b/_pages/history/2011/regionals/northeast.md
@@ -1,0 +1,151 @@
+---
+layout: page
+title: "2011 Northeast Regionals"
+permalink: /history/2011/regionals/northeast/
+date: "2011-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2011 Season
+    link: /history/2011/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team                                   |    W |    L | Total |  Avg |
+| ---: | -------------------------------------- | ---: | ---: | ----: | ---: |
+|    1 | Praise A/G, Garfield, NJ "Taste Death" |   12 |    0 |  2870 |  239 |
+|    2 | Word of Life, Springfield, VA          |   10 |    2 |  2485 |  207 |
+|    3 | Journey Church, Bridgeville, PA "Witho |    9 |    3 |  2140 |  178 |
+|    4 | First A/G, Binghamton, NY              |    8 |    4 |  2180 |  182 |
+|    5 | Manassas A/G, Manassas, VA             |    8 |    4 |  1930 |  161 |
+|    6 | Living Hope Worship Center, Swedesb    |    8 |    4 |  1910 |  159 |
+|    7 | Bethlehem Church, Richmond Hill, NY    |    7 |    5 |  1575 |  131 |
+|    8 | Walnut Grove A/G, West Mifflin, PA "B  |    6 |    6 |  1365 |  114 |
+|    9 | Vineyard Haven A/G, Vineyard Haven,    |    4 |    8 |   650 |   54 |
+|   10 | Bethany Church, Wyckoff, NJ            |    3 |    9 |   860 |   72 |
+|   11 | State College A/G, State College, PA " |    2 |   10 |   380 |   32 |
+|   12 | Evangel A/G, Ephrata, PA "Simon Say    |    1 |   11 |   440 |   37 |
+|   13 | Full Gospel Church, Livingston, NJ     |    0 |   12 |   390 |   33 |
+
+### Individuals
+
+|    # | Quizzer            | Team                                   | Total |   QO |  Avg |
+| ---: | ------------------ | -------------------------------------- | ----: | ---: | ---: |
+|    1 | Catherine Hains    | Manassas A/G, Manassas, VA             |  1470 |   11 |  123 |
+|    2 | Isaac Ward         | First A/G, Binghamton, NY              |  1265 |   10 |  105 |
+|    3 | Kyler Sederwall    | Praise A/G, Garfield, NJ "Taste Death" |  1235 |   11 |  103 |
+|    4 | Justin Czubkowski  | Praise A/G, Garfield, NJ "Taste Death" |  1040 |   10 |   87 |
+|    5 | Jonathan Brown     | Walnut Grove A/G, West Mifflin, PA "B  |  1005 |    8 |   84 |
+|    6 | Joshua Inyangson   | Word of Life, Springfield, VA          |   945 |    6 |   79 |
+|    7 | Dana Warnock       | Journey Church, Bridgeville, PA "Witho |   945 |    5 |   79 |
+|    8 | Aaron Scarinzi     | First A/G, Binghamton, NY              |   915 |   10 |   76 |
+|    9 | Colton Bononi      | Journey Church, Bridgeville, PA "Witho |   875 |    7 |   73 |
+|   10 | Kayla Hill         | Living Hope Worship Center, Swedesb    |   850 |    8 |   71 |
+|   11 | Santosh Mathews    | Word of Life, Springfield, VA          |   770 |    5 |   64 |
+|   12 | Jared Hill         | Living Hope Worship Center, Swedesb    |   750 |    7 |   63 |
+|   13 | Rachael Stewart    | Bethany Church, Wyckoff, NJ            |   620 |    6 |   52 |
+|   14 | Rebecca Ford       | Bethlehem Church, Richmond Hill, NY    |   615 |    6 |   51 |
+|   15 | Sam York           | Word of Life, Springfield, VA          |   590 |    5 |   49 |
+|   16 | Christopher Galea  | Praise A/G, Garfield, NJ "Taste Death" |   585 |    6 |   49 |
+|   17 | Kija Nivala        | Vineyard Haven A/G, Vineyard Haven,    |   570 |    4 |   48 |
+|   18 | Rachael Singh      | Bethlehem Church, Richmond Hill, NY    |   460 |    1 |   38 |
+|   19 | Caleb Pons         | State College A/G, State College, PA " |   370 |    4 |   31 |
+|   20 | Jonathan Kelly     | Walnut Grove A/G, West Mifflin, PA "B  |   355 |    1 |   30 |
+|   21 | Connor O'Keefe     | Journey Church, Bridgeville, PA "Witho |   320 |    4 |   27 |
+|   22 | Chase Hill         | Living Hope Worship Center, Swedesb    |   320 |    2 |   27 |
+|   23 | Nick DePasquale    | Full Gospel Church, Livingston, NJ     |   315 |    1 |   26 |
+|   24 | Kristyn Jones      | Manassas A/G, Manassas, VA             |   275 |    1 |   23 |
+|   25 | Vincent Okafor     | Bethlehem Church, Richmond Hill, NY    |   255 |    1 |   21 |
+|   26 | Robbie Mitchell    | Bethany Church, Wyckoff, NJ            |   245 |    0 |   20 |
+|   27 | Jordanne Prime     | Bethlehem Church, Richmond Hill, NY    |   235 |    1 |   20 |
+|   28 | Nathan Kiner       | Evangel A/G, Ephrata, PA "Simon Say    |   210 |    1 |   18 |
+|   29 | Zerubabbel Tessema | Word of Life, Springfield, VA          |   185 |    2 |   15 |
+|   30 | Melody Asper       | Evangel A/G, Ephrata, PA "Simon Say    |   145 |    0 |   12 |
+|   31 | Victoria Thee      | Manassas A/G, Manassas, VA             |   140 |    0 |   12 |
+|   32 | Cynthia Earl       | Evangel A/G, Ephrata, PA "Simon Say    |    85 |    0 |    7 |
+|   33 | Benjamin Nivala    | Vineyard Haven A/G, Vineyard Haven,    |    80 |    0 |    7 |
+|   34 | Kerry O’bannon     | Manassas A/G, Manassas, VA             |    50 |    0 |    4 |
+|   35 | Osasha London      | Full Gospel Church, Livingston, NJ     |    30 |    0 |    3 |
+|   36 | Reyna Martin       | Full Gospel Church, Livingston, NJ     |    30 |    0 |    3 |
+|   37 | Stephen Pitterle   | State College A/G, State College, PA " |    15 |    0 |    1 |
+|   38 | Jessica Kelly      | Walnut Grove A/G, West Mifflin, PA "B  |    10 |    0 |    1 |
+|   39 | Omari Dixon        | Bethlehem Church, Richmond Hill, NY    |    10 |    0 |    1 |
+|   40 | Liz DePasquale     | Full Gospel Church, Livingston, NJ     |    10 |    0 |    1 |
+|   41 | Trey Sederwall     | Praise A/G, Garfield, NJ "Taste Death" |    10 |    0 |    1 |
+|   42 | David Bambilla     | Full Gospel Church, Livingston, NJ     |     5 |    0 |    0 |
+|   43 | Maryanne Raushenb  | aBethany Church, Wyckoff, NJ           |     0 |    0 |    0 |
+|   44 | Rebekah Welesko    | Journey Church, Bridgeville, PA "Witho |     0 |    0 |    0 |
+|   45 | Anna Moyer         | State College A/G, State College, PA " |     0 |    0 |    0 |
+|   46 | Liz Smith          | State College A/G, State College, PA " |     0 |    0 |    0 |
+|   47 | Abhishek Mathews   | Word of Life, Springfield, VA          |     0 |    0 |    0 |
+|   48 | Jessica Fenton     | State College A/G, State College, PA " |    -5 |    0 |    0 |
+|   49 | Megan Steves       | Living Hope Worship Center, Swedesb    |   -10 |    0 |   -1 |
+
+## Middle School Division
+
+### Teams
+
+|    # | Team                                   |    W |    L | Total |  Avg |
+| ---: | -------------------------------------- | ---: | ---: | ----: | ---: |
+|    1 | Mohawk Valley Homeschool, NY           |   11 |    0 |  2615 |  238 |
+|    2 | South Hills A/G, Bethel Park, PA "Mira |    9 |    2 |  1755 |  160 |
+|    3 | Word of Life, Springfield, VA          |    8 |    3 |  1910 |  174 |
+|    4 | Praise A/G, Garfield, NJ               |    7 |    4 |  1300 |  118 |
+|    5 | South Hills A/G, Bethel Park, PA "Com  |    5 |    6 |   950 |   86 |
+|    5 | Calvary A/G, Ozone Park, NY            |    5 |    6 |   890 |   81 |
+|    5 | Christian Life A/G, Chambersburg, PA   |    5 |    6 |   890 |   81 |
+|    8 | Covenant Baptist Church, Acton, ME     |    4 |    7 |   665 |   60 |
+|    8 | Church of the Risen King, Gloucester C |    4 |    7 |   510 |   46 |
+|   10 | State College A/G, State College, PA " |    3 |    8 |   545 |   50 |
+|   10 | Emmanuel A/G, Allentown, PA "The 4     |    3 |    8 |   460 |   42 |
+|   12 | First A/G, Binghamton, NY              |    2 |    9 |   625 |   57 |
+
+### Individuals
+
+|    # | Quizzer               | Team                                   | Total |   QO |  Avg |
+| ---: | --------------------- | -------------------------------------- | ----: | ---: | ---: |
+|    1 | Jacob Martinez        | Mohawk Valley Homeschool, NY           |  1170 |    8 |  106 |
+|    2 | Caleb Hoffmann        | Mohawk Valley Homeschool, NY           |   825 |    8 |   75 |
+|    3 | David Inyangson       | Word of Life, Springfield, VA          |   815 |    7 |   74 |
+|    4 | A.J. Songsong         | Praise A/G, Garfield, NJ               |   775 |    6 |   70 |
+|    5 | Isabelle Stasenko     | South Hills A/G, Bethel Park, PA "Mira |   755 |    7 |   69 |
+|    6 | Hannah Tower          | South Hills A/G, Bethel Park, PA "Com  |   745 |    5 |   68 |
+|    7 | Zachary Berthiaume    | Covenant Baptist Church, Acton, ME     |   665 |    5 |   60 |
+|    8 | Jordan Wiltanger      | South Hills A/G, Bethel Park, PA "Mira |   660 |    4 |   60 |
+|    9 | Solomon Stevens       | Mohawk Valley Homeschool, NY           |   630 |    7 |   57 |
+|   10 | Jerrell Sydney        | Word of Life, Springfield, VA          |   570 |    4 |   52 |
+|   11 | Elizabeth Reigel      | State College A/G, State College, PA " |   550 |    5 |   50 |
+|   12 | Sadya Ouedraogo       | Word of Life, Springfield, VA          |   535 |    4 |   49 |
+|   13 | Zach Wisz             | Praise A/G, Garfield, NJ               |   525 |    6 |   48 |
+|   14 | Hanna Singh           | Calvary A/G, Ozone Park, NY            |   490 |    5 |   45 |
+|   15 | Trey Binkley          | Christian Life A/G, Chambersburg, PA   |   435 |    2 |   40 |
+|   16 | Natalie Carlson       | Christian Life A/G, Chambersburg, PA   |   415 |    1 |   38 |
+|   17 | Kevin Sanders         | First A/G, Binghamton, NY              |   405 |    1 |   37 |
+|   18 | Jared Jordan          | Church of the Risen King, Gloucester C |   370 |    1 |   34 |
+|   19 | Elizabeth Beachy      | South Hills A/G, Bethel Park, PA "Mira |   340 |    1 |   31 |
+|   20 | Nathaniel Stuart      | Emmanuel A/G, Allentown, PA "The 4     |   310 |    1 |   28 |
+|   21 | Timothy Sumner        | Calvary A/G, Ozone Park, NY            |   220 |    0 |   20 |
+|   22 | Terril Grant          | Calvary A/G, Ozone Park, NY            |   180 |    2 |   16 |
+|   23 | Ben Fenstermaker      | Emmanuel A/G, Allentown, PA "The 4     |   165 |    0 |   15 |
+|   24 | Shailyn Rose          | South Hills A/G, Bethel Park, PA "Com  |   140 |    0 |   13 |
+|   25 | Jason Flores          | Church of the Risen King, Gloucester C |   130 |    0 |   12 |
+|   26 | Abbey Ellis           | First A/G, Binghamton, NY              |   110 |    0 |   10 |
+|   27 | Jonah Bennett         | First A/G, Binghamton, NY              |   110 |    0 |   10 |
+|   28 | Emma Powers           | South Hills A/G, Bethel Park, PA "Com  |    50 |    0 |    5 |
+|   29 | Cabel Vannoy          | Christian Life A/G, Chambersburg, PA   |    40 |    0 |    4 |
+|   30 | Sydney Misak          | South Hills A/G, Bethel Park, PA "Com  |    15 |    0 |    1 |
+|   31 | Joshua Abedejos       | Church of the Risen King, Gloucester C |    10 |    0 |    1 |
+|   32 | Isabella Chittumuri   | Bethlehem Church, Richmond Hill, NY    |     0 |    0 |    0 |
+|   33 | Christina Okafor      | Bethlehem Church, Richmond Hill, NY    |     0 |    0 |    0 |
+|   34 | Tanisha Simon         | Calvary A/G, Ozone Park, NY            |     0 |    0 |    0 |
+|   35 | Elizabeth (Liza) Reyn | Church of the Risen King, Gloucester C |     0 |    0 |    0 |
+|   36 | Elissa Creisher       | Covenant Baptist Church, Acton, ME     |     0 |    0 |    0 |
+|   37 | Gerald Koon           | Word of Life, Springfield, VA          |    -5 |    0 |    0 |
+|   38 | Annie Harbison        | State College A/G, State College, PA " |    -5 |    0 |    0 |
+|   39 | Gavin Sellers         | Mohawk Valley Homeschool, NY           |   -10 |    0 |   -1 |
+|   40 | Josiah Stuart         | Emmanuel A/G, Allentown, PA "The 4     |   -15 |    0 |   -1 |

--- a/_pages/history/2011/regionals/northwest.md
+++ b/_pages/history/2011/regionals/northwest.md
@@ -1,0 +1,101 @@
+---
+layout: page
+title: "2011 Northwest Regionals"
+permalink: /history/2011/regionals/northwest/
+date: "2011-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2011 Season
+    link: /history/2011/
+    icon: fas fa-home
+---
+
+## Senior Division
+
+### Teams
+
+|    # | Team                   |    W |    L | Total |  Avg |
+| ---: | ---------------------- | ---: | ---: | ----: | ---: |
+|    1 | Bellevue- Nazarus!     |    9 |    1 | 1,395 |  140 |
+|    2 | Belgrade- Crossed Over |    6 |    4 | 1,185 |  119 |
+|    3 | Bothell- One Blessing  |    6 |    4 | 1,110 |  111 |
+|    4 | Kuna- Twisted Together |    6 |    4 | 1,100 |  110 |
+|    5 | Meridian- Nardly       |    3 |    7 |   760 |   76 |
+|    6 | Renton- Free Indeed    |    - |   10 |   430 |   43 |
+
+### Individuals
+
+|    # | Quizzer          | Team                   | Total |  Avg |
+| ---: | ---------------- | ---------------------- | ----: | ---: |
+|    1 | Katie Godfrey    | Belgrade- Crossed Over |   995 |  100 |
+|    2 | Kara Gallo       | Bellevue- Nazarus!     |   755 |   76 |
+|    3 | Missa Quintana   | Kuna- Twisted Together |   670 |   67 |
+|    4 | Josh Gallo       | Bellevue- Nazarus!     |   590 |   59 |
+|    5 | Adi Purohith     | Bothell- One Blessing  |   535 |   54 |
+|    6 | Keaton Gillihan  | Kuna- Twisted Together |   435 |   44 |
+|    7 | Devon Griggs     | Renton- Free Indeed    |   410 |   41 |
+|    8 | Anita Jagonath   | Bothell- One Blessing  |   390 |   39 |
+|    9 | Link Patrick     | Meridian- Nardly       |   345 |   35 |
+|   10 | Rachael Budahl   | Meridian- Nardly       |   340 |   34 |
+|   11 | Ani Purohith     | Bothell- One Blessing  |   190 |   19 |
+|   12 | Ian Godfrey      | Belgrade- Crossed Over |   165 |   17 |
+|   13 | Marissa Emerson  | Meridian- Nardly       |    65 |    7 |
+|   14 | Jessica Dawson   | Bellevue- Nazarus!     |    55 |    6 |
+|   15 | Karley Doty      | Belgrade- Crossed Over |    30 |    3 |
+|   16 | Liana Papini     | Renton- Free Indeed    |    25 |    3 |
+|   17 | Arie Emerson     | Meridian- Nardly       |    10 |    1 |
+|   18 | Emily Warner     | Renton- Free Indeed    |    10 |    1 |
+|   19 | Isaac Moore      | Bothell- One Blessing  |    10 |    1 |
+|   20 | Adam Grosjean    | Kuna- Twisted Together |     - |    - |
+|   21 | Andre' Nicolov   | Bothell- One Blessing  |     - |    - |
+|   22 | Jennifer Emerson | Meridian- Nardly       |     - |    - |
+|   23 | Stuart Jacobs    | Renton- Free Indeed    |     - |    - |
+|   24 | Trevor Olson     | Kuna- Twisted Together |     - |    - |
+|   25 | Sarah Barr       | Renton- Free Indeed    |   -15 |   -2 |
+
+## Novice Division
+
+### Teams
+
+|    # | Team                        |    W |    L |   Total |    Avg |
+| ---: | --------------------------- | ---: | ---: | ------: | -----: |
+|    # | Team                        |    W |    L |   Total |    Avg |
+|  --- | --------------------------- |  --- | ---- | ------- | ------ |
+|    1 | Bothell- The Wonder Force   |    9 |    1 |   2,090 |        |
+|    2 | Tacoma- Bread of Life       |    9 |    1 |   1,525 |        |
+|    3 | Lacey- Stop Grumbling       |    4 |    6 |   1,040 |        |
+|    4 | Renton- Small Fish          |    4 |    6 |     645 |        |
+|    5 | Kalispell- Not of...World   |    4 |    6 |     315 |        |
+|    6 | Meridian- Free Indeed       |    - |   10 |     330 |        |
+
+### Individuals
+
+|    # | Quizzer          | Team                      | Total |  Avg |
+| ---: | ---------------- | ------------------------- | ----: | ---: |
+|    1 | Abigail Peterson | Tacoma- Bread of Life     | 1,085 |  109 |
+|    2 | EJ Olsen         | Bothell- The Wonder Force |   995 |  100 |
+|    3 | Jacob Schumacher | Bothell- The Wonder Force |   735 |   74 |
+|    4 | Josh Halvers     | Lacey- Stop Grumbling     |   490 |   49 |
+|    5 | Ashlin Staub     | Tacoma- Bread of Life     |   445 |   45 |
+|    6 | Joe Uchytil      | Lacey- Stop Grumbling     |   330 |   33 |
+|    7 | Jonathan Ro      | Bothell- The Wonder Force |   280 |   28 |
+|    8 | Justin Lee       | Renton- Small Fish        |   275 |   28 |
+|    9 | Alex Budahl      | Meridian- Free Indeed     |   270 |   27 |
+|   10 | Jayden Wirk      | Kalispell- Not of...World |   160 |   16 |
+|   11 | Christina Kir    | Kalispell- Not of...World |   145 |   15 |
+|   12 | Nolan Griggs     | Renton- Small Fish        |   145 |   15 |
+|   13 | Zack Schiew      | Lacey- Stop Grumbling     |   140 |   14 |
+|   14 | Wesley Jaco      | Renton- Small Fish        |   130 |   13 |
+|   15 | Iva Papini       | Renton- Small Fish        |    95 |   10 |
+|   16 | Samuel Schu      | Bothell- The Wonder Force |    85 |    9 |
+|   17 | Alicia Uchytil   | Lacey- Stop Grumbling     |    80 |    8 |
+|   18 | Abby Fruech      | Meridian- Free Indeed     |    50 |    5 |
+|   19 | Jacob Fruec      | Meridian- Free Indeed     |    10 |    1 |
+|   20 | Alexis Baldw     | Bothell- The Wonder Force |     - |    - |
+|   21 | Ellis Clevlen    | Tacoma- Bread of Life     |     - |    - |
+|   22 | Emily Floyd      | Tacoma- Bread of Life     |     - |    - |
+|   23 | Michael Clev     | Tacoma- Bread of Life     |     - |    - |
+|   24 | Ryan Shaw        | Lacey- Stop Grumbling     |     - |    - |
+|   25 | Mckenna Mu       | Kalispell- Not of...World |   -10 |   -1 |

--- a/_pages/history/2011/regionals/south-central.md
+++ b/_pages/history/2011/regionals/south-central.md
@@ -1,0 +1,109 @@
+---
+layout: page
+title: "2011 South Central Regionals"
+permalink: /history/2011/regionals/south-central/
+date: "2022-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2011 Season
+    link: /history/2011/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+|    # | Team                       | Church               | W\L | Total |
+| ---: | -------------------------- | -------------------- | --- | ----: |
+|    1 | Xtreme A-League            | Owasso First         | 7\0 |  2075 |
+|   2* | Overland Park              | Overland Park        | 5\2 |  1325 |
+|   3* | Highpointe Church          | Highpointe Church    | 5\2 |  1015 |
+|   4* | Muskogee First             | Muskogee First       | 4\3 |  1145 |
+|   5* | CT Church                  | CT Church            | 4\3 |   865 |
+|    6 | Blind, Lame, and Paralyzed | Harvest Assembly     | 2\5 |   400 |
+|    7 | Braeswood                  | Braeswood            | 1\6 |   410 |
+|    8 | Abundant Life Church       | Abundant Life Church | 0\7 |   170 |
+
+\* 2nd, 3rd, 4th, 5th place determined by playoff.
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+|    # | Quizzer           | Team                       | Church               |  Total |   QO |
+| ---: | ----------------- | -------------------------- | -------------------- | -----: | ---: |
+|    1 | Daniel Wagner     | Xtreme A-League            | Owasso First         | 106.43 |    7 |
+|    2 | Jesse Wagner      | Xtreme A-League            | Owasso First         | 101.43 |    6 |
+|    3 | Ariel Brookbank   | Overland Park              | Overland Park        |  99.29 |    6 |
+|    4 | Micah Samuelson   | Highpointe Church          | Highpointe Church    |  93.57 |    5 |
+|    5 | Paul Meddaugh     | Muskogee First             | Muskogee First       |  87.86 |    5 |
+|    6 | Luke Wagner       | Xtreme A-League            | Owasso First         |  75.71 |    5 |
+|    7 | David Meddaugh    | Muskogee First             | Muskogee First       |  71.43 |    5 |
+|    8 | Tim Pyle          | CT Church                  | CT Church            |  58.57 |    4 |
+|    9 | Andrew Forsman    | CT Church                  | CT Church            |     55 |    2 |
+|   10 | David Kpando      | Braeswood                  | Braeswood            |  53.57 |    3 |
+|   11 | Zach Brookbank    | Overland Park              | Overland Park        |  46.43 |    3 |
+|   12 | Jed Brookbank     | Overland Park              | Overland Park        |     45 |    3 |
+|   13 | Matthew Samuelson | Highpointe Church          | Highpointe Church    |  32.86 |    2 |
+|   14 | Wayne Elkins      | Blind, Lame, and Paralyzed | Harvest Assembly     |  27.14 |    1 |
+|   15 | Bryson Cobb       | Abundant Life Church       | Abundant Life Church |  23.57 |      |
+|   16 | Bridgett Donnells | Blind, Lame, and Paralyzed | Harvest Assembly     |  18.57 |      |
+|   17 | Connor McGraw     | Highpointe Church          | Highpointe Church    |  17.14 |      |
+|   18 | Aaron Jackson     | Xtreme A-League            | Owasso First         |  14.29 |    1 |
+|   19 | Evans Cheroben    | Blind, Lame, and Paralyzed | Harvest Assembly     |  13.57 |      |
+|   20 | Matthew Kirby     | CT Church                  | CT Church            |  10.71 |      |
+|   21 | Daniel Oyolu      | Braeswood                  | Braeswood            |   4.29 |      |
+|   21 | Ryley Nutt        | Muskogee First             | Muskogee First       |   4.29 |      |
+|   22 | Caitlin Cruz      | Abundant Life Church       | Abundant Life Church |   2.14 |      |
+|   22 | Kenny Ukoh        | Braeswood                  | Braeswood            |   2.14 |      |
+|   23 | Seth Urbina       | Highpointe Church          | Highpointe Church    |   1.43 |      |
+|   24 | AJ Davis          | Highpointe Church          | Highpointe Church    |      0 |      |
+|   24 | Ciara Cruz        | Abundant Life Church       | Abundant Life Church |      0 |      |
+|   24 | Matthew Alfaro    | Highpointe Church          | Highpointe Church    |      0 |      |
+|   24 | Joe Pisenti       | Abundant Life Church       | Abundant Life Church |      0 |      |
+|   24 | Uzondu Okoro      | Braeswood                  | Braeswood            |      0 |      |
+|   25 | Chris Tune        | Blind, Lame, and Paralyzed | Harvest Assembly     |  -2.14 |      |
+|   26 | Anna Kirby        | CT Church                  | CT Church            |  -0.71 |      |
+|   26 | Josh Cruz         | Abundant Life Church       | Abundant Life Church |  -0.71 |      |
+
+## MSQ League
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+|    # | Team                 | Church         | W\L | Total |    Avg |
+| ---: | -------------------- | -------------- | --- | ----: | -----: |
+|    1 | Muskogee First       | Muskogee First | 7\1 |  1105 | 138.13 |
+|   2* | Braeswood            | Braeswood      | 5\3 |   810 | 101.25 |
+|   2* | CT Church            | CT Church      | 5\3 |   715 |  89.38 |
+|    4 | Xtreme Middle School | Owasso First   | 2\6 |   320 |     40 |
+|    5 | Awesome              | Fredonia First | 1\7 |   130 |  16.25 |
+
+\* 2nd and 3rd place teams split double round-robin. Placement determined by points.
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+|    # | Quizzer             | Team                   | Church           |   Total |      Avg |   QO |
+| ---: | ------------------- | ---------------------- | ---------------- | ------: | -------: | ---: |
+|    1 | Mary Meddaugh       | Muskogee First         | Muskogee First   |     830 |   103.75 |    6 |
+|    2 | Deborah Okoro       | Braeswood              | Braeswood        |     415 |    51.88 |    3 |
+|    3 | Ben Ofomata         | Braeswood              | Braeswood        |     395 |    49.38 |    3 |
+|    4 | Daniel Kirby        | CT Church              | CT Church        |     390 |    48.75 |    3 |
+|    5 | Andres Garro        | CT Church              | CT Church        |     325 |    40.63 |    3 |
+|    6 | Toshali Nutt        | Muskogee First         | Muskogee First   |     250 |    31.25 |    1 |
+|    7 | Dylan Wills         | Xtreme Middle School   | Owasso First     |     190 |    23.75 |      |
+|    8 | Kelly Fischer       | Xtreme Middle School   | Owasso First     |     100 |     12.5 |      |
+|    9 | Danielle Comstock   | Awesome                | Fredonia First   |      70 |     8.75 |      |
+|   10 | Michaela Tindle     | Awesome                | Fredonia First   |      35 |     4.38 |      |
+|   11 | Matt Garman         | Xtreme Middle School   | Owasso First     |      30 |     3.75 |      |
+|   11 | Parker Harris       | Muskogee First         | Muskogee First   |      30 |     3.75 |      |
+|   12 | Cejae Jordan        | Awesome                | Fredonia First   |      25 |     3.13 |      |
+|   13 | Jeremiah Boylan     | Muskogee First         | Muskogee First   |         |        0 |      |

--- a/_pages/history/2011/regionals/southeast.md
+++ b/_pages/history/2011/regionals/southeast.md
@@ -1,0 +1,121 @@
+---
+layout: page
+title: "2011 Southeast Regionals"
+permalink: /history/2011/regionals/southeast/
+date: "2011-05-18"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2011 Season
+    link: /history/2011/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+|    # | Team                                     |    W |    L | Total |
+| ---: | ---------------------------------------- | ---: | ---: | ----: |
+|    1 | Wesley Chapel FL Victorious Life Church  |    8 |    0 |  1815 |
+|    2 | Montgomery AL First A/G                  |    6 |    2 |  1290 |
+|    3 | Cumming GA Christ Community Church       |    5 |    3 |  1415 |
+|   4* | Fort Lauderdale FL Christian Life Center |    4 |    4 |   785 |
+|   5* | Orlando FL Faith A/G                     |    4 |    4 |   965 |
+|   6* | Toccoa GA Rehobth A/G                    |    4 |    4 |   945 |
+|    7 | Snellville GA Evangel Community Church   |    3 |    5 |   825 |
+|    8 | Ashland AL First A/G                     |    2 |    6 |   925 |
+|    9 | Warner Robins GA First A/G               |    0 |    8 |   610 |
+
+\* Fort Lauderdale won both legs of a three-way playoff for fourth. Orlando defeated Toccoa for fifth.
+
+### Individuals
+
+|    # | Quizzer            | Church             | Total |   Avg |   QO |
+| ---: | ------------------ | ------------------ | ----: | ----: | ---: |
+|    1 | Abby Rogers        | Wesley Chapel FL   |  1080 |   135 |    8 |
+|    2 | Tamera Burkhalter  | Orlando FL         |   775 | 96.88 |    6 |
+|    3 | Hudson Kelley      | Montgomery AL      |   770 | 96.25 |    6 |
+|    4 | Lindsay Cowan      | Toccoa GA          |   755 | 94.38 |    5 |
+|    5 | Katie Willis       | Ashland AL         |   735 | 91.88 |    7 |
+|    6 | Yoki Belay         | Snellville GA      |   650 | 81.25 |    6 |
+|    7 | Erinn Wolf         | Wesley Chapel FL   |   645 | 80.63 |    6 |
+|    8 | Anna Rice          | Cumming GA         |   635 | 79.38 |    4 |
+|    9 | Daniel Notman      | Fort Lauderdale FL |   580 |  72.5 |    6 |
+|   10 | Emily Herron       | Warner Robins GA   |   565 | 70.63 |    5 |
+|   11 | Silas Mims         | Montgomery AL      |   480 |    60 |    6 |
+|   12 | Sarah Rice         | Cumming GA         |   425 | 53.13 |    4 |
+|   13 | Rachel Rice        | Cumming GA         |   350 | 43.75 |    2 |
+|   14 | Sabrina Burkhalter | Orlando FL         |   205 | 25.63 |      |
+|   15 | Paul Willis        | Ashland AL         |   180 |  22.5 |    1 |
+|   16 | Allison Johnson    | Toccoa GA          |   160 |    20 |      |
+|   17 | Ceiran Beasley     | Snellville GA      |   135 | 16.88 |      |
+|   18 | Reesie Owens       | Wesley Chapel FL   |   100 |  12.5 |      |
+|   19 | Rachel Delongy     | Fort Lauderdale FL |    80 |    10 |      |
+|   20 | David Notman       | Fort Lauderdale FL |    55 |  6.88 |    1 |
+|   21 | Angela Magditch    | Warner Robins GA   |    55 |  6.88 |      |
+|   22 | Oore Morakinyo     | Fort Lauderdale FL |    45 |  5.63 |      |
+|   23 | Rodney Brown       | Snellville GA      |    40 |     5 |      |
+|  23* | Tobi Morakinyo     | Fort Lauderdale FL |    40 |     5 |      |
+|   25 | Sidney Mims        | Montgomery AL      |    35 |  4.38 |      |
+|  25* | Lacey Cowan        | Toccoa GA          |    35 |  4.38 |      |
+|   27 | E.J. Mintah        | Wesley Chapel FL   |    20 |   2.5 |      |
+|  27* | Curtis Gardner     | Cumming GA         |    20 |   2.5 |      |
+|   29 | David Willis       | Ashland AL         |    10 |  1.25 |      |
+|  29* | Josh Hester        | Ashland AL         |    10 |  1.25 |      |
+|   31 | Jonice Grant       | Orlando FL         |     0 |     0 |      |
+|  31* | Sarah Swales       | Snellville GA      |     0 |     0 |      |
+|  31* | Peter Barron       | Snellville GA      |     0 |     0 |      |
+|  31* | Hannah Mason       | Montgomery AL      |     0 |     0 |      |
+|  31* | Abbey Willis       | Ashland AL         |     0 |     0 |      |
+|  31* | Tiffany Boykin     | Warner Robins GA   |     0 |     0 |      |
+|   37 | Mo Adewunmi        | Wesley Chapel FL   |    -5 | -0.63 |      |
+|  37* | Zach Freer         | Orlando FL         |    -5 | -0.63 |      |
+|  37* | Logan Gregory      | Warner Robins GA   |    -5 | -0.63 |      |
+|   40 | Izu Aginwa         | Ashland AL         |   -10 | -1.25 |      |
+
+## Middle School League
+
+### Teams
+
+|    # | Team                                    |    W |    L | Total |
+| ---: | --------------------------------------- | ---: | ---: | ----: |
+|    1 | Greensboro NC Calvary Church            |    7 |    0 |   905 |
+|    2 | Wesley Chapel FL Victorious Life Church |    5 |    2 |  1115 |
+|    3 | Raleigh NC First A/G                    |    4 |    3 |   580 |
+|    4 | Dunwoody GA Calvary Church              |    4 |    3 |   495 |
+|    5 | Warner Robins GA First A/G              |    4 |    3 |   395 |
+|    6 | Snellville GA Evangel Community Church  |    3 |    4 |   630 |
+|    7 | Orlando FL Faith A/G                    |    1 |    6 |   300 |
+|    8 | Hueytown AL Garywood A/G                |    0 |    7 |   100 |
+
+### Individuals
+
+|    # | Quizzer            | Church           | Total |   Avg |   QO |
+| ---: | ------------------ | ---------------- | ----: | ----: | ---: |
+|    1 | Paula Ann Granston | Snellville GA    |   520 | 74.29 |    4 |
+|    2 | Shannon Wolf       | Wesley Chapel FL |   510 | 72.86 |    2 |
+|    3 | Ben Coleman        | Raleigh NC       |   475 | 67.86 |    4 |
+|    4 | Alexandria Mintah  | Wesley Chapel FL |   460 | 65.71 |    3 |
+|    5 | Rahul George       | Greensboro NC    |   385 |    55 |    3 |
+|    6 | Sydrena Dockery    | Dunwoody GA      |   375 | 53.57 |    3 |
+|    7 | David Barnes       | Greensboro NC    |   270 | 38.57 |    2 |
+|    8 | Rohan George       | Greensboro NC    |   250 | 35.71 |    1 |
+|    9 | Lola Babatola      | Warner Robins GA |   245 |    35 |      |
+|   10 | Emily Freer        | Orlando FL       |   220 | 31.43 |    1 |
+|   11 | Elizabeth Olatunji | Wesley Chapel FL |   130 | 18.57 |      |
+|   12 | Timi Fagbameye     | Warner Robins GA |   130 | 18.57 |      |
+|   13 | Abigail Knutson    | Raleigh NC       |   105 |    15 |      |
+|   14 | Stellah Indiya     | Dunwoody GA      |    70 |    10 |      |
+|   15 | Connor Davis       | Hueytown AL      |    60 |  8.57 |      |
+|   16 | Brielle Smith      | Snellville GA    |    50 |  7.14 |      |
+|  Chi | Chi Osunkwo        | Dunwoody GA      |    50 |  7.14 |      |
+|   18 | Dakarai Cherefant  | Orlando FL       |    45 |  6.43 |      |
+|   19 | Samuel Reichle     | Hueytown AL      |    40 |  5.71 |      |
+|   20 | Keanna Clarke      | Snellville GA    |    35 |     5 |      |
+|  20* | Joel Keva          | Orlando FL       |    35 |     5 |      |
+|   22 | Christopher Vogan  | Snellville GA    |    25 |  3.57 |      |
+|   23 | Dara Ogunsakin     | Warner Robins GA |    20 |  2.86 |      |
+|   24 | Daniel Olatunji    | Wesley Chapel FL |    15 |  2.14 |      |
+|   25 | Daniel Adewunmi    | Wesley Chapel FL |     0 |     0 |      |

--- a/_pages/history/2011/regionals/southwest.md
+++ b/_pages/history/2011/regionals/southwest.md
@@ -1,0 +1,78 @@
+---
+layout: page
+title: "2011 Southwest Regionals"
+permalink: /history/2011/regionals/southwest/
+date: "2011-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2011 Season
+    link: /history/2011/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+|    # | Team                      | Church                                   | W/L    | Total |
+| ---: | ------------------------- | ---------------------------------------- | ------ | ----: |
+|    1 | No Wasted Baskets         | Timberline, Ft. Collins, CO              | 12 / 0 |  2400 |
+|    2 | A Region Near the Desert* | Phoenix, AZ                              | 8 /4   |  2190 |
+|    3 | Bones Will Be Broken*     | Living Hope Church, Colorado Springs, CO | 8 /4   |  1990 |
+|    4 | Five Barley Loaves        | Orange County F/A                        | 7 / 5  |  1850 |
+|    5 | OCCEC                     | Orange County E/C                        | 5 / 7  |  1505 |
+|    6 | Hagiazo                   | Scottsdale F/A                           | 2 / 10 |   455 |
+|    7 | The Watchmen              | Worship Center @ Brighton, CO            | 0 / 12 |   475 |
+
+\* Tie broken by points.
+
+### Individuals
+
+|    # | Quizzer         | Team                     | Total |    Avg |
+| ---: | --------------- | ------------------------ | ----: | -----: |
+|    1 | Jessica Lynch   | Five Barley Loaves       |  1275 | 106.25 |
+|    2 | Kyle Witter     | No Wasted Baskets        |  1270 | 105.83 |
+|    3 | Chad Stogner    | A Region Near The Desert |  1185 |  98.75 |
+|    4 | Tiffany Wu      | OCCEC                    |  1125 |  93.75 |
+|    5 | Meg Pace        | Bones Will Be Broken     |   860 |  71.67 |
+|    6 | Kory Witter     | No Wasted Baskets        |   840 |     70 |
+|    7 | Ashley Kellock  | A Region Near The Desert |   665 |  55.42 |
+|    8 | Julianne Kelley | Bones Will Be Broken     |   590 |  49.17 |
+|    9 | Armando Sapien  | Bones Will Be Broken     |   515 |  42.92 |
+|   10 | Dane Kuroishi   | Five Barley Loaves       |   505 |  42.08 |
+|   11 | Christin Milman | The Watchmen             |   475 |  39.58 |
+|   12 | Rachael Moses   | Hagiazo                  |   365 |  30.42 |
+
+## Middle School League
+
+### Teams
+
+|    # | Team                    | Church                                   | W/L    | Total |
+| ---: | ----------------------- | ---------------------------------------- | ------ | ----: |
+|    1 | Consumers of the Word   | Church @ Briargate, Colorado Springs, CO | 10 / 0 |  1940 |
+|    2 | Water and the Spirit*   | New Hope C/C, Golden, CO                 | 6 / 4  |  1130 |
+|    3 | Not Yet 50 Years Old*   | Living Hope Church, Colorado Springs, CO | 6 / 4  |   865 |
+|    4 | Never Thirst*           | Anaheim C/C                              | 6 / 4  |   860 |
+|    5 | Never Follow a Stranger | Worship Center @ Brighton, CO            | 2 / 8  |   385 |
+|    6 | Glorious 1 C/C          | Phoenix, AZ                              | 0 / 10 |   185 |
+
+\* Tie broken by points.
+
+### Individuals
+
+|    # | Quizzer         | Team                    | Total |   Avg |
+| ---: | --------------- | ----------------------- | ----: | ----: |
+|    1 | Tiffani Phaneuf | Consumers of the Word   |  1185 | 118.5 |
+|    2 | Braden Atchley  | Water and the Spirit    |   785 |  78.5 |
+|    3 | Joshua Dupree   | Never Thirst            |   660 |    66 |
+|    4 | Emily Sapien    | Not Yet 50 Years Old    |   550 |    55 |
+|    5 | Caleb Phaneuf   | Consumers of the Word   |   535 |  53.5 |
+|    6 | Bharat Bhargava | Water and the Spirit    |   350 |    35 |
+|    7 | Laura Lipsky    | Never Follow a Stranger |   345 |  34.5 |
+|    8 | Kegan Venegas   | Never Thirst            |   200 |    20 |
+|    9 | Lillie Rainey   | Consumers of the Word   |   170 |    17 |
+|   10 | Sam Butler      | Not Yet 50 Years Old    |   160 |    16 |
+|   11 | Caleb Butler    | Not Yet 50 Years Old    |   155 |  15.5 |
+|   12 | Alyssa Gomez    | Glorious 1              |   125 |  12.5 |

--- a/_pages/history/2012/regionals/great-lakes.md
+++ b/_pages/history/2012/regionals/great-lakes.md
@@ -1,0 +1,129 @@
+---
+layout: page
+title: "2012 Great Lakes Regionals"
+permalink: /history/2012/regionals/great-lakes/
+date: "2012-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2012 Season
+    link: /history/2012/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+|    # | Team          |    W |    L | Total |   Avg |
+| ---: | ------------- | ---: | ---: | ----: | ----: |
+|    1 | Bowling Green |   12 |    1 |  2870 | 220.8 |
+|    2 | South Bend    |   11 |    2 |  2875 | 221.2 |
+|   3* | East Lansing  |   10 |    3 |  2245 | 172.7 |
+|    4 | White Cloud   |   10 |    3 |  1955 | 150.4 |
+|    5 | Lexington #1  |    9 |    4 |  2240 | 172.3 |
+|   6* | Lexington #2  |    7 |    6 |  1960 | 150.8 |
+|    7 | Mount Vernon  |    7 |    6 |  1525 | 117.3 |
+|    8 | Plainfield    |    6 |    7 |  1620 | 124.6 |
+|    9 | Hubbard       |    6 |    7 |  1550 | 119.2 |
+|   10 | Franklin      |    6 |    7 |  1425 | 109.6 |
+|   11 | Connersville  |    3 |   10 |   690 |  53.1 |
+|   12 | Champaign     |    3 |   10 |   625 |  48.1 |
+|   13 | Georgetown    |    1 |   12 |   565 |  43.5 |
+|   14 | Ft. Wayne     |    0 |   13 |   485 |  37.3 |
+
+\* East Lansing defeated White Cloud head 2 head\
+\*\* Lexington #2 wins playoff 160 to 115 over Mt Vernon.
+
+### Individuals
+
+|    # | Quizzer           | Total |   Avg | QO Fwd | QO Bk |
+| ---: | ----------------- | ----: | ----: | -----: | ----: |
+|    1 | Jeremy Albrecht   |  1665 | 128.1 |     13 |     0 |
+|    2 | Samuel Pryer      |  1440 | 110.8 |     12 |     1 |
+|    3 | Makena Schrock    |  1420 | 109.2 |     10 |     0 |
+|    4 | Rachel Roller     |  1400 | 107.7 |     11 |     2 |
+|    5 | Courtney Walin    |  1335 | 102.7 |     10 |     0 |
+|    6 | James Cary        |  1260 |  96.9 |     10 |     3 |
+|    7 | Kenadee Schrock   |  1135 |  87.3 |     10 |     2 |
+|    8 | Tabitha DiBacco   |  1120 |  86.2 |      9 |     2 |
+|    9 | Claire Convis     |  1050 |  80.8 |      6 |     0 |
+|   10 | Billy Laakkonen   |  1050 |  80.8 |      6 |     4 |
+|   11 | Brayden Laakkonen |  1010 |  77.7 |      7 |     1 |
+|   12 | Olivia Cox        |   750 |  57.7 |      7 |     1 |
+|   13 | Aaron Smith       |   735 |  56.5 |      7 |     0 |
+|   14 | Geddy Walker      |   630 |  48.5 |      7 |     1 |
+|   15 | Drew Harr         |   560 |  43.1 |      4 |     1 |
+|   16 | Christen Smith    |   535 |  41.2 |      2 |     0 |
+|   17 | Will Turner       |   485 |  37.3 |      4 |     1 |
+|   18 | Brianna Albrecht  |   475 |  36.5 |      4 |     2 |
+|   19 | David Pryer       |   440 |  33.8 |      5 |     3 |
+|   20 | Mike Klein        |   440 |  33.8 |      2 |     2 |
+|   21 | Jonathan Burd     |   400 |  30.8 |      3 |     8 |
+|   22 | Josh Schieber     |   360 |  27.7 |      3 |     3 |
+|   23 | Sam Dickson       |   350 |  26.9 |      3 |     2 |
+|   24 | Olivia Scott      |   335 |  25.8 |      1 |     0 |
+|   25 | Brianna Silvey    |   290 |  22.3 |      1 |     1 |
+|   26 | Kyle Benson       |   265 |  20.4 |      2 |     0 |
+|   27 | Madeline Headtke  |   230 |  17.7 |      0 |     0 |
+|   28 | Nathan Andrews    |   180 |  13.8 |      0 |     0 |
+|   29 | Zack Hoffman      |   180 |  13.8 |      0 |     1 |
+|   30 | Faith Pryer       |   170 |  13.1 |      0 |     2 |
+
+## Middle School League
+
+### Teams
+
+|    # | Team          |    W |    L | Total |   Avg |
+| ---: | ------------- | ---: | ---: | ----: | ----: |
+|   1* | Columbiaville |   10 |    1 |  2185 | 198.6 |
+|    2 | Novi          |   10 |    1 |  1880 | 170.9 |
+|   3* | Lexington     |    9 |    2 |  2080 | 189.1 |
+|    4 | East Lansing  |    9 |    2 |  2320 | 210.9 |
+|    5 | Orland Park   |    7 |    4 |  1355 | 123.2 |
+|    6 | Georgetown    |    6 |    5 |  1715 | 155.9 |
+|    7 | Ft. Wayne     |    5 |    6 |   905 |  82.3 |
+|    8 | Indianapolis  |    3 |    8 |   510 |  46.4 |
+|    9 | Greencastle   |    3 |    8 |   425 |  38.6 |
+|   10 | Elkhart       |    2 |    9 |   825 |    75 |
+|   11 | Champaign     |    1 |   10 |   485 |  44.1 |
+|   12 | Pendleton     |    1 |   10 |   215 |  19.5 |
+
+\* Columbiaville wins playoff 195 to 30 over Novi.\
+\*\* Lexington defeated East Lansing head to head.
+
+### Individuals
+
+|    # | Quizzer            | Total |   Avg | QO Fwd | QO Bk |
+| ---: | ------------------ | ----: | ----: | -----: | ----: |
+|    1 | Celah Convis       |  1415 | 128.6 |     10 |     0 |
+|    2 | Christopher Turner |  1235 | 112.3 |     10 |     0 |
+|    3 | Seth Smith         |  1160 | 105.5 |      9 |     2 |
+|    4 | Caleb Czaja        |  1160 | 105.5 |      8 |     2 |
+|    5 | Sheila Peters      |  1035 |  94.1 |      8 |     1 |
+|    6 | Deanna Davenport   |   995 |  90.5 |      7 |     3 |
+|    7 | Kirsten Andrews    |   905 |  82.3 |      9 |     0 |
+|    8 | Alexander Peters   |   900 |  81.8 |     10 |     0 |
+|    9 | Matthew Walker     |   895 |  81.4 |      9 |     0 |
+|   10 | Lauren Chapman     |   610 |  55.5 |      3 |     0 |
+|   11 | Jonathan Gomez     |   555 |  50.5 |      4 |     1 |
+|   12 | Elijah Pettit      |   480 |  43.6 |      3 |     2 |
+|   13 | Lilie Burd         |   390 |  35.5 |      4 |     6 |
+|   14 | Luke Myer          |   385 |    35 |      4 |     4 |
+|   15 | Mikaela Disinger   |   385 |    35 |      2 |     1 |
+|   16 | Moriah Hendrie     |   350 |  31.8 |      2 |     1 |
+|   17 | Lauren Randolph    |   275 |    25 |      1 |     0 |
+|   18 | Max Holleman       |   270 |  24.5 |      2 |     2 |
+|   19 | Luke Hollin        |   255 |  23.2 |      0 |     0 |
+|   20 | Kylie Dowers       |   240 |  21.8 |      1 |     1 |
+|   21 | Sopulu Anidobu     |   195 |  17.7 |      0 |     1 |
+|   22 | Katie Dowers       |   165 |    15 |      1 |     0 |
+|   23 | Cameron Watson     |   150 |  13.6 |      0 |     3 |
+|   24 | Rebecca Eschbach   |   135 |  12.3 |      0 |     0 |
+|   25 | Caitlyn Binkerd    |   120 |  10.9 |      0 |     0 |
+|   26 | Brooke Garcia      |   105 |   9.5 |      0 |     0 |
+|   27 | Isaac Goar         |    75 |   6.8 |      0 |     0 |
+|   28 | Madison Trout      |    35 |   3.2 |      0 |     0 |
+|   29 | Jonny Laakkonen    |    35 |   3.2 |      0 |     0 |
+|   30 | Lydia Trout        |    30 |   2.7 |      0 |     0 |

--- a/_pages/history/2012/regionals/gulf.md
+++ b/_pages/history/2012/regionals/gulf.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: "2012 Gulf Regionals"
+permalink: /history/2012/regionals/gulf/
+date: "2012-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2012 Season
+    link: /history/2012/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+| Team                    |    W |    L | Total |  Avg |
+| ----------------------- | ---: | ---: | ----: | ---: |
+| JRA-Ignorant & Unstable |    3 |    1 |   655 |  163 |
+| Central-Quick           |    2 |    1 |   515 |  171 |
+| Central-What They Fear  |    0 |    3 |   170 |   56 |
+
+### Individuals
+
+|    # | Quizzer          | Team                    | Total |  Avg |   QO |
+| ---: | ---------------- | ----------------------- | ----: | ---: | ---: |
+|    1 | Joshua George    | JRA-Ignorant & Unstable |   370 |   93 |    3 |
+|    2 | Daniel Quick     | Central-Quick           |   325 |  109 |    3 |
+|    3 | Hannah Quick     | Central-Quick           |   200 |   67 |    0 |
+|    4 | Devon Colegrove  | JRA-Ignorant & Unstable |   170 |   43 |    2 |
+|    5 | Jillian Griffith | JRA-Ignorant & Unstable |   115 |   29 |    0 |
+|    6 | Elllen Oss       | Central-What They Fear  |   110 |   37 |    1 |
+|    7 | Amie Oss         | Central-What They Fear  |   100 |   34 |    0 |
+|    8 | Brianna Riley    | Central-What They Fear  |    80 |   27 |    0 |
+|    9 | Caroline Oss     | Central-Quick           |    50 |   17 |    0 |
+
+## Middle School League
+
+### Teams
+
+| Team                         |    W |    L | Total |  Avg |
+| ---------------------------- | ---: | ---: | ----: | ---: |
+| King's Chapel                |    4 |    2 |  1075 |  179 |
+| JRA-Be Afraid                |    4 |    2 |   985 |  164 |
+| Central-Zorehkey             |    3 |    3 |   930 |  155 |
+| JRA-They Deliberately Forget |    1 |    5 |   645 |  107 |
+
+### Individuals
+
+|    # | Quizzer                      | Team            | Total |  Avg |   QO |
+| ---: | ---------------------------- | --------------- | ----: | ---: | ---: |
+|    1 | King's Chapel                | Luna Cooper     |   550 |   92 |    5 |
+|    2 | Central-Zorehkey             | Jacob Zorehkey  |   540 |   90 |    3 |
+|    3 | King's Chapel                | Brock Peters    |   505 |   85 |    4 |
+|    4 | JRA-Be Afraid                | Jaron Klassen   |   415 |   69 |    1 |
+|    5 | JRA-They Deliberately Forget | Leisl Jansen    |   375 |   63 |    3 |
+|    6 | Central-Zorehkey             | Nathan Pulis    |   360 |   60 |    4 |
+|    7 | JRA-Be Afraid                | Christina Burks |   330 |   55 |    2 |
+|    8 | JRA-Be Afraid                | Travis Griessel |   240 |   40 |    1 |
+|    9 | JRA-They Deliberately Forget | Abby O'Connell  |   205 |   34 |    2 |
+|   10 | JRA-They Deliberately Forget | Stacy Roberts   |    45 |    8 |    0 |
+|   11 | Central-Zorehkey             | Luke Anger      |    30 |    5 |    0 |
+|   12 | JRA-They Deliberately Forget | Sarah Roberts   |    20 |    4 |    0 |
+|   12 | King's Chapel                | Maia Cooper     |    20 |    3 |    0 |

--- a/_pages/history/2012/regionals/north-central.md
+++ b/_pages/history/2012/regionals/north-central.md
@@ -1,0 +1,78 @@
+---
+layout: page
+title: "2012 North Central Regionals"
+permalink: /history/2012/regionals/north-central/
+date: "2012-05-18"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2012 Season
+    link: /history/2012/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team              | Church                        |  W / L | Total |   Avg |
+| ---: | ----------------- | ----------------------------- | -----: | ----: | ----: |
+|    1 | Gering, NE        | Northfield Assembly of God    | 10 / 0 |  1600 |   160 |
+|    2 | Cedar Rapids, IA  | First Assembly of God         |  9 / 1 |  2010 |   201 |
+|    3 | Hastings, NE      | North Shore Assembly of God   |  7 / 3 |  1080 |   108 |
+|    4 | Racine, WI        | Racine Assembly of God        |  7 / 3 |  1000 |   100 |
+|    5 | Portage, WI       | Crosspoint Assembly of God    |  6 / 4 |  1035 | 103.5 |
+|    6 | Rapid City, SD    | Bethel Assembly of God        |  5 / 5 |  1260 |   126 |
+|    7 | Moberly, MO       | First Assembly of God         |  4 / 6 |   760 |    76 |
+|    8 | Watford City, ND  | Watford City Assembly of God  |  4 / 6 |   790 |    79 |
+|    9 | Sparta, WI        | New Life Assembly of God      |  2 / 8 |   500 |    50 |
+|   10 | Bismarck, ND      | Evangel Assembly of God       |  1 / 9 |   400 |    40 |
+|   11 | Detroit Lakes, MN | Detroit Lakes Assembly of God | 0 / 10 |   165 |  16.5 |
+
+### Individuals
+
+|    # | Quizzer          | Team              | Church                        | Total |   Avg |   QO |
+| ---: | ---------------- | ----------------- | ----------------------------- | ----: | ----: | ---: |
+|    1 | Luke Hamilton    | Gering, NE        | Northfield Assembly of God    |  1395 | 139.5 |    9 |
+|    2 | Josiah Coder     | Cedar Rapids, IA  | First Assembly of God         |  1040 |   104 |   10 |
+|    3 | Jennifer Maki    | Cedar Rapids, IA  | First Assembly of God         |   895 |  89.5 |    7 |
+|    4 | Tori Beye        | Hastings, NE      | North Shore Assembly of God   |   830 |    83 |    6 |
+|    5 | Spenser Wilhelm  | Rapid City, SD    | Bethel Assembly of God        |   785 |  78.5 |    7 |
+|    6 | Marlie Heiser    | Watford City, ND  | Watford City Assembly of God  |   700 |    70 |    4 |
+|    7 | Ryan Toeller     | Racine, WI        | Racine Assembly of God        |   645 |  64.5 |    6 |
+|    8 | Ben Hazard       | Portage, WI       | Crosspoint Assembly of God    |   540 |    54 |    2 |
+|    9 | Jennifer Meyer   | Sparta, WI        | New Life Assembly of God      |   500 |    50 |    2 |
+|   10 | Lucas Hying      | Moberly, MO       | First Assembly of God         |   445 |  44.5 |    2 |
+|   11 | Nathan Hazard    | Portage, WI       | Crosspoint Assembly of God    |   320 |    32 |    3 |
+|   12 | Danelle Ragains  | Bismarck, ND      | Evangel Assembly of God       |   310 |    31 |    2 |
+|   13 | Chasey Knepler   | Moberly, MO       | First Assembly of God         |   280 |    28 |    3 |
+|   14 | Abigail Swanson  | Hastings, NE      | North Shore Assembly of God   |   245 |  24.5 |      |
+|   15 | Charlie Wilhelm  | Rapid City, SD    | Bethel Assembly of God        |   205 |  20.5 |    1 |
+|   16 | Renee Toeller    | Racine, WI        | Racine Assembly of God        |   200 |    20 |      |
+|   16 | Aimee Lojeski    | Racine, WI        | Racine Assembly of God        |   200 |    20 |      |
+|   17 | Bethia Hamilton  | Gering, NE        | Northfield Assembly of God    |   190 |    19 |    1 |
+|   18 | Tyler Roesler    | Portage, WI       | Crosspoint Assembly of God    |   180 |    18 |      |
+|   19 | April Stevenson  | Detroit Lakes, MN | Detroit Lakes Assembly of God |   150 |    15 |    1 |
+|   20 | Neal Svenson     | Rapid City, SD    | Bethel Assembly of God        |   135 |  13.5 |      |
+|   21 | Karrin Sullivan  | Rapid City, SD    | Bethel Assembly of God        |   110 |    11 |    1 |
+|   22 | Matthew Coder    | Cedar Rapids, IA  | First Assembly of God         |    60 |     6 |    1 |
+|   23 | Lucas Bender     | Bismarck, ND      | Evangel Assembly of God       |    55 |   5.5 |      |
+|   23 | Arianna Kindel   | Watford City, ND  | Watford City Assembly of God  |    55 |   5.5 |      |
+|   24 | Jasmyn Loven     | Bismarck, ND      | Evangel Assembly of God       |    40 |     4 |      |
+|   24 | Samantha Gowin   | Moberly, MO       | First Assembly of God         |    40 |     4 |      |
+|   24 | Micah Pennel     | Rapid City, SD    | Bethel Assembly of God        |    40 |     4 |      |
+|   25 | Liberty Kay      | Watford City, ND  | Watford City Assembly of God  |    35 |   3.5 |      |
+|   25 | Micki Stevenson  | Detroit Lakes, MN | Detroit Lakes Assembly of God |    35 |   3.5 |      |
+|   26 | Rachel Maki      | Cedar Rapids, IA  | First Assembly of God         |    20 |     2 |      |
+|   27 | Levi Hamilton    | Gering, NE        | Northfield Assembly of God    |    15 |   1.5 |      |
+|   28 | Andrea Conteras  | Hastings, NE      | North Shore Assembly of God   |    10 |     1 |      |
+|   29 | Reanna Toeller   | Racine, WI        | Racine Assembly of God        |       |     0 |      |
+|   29 | Victoria Roesler | Portage, WI       | Crosspoint Assembly of God    |       |     0 |      |
+|   29 | Bridget Pogue    | Moberly, MO       | First Assembly of God         |       |     0 |      |
+|   29 | Brielle Larson   | Sparta, WI        | New Life Assembly of God      |       |     0 |      |
+|   29 | Brock Williamson | Sparta, WI        | New Life Assembly of God      |       |     0 |      |
+|   30 | Sean Daniels     | Racine, WI        | Racine Assembly of God        |   -45 |  -4.5 |      |
+|   31 | Tim Kallstrom    | Detroit Lakes, MN | Detroit Lakes Assembly of God |   -20 |    -2 |      |
+|   32 | Adrian Epp       | Hastings, NE      | North Shore Assembly of God   |    -5 |  -0.5 |      |
+|   32 | Curtis Svenson   | Rapid City, SD    | Bethel Assembly of God        |    -5 |  -0.5 |      |

--- a/_pages/history/2012/regionals/northeast.md
+++ b/_pages/history/2012/regionals/northeast.md
@@ -12,280 +12,181 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## Regionals for Nationals
-
-### Teams
-
-*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
-
-| #  | Team                    | Church                        | W/L  | Total | Avg    |
-|---:|-------------------------|-------------------------------|------|------:|-------:|
-| 1  | 12 -- Gering, NE        | Northfield Assembly of God    | 13/0 | 2040  | 156.92 |
-| 2  | 04 -- Cedar Rapids, IA  | First Assembly of God         | 12/1 | 2755  | 211.92 |
-| 3  | 14 -- Hastings, NE      | North Shore Assembly of God   | 10/3 | 1365  | 105.00 |
-| 4  | 11 -- Racine, WI        | Racine Assembly of God        | 10/3 | 1420  | 109.23 |
-| 5  | 05 -- Portage, WI       | Crosspoint Assembly of God    | 9/4  | 1335  | 102.69 |
-| 6  | 07 -- Rapid City, SD    | Bethel Assembly of God        | 8/5  | 1655  | 127.31 |
-| 7  | 10 -- Watford City, ND  | Watford City Assembly of God  | 6/7  | 1105  | 85.00  |
-| 8  | 08 -- Moberly, MO       | First Assembly of God         | 6/7  | 1070  | 82.31  |
-| 9  | 02 -- Sioux Falls, SD   | First Evangelical Free        | 6/7  | 745   | 57.31  |
-| 10 | 06 -- Sparta, WI        | New Life Assembly of God      | 3/10 | 605   | 46.54  |
-| 11 | 13 -- Bismarck, ND      | Evangel Assembly of God       | 3/10 | 500   | 38.46  |
-| 12 | 03 -- Fergus Falls, MN  | Life Church                   | 3/10 | 395   | 30.38  |
-| 13 | 09 -- Detroit Lakes, MN | Detroit Lakes Assembly of God | 1/12 | 205   | 15.77  |
-| 14 | 01 -- Orange City, IA   | New Hope Evangelical Free     | 1/12 | 280   | 21.54  |
-
-### Individuals
-
-*Ties broken by QuizOuts (Scores sorted by TOTAL)*
-
-| #  | Quizzer          | Team                    | Church                        | Total | Avg    | QO |
-|---:|------------------|-------------------------|-------------------------------|------:|-------:|---:|
-| 1  | Luke Hamilton    | 12 -- Gering, NE        | Northfield Assembly of God    | 1835  | 141.15 | 13 |
-| 2  | Josiah Coder     | 04 -- Cedar Rapids, IA  | First Assembly of God         | 1410  | 108.46 | 13 |
-| 3  | Jennifer Maki    | 04 -- Cedar Rapids, IA  | First Assembly of God         | 1220  | 93.85  | 10 |
-| 4  | Tori Beye        | 14 -- Hastings, NE      | North Shore Assembly of God   | 1090  | 83.85  | 7  |
-| 5  | Spenser Wilhelm  | 07 -- Rapid City, SD    | Bethel Assembly of God        | 990   | 76.15  | 8  |
-| 6  | Marlie Heiser    | 10 -- Watford City, ND  | Watford City Assembly of God  | 930   | 71.54  | 6  |
-| 7  | Ryan Toeller     | 11 -- Racine, WI        | Racine Assembly of God        | 835   | 64.23  | 4  |
-| 8  | Lucas Hying      | 08 -- Moberly, MO       | First Assembly of God         | 745   | 57.31  | 4  |
-| 8  | Ben Hazard       | 05 -- Portage, WI       | Crosspoint Assembly of God    | 745   | 57.31  | 4  |
-| 9  | Jennifer Meyer   | 06 -- Sparta, WI        | New Life Assembly of God      | 605   | 46.54  | 2  |
-| 10 | Selena Rodriguez | 02 -- Sioux Falls, SD   | First Evangelical Free        | 465   | 35.77  | 1  |
-| 11 | Nathan Hazard    | 05 -- Portage, WI       | Crosspoint Assembly of God    | 415   | 31.92  | 4  |
-| 12 | Danelle Ragains  | 13 -- Bismarck, ND      | Evangel Assembly of God       | 375   | 28.85  | 2  |
-| 13 | Renee Toeller    | 11 -- Racine, WI        | Racine Assembly of God        | 335   | 25.77  | 1  |
-| 14 | Abigail Swanson  | 14 -- Hastings, NE      | North Shore Assembly of God   | 290   | 22.31  |    |
-| 15 | Chasey Knepler   | 08 -- Moberly, MO       | First Assembly of God         | 285   | 21.92  | 3  |
-| 16 | Aimee Lojeski    | 11 -- Racine, WI        | Racine Assembly of God        | 285   | 21.92  |    |
-| 17 | Bethany Dykstra  | 01 -- Orange City, IA   | New Hope Evangelical Free     | 235   | 18.08  | 2  |
-| 18 | Trevor Seidel    | 03 -- Fergus Falls, MN  | Life Church                   | 235   | 18.08  | 1  |
-| 19 | Neal Svenson     | 07 -- Rapid City, SD    | Bethel Assembly of God        | 225   | 17.31  | 1  |
-| 20 | Charlie Wilhelm  | 07 -- Rapid City, SD    | Bethel Assembly of God        | 210   | 16.15  | 1  |
-| 21 | Karrin Sullivan  | 07 -- Rapid City, SD    | Bethel Assembly of God        | 200   | 15.38  | 1  |
-| 22 | Bethia Hamilton  | 12 -- Gering, NE        | Northfield Assembly of God    | 195   | 15.00  | 1  |
-| 23 | April Stevenson  | 09 -- Detroit Lakes, MN | Detroit Lakes Assembly of God | 185   | 14.23  | 1  |
-| 24 | Tyler Roesler    | 05 -- Portage, WI       | Crosspoint Assembly of God    | 185   | 14.23  |    |
-| 25 | Carrie Veer      | 03 -- Fergus Falls, MN  | Life Church                   | 155   | 11.92  |    |
-| 26 | Chad Schwartz    | 02 -- Sioux Falls, SD   | First Evangelical Free        | 115   | 8.85   |    |
-| 26 | Arianna Kindel   | 10 -- Watford City, ND  | Watford City Assembly of God  | 115   | 8.85   |    |
-| 27 | Larissa Friesen  | 02 -- Sioux Falls, SD   | First Evangelical Free        | 105   | 8.08   |    |
-| 28 | Lucas Bender     | 13 -- Bismarck, ND      | Evangel Assembly of God       | 95    | 7.31   |    |
-| 29 | Matthew Coder    | 04 -- Cedar Rapids, IA  | First Assembly of God         | 85    | 6.54   |    |
-| 30 | Liberty Kay      | 10 -- Watford City, ND  | Watford City Assembly of God  | 65    | 5.00   |    |
-| 31 | Caleb Davidson   | 01 -- Orange City, IA   | New Hope Evangelical Free     | 60    | 4.62   |    |
-| 31 | Rachel Schoon    | 02 -- Sioux Falls, SD   | First Evangelical Free        | 60    | 4.62   |    |
-| 32 | Rachel Maki      | 04 -- Cedar Rapids, IA  | First Assembly of God         | 45    | 3.46   |    |
-| 32 | Samantha Gowin   | 08 -- Moberly, MO       | First Assembly of God         | 45    | 3.46   |    |
-| 33 | Micki Stevenson  | 09 -- Detroit Lakes, MN | Detroit Lakes Assembly of God | 40    | 3.08   |    |
-| 33 | Jasmyn Loven     | 13 -- Bismarck, ND      | Evangel Assembly of God       | 40    | 3.08   |    |
-| 34 | Micah Pennel     | 07 -- Rapid City, SD    | Bethel Assembly of God        | 35    | 2.69   |    |
-| 35 | Levi Hamilton    | 12 -- Gering, NE        | Northfield Assembly of God    | 15    | 1.15   |    |
-| 36 | Andrea Conteras  | 14 -- Hastings, NE      | North Shore Assembly of God   | 10    | .77    |    |
-| 36 | Lilly Mallet     | 02 -- Sioux Falls, SD   | First Evangelical Free        | 10    | .77    |    |
-| 36 | Rachel Seidel    | 03 -- Fergus Falls, MN  | Life Church                   | 10    | .77    |    |
-| 37 | Curtis Svenson   | 07 -- Rapid City, SD    | Bethel Assembly of God        | 5     | .38    |    |
-| 38 | Elizabeth Rankin | 01 -- Orange City, IA   | New Hope Evangelical Free     |       | .00    |    |
-| 38 | Michaiah Melody  | 03 -- Fergus Falls, MN  | Life Church                   |       | .00    |    |
-| 38 | Brielle Larson   | 06 -- Sparta, WI        | New Life Assembly of God      |       | .00    |    |
-| 38 | Reanna Toeller   | 11 -- Racine, WI        | Racine Assembly of God        |       | .00    |    |
-| 38 | Bridget Pogue    | 08 -- Moberly, MO       | First Assembly of God         |       | .00    |    |
-| 38 | Candi Veer       | 03 -- Fergus Falls, MN  | Life Church                   |       | .00    |    |
-| 38 | Travis Seidel    | 03 -- Fergus Falls, MN  | Life Church                   |       | .00    |    |
-| 38 | Megan Graves     | 02 -- Sioux Falls, SD   | First Evangelical Free        |       | .00    |    |
-| 38 | Brock Williamson | 06 -- Sparta, WI        | New Life Assembly of God      |       | .00    |    |
-| 38 | Kaleb Andersen   | 01 -- Orange City, IA   | New Hope Evangelical Free     |       | .00    |    |
-| 39 | Sean Daniels     | 11 -- Racine, WI        | Racine Assembly of God        | -35   | -2.69  |    |
-| 40 | Adrian Epp       | 14 -- Hastings, NE      | North Shore Assembly of God   | -25   | -1.92  |    |
-| 41 | Tim Kallstrom    | 09 -- Detroit Lakes, MN | Detroit Lakes Assembly of God | -20   | -1.54  |    |
-| 42 | Carlee Tullar    | 01 -- Orange City, IA   | New Hope Evangelical Free     | -5    | -0.38  |    |
-| 42 | Victoria Roesler | 05 -- Portage, WI       | Crosspoint Assembly of God    | -5    | -0.38  |    |
-| 42 | Kierstyn Marker  | 01 -- Orange City, IA   | New Hope Evangelical Free     | -5    | -0.38  |    |
-
-
 ## A Division
 
-### Teams
+### All Teams
 
-*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+|    # | Team                                    | Church              |    W |    L | Total |    Avg |
+| ---: | --------------------------------------- | ------------------- | ---: | ---: | ----: | -----: |
+|    1 | Praise Assembly "The End of All Things" | Garfield, NJ        |   16 |    1 |  3955 | 232.65 |
+|    2 | Journey A/G "Inexpressible"             | Bridgeville,PA      |   15 |    2 |  3365 | 197.94 |
+|    3 | LHWC - "The Real Deal"                  | Swedesboro, NJ      |   13 |    4 |  2760 | 162.35 |
+|    4 | Word of Life Assembly                   | Springfield, VA     |   13 |    4 |  2470 | 145.29 |
+|    5 | 1st Assembly of God                     | Binghamton, NY      |   12 |    5 |  3035 | 178.53 |
+|    6 | Manassas A/G                            | Bristow, VA         |   12 |    5 |  2620 | 154.12 |
+|    7 | Pocono Community Church "Black Sheep"   | Mt. Pocono, PA      |   11 |    6 |  2890 | 170.00 |
+|    8 | Bethlehem Church                        | Richmond Hill, NY   |   11 |    6 |  2420 | 142.35 |
+|    9 | Redeemer Church                         | Utica, NY           |    9 |    8 |  2130 | 125.00 |
+|   10 | Walnut Grove A/G "Greater Than Gold"    | West Mifflin, PA    |    9 |    8 |  1605 |  94.41 |
+|   11 | First A/G "Friends of the High Priest"  | Wilkes-Barre, PA    |    8 |    9 |  2145 | 126.18 |
+|   12 | Bethany Church "Family of God"          | Wyckoff, NJ         |    7 |   10 |  1305 |  76.76 |
+|   13 | Church of the Risen King "Seeking Him"  | Gloucester City, NJ |    4 |   13 |  1065 |  62.65 |
+|   14 | First Assembly of God                   | Houlton, ME         |    4 |   13 |   645 |  37.94 |
+|   15 | Cornerstone A/G                         | Bowie, MD           |    3 |   14 |   790 |  46.47 |
+|   16 | Monmouth Worship Center                 | Marlboro, NJ        |    3 |   14 |   690 |  40.59 |
+|   17 | New Hope Bible Church                   | Front Royal, VA     |    2 |   15 |   825 |  48.53 |
+|   18 | Bethany Assembly of God                 | Agawam, MA          |    1 |   16 |   225 |  13.24 |
 
-| #  | Team                                      | Church                | W/L  | Total | Avg    |
-|---:|-------------------------------------------|-----------------------|------|------:|-------:|
-| 1  | Praise Assembly \"The End of All Things\" | Garfield, NJ          | 16/1 | 3955  | 232.65 |
-| 2  | Journey A/G \"Inexpressible\"             | Bridgeville,PA        | 15/2 | 3365  | 197.94 |
-| 3  | LHWC - \"The Real Deal\"                  | Swedesboro, NJ        | 13/4 | 2760  | 162.35 |
-| 4  | Word of Life Assembly                     | Springfield, VA       | 13/4 | 2470  | 145.29 |
-| 5  | Manassas A/G                              | Bristow, VA           | 12/5 | 2620  | 154.12 |
-| 6  | First Assembly of God                     | Binghamton, NY        | 12/5 | 3035  | 178.53 |
-| 7  | Pocono Community Church \"Black Sheep\"   | Mt. Pocono, PA        | 11/6 | 2890  | 170.00 |
-| 8  | Bethlehem Church                          | Richmond Hill, NY     | 11/6 | 2420  | 142.35 |
-| 9  | Walnut Grove A/G \"Greater Than Gold\"    | West Mifflin, PA      | 9/8  | 1605  | 94.41  |
-| 10 | Redeemer Church                           | Utica, NY             | 9/8  | 2130  | 125.29 |
-| 11 | First A/G \"Friends of the High Priest\"  | Wilkes-Barre, PA      | 8/9  | 2145  | 126.18 |
-| 12 | Bethany Church \"Family of God\"          | Wyckoff, NJ           | 7/10 | 1305  | 76.76  |
-| 13 | Church of the Risen King \"Seeking Him\"  | Gloucester City, NJ   | 4/13 | 1065  | 62.65  |
-| 14 | First Assembly of God                     | Houlton, ME           | 4/13 | 645   | 37.94  |
-| 15 | Cornerstone A/G                           | Bowie, MD             | 3/14 | 790   | 46.47  |
-| 16 | Monmouth Worship Center                   | Marlboro, NJ          | 3/14 | 690   | 40.59  |
-| 17 | New Hope Bible Church                     | Front Royal, Virginia | 2/15 | 825   | 48.53  |
-| 18 | Bethany Assembly of God                   | Agawam, MA            | 1/16 | 225   | 13.24  |
+### AG Teams Only
 
-### Individuals
-
-*Ties broken by QuizOuts (Scores sorted by TOTAL)*
-
-| #  | Quizzer            | Team                                      | Church                | Total | Avg    | QO |
-|---:|--------------------|-------------------------------------------|-----------------------|------:|-------:|---:|
-| 1  | Isaac Ward         | First Assembly of God                     | Binghamton, NY        | 1910  | 112.35 | 13 |
-| 2  | Joseph Chacra      | Pocono Community Church \"Black Sheep\"   | Mt. Pocono, PA        | 1885  | 110.88 | 12 |
-| 3  | Catherine Hains    | Manassas A/G                              | Bristow, VA           | 1755  | 103.24 | 15 |
-| 4  | Kyler Sederwall    | Praise Assembly \"The End of All Things\" | Garfield, NJ          | 1675  | 98.53  | 14 |
-| 5  | Colton Bononi      | Journey A/G \"Inexpressible\"             | Bridgeville,PA        | 1655  | 97.35  | 15 |
-| 6  | Justin Czubkowski  | Praise Assembly \"The End of All Things\" | Garfield, NJ          | 1430  | 84.12  | 10 |
-| 7  | Jared Hill         | LHWC - \"The Real Deal\"                  | Swedesboro, NJ        | 1385  | 81.47  | 11 |
-| 8  | Caleb Hoffman      | Redeemer Church                           | Utica, NY             | 1315  | 77.35  | 11 |
-| 9  | Julia Rodriguez    | First A/G \"Friends of the High Priest\"  | Wilkes-Barre, PA      | 1315  | 77.35  | 9  |
-| 10 | Chase Hill         | LHWC - \"The Real Deal\"                  | Swedesboro, NJ        | 1200  | 70.59  | 11 |
-| 11 | Joshua Inyangson   | Word of Life Assembly                     | Springfield, VA       | 1155  | 67.94  | 6  |
-| 12 | Aaron Scarinzi     | First Assembly of God                     | Binghamton, NY        | 1135  | 66.76  | 10 |
-| 13 | Rachel Singh       | Bethlehem Church                          | Richmond Hill, NY     | 1000  | 58.82  | 7  |
-| 14 | Jonathan Brown     | Walnut Grove A/G \"Greater Than Gold\"    | West Mifflin, PA      | 960   | 56.47  | 5  |
-| 15 | Dana Warnock       | Journey A/G \"Inexpressible\"             | Bridgeville,PA        | 890   | 52.35  | 4  |
-| 16 | Tyler Adelmann     | Bethany Church \"Family of God\"          | Wyckoff, NJ           | 840   | 49.41  | 6  |
-| 17 | Connor O'Keefe     | Journey A/G \"Inexpressible\"             | Bridgeville,PA        | 820   | 48.24  | 10 |
-| 18 | Jacob Martinez     | Redeemer Church                           | Utica, NY             | 820   | 48.24  | 6  |
-| 19 | Bethany York       | Cornerstone A/G                           | Bowie, MD             | 745   | 43.82  | 6  |
-| 20 | Omari Dixon        | Bethlehem Church                          | Richmond Hill, NY     | 740   | 43.53  | 6  |
-| 21 | Kristyn Jones      | Manassas A/G                              | Bristow, VA           | 730   | 42.94  | 9  |
-| 22 | Sam York           | Word of Life Assembly                     | Springfield, VA       | 705   | 41.47  | 6  |
-| 23 | Rebecca Ford       | Bethlehem Church                          | Richmond Hill, NY     | 700   | 41.18  | 5  |
-| 24 | Christopher Galea  | Praise Assembly \"The End of All Things\" | Garfield, NJ          | 675   | 39.71  | 6  |
-| 25 | Abby Weatherholtz  | New Hope Bible Church                     | Front Royal, Virginia | 650   | 38.24  | 2  |
-| 26 | Jonathan Kelly     | Walnut Grove A/G \"Greater Than Gold\"    | West Mifflin, PA      | 645   | 37.94  | 5  |
-| 27 | Elijah Coryell     | Pocono Community Church \"Black Sheep\"   | Mt. Pocono, PA        | 565   | 33.24  | 4  |
-| 28 | Ethan Holmes       | First Assembly of God                     | Houlton, ME           | 545   | 32.06  | 4  |
-| 29 | Dylan Marmion      | Monmouth Worship Center                   | Marlboro, NJ          | 520   | 30.59  | 4  |
-| 30 | Jhenny Jayme       | Church of the Risen King \"Seeking Him\"  | Gloucester City, NJ   | 500   | 29.41  | 1  |
-| 31 | April Balobalo     | Church of the Risen King \"Seeking Him\"  | Gloucester City, NJ   | 480   | 28.24  | 1  |
-| 32 | Amanda Persaud     | Pocono Community Church \"Black Sheep\"   | Mt. Pocono, PA        | 475   | 27.94  | 4  |
-| 33 | Rachel Stewart     | Bethany Church \"Family of God\"          | Wyckoff, NJ           | 465   | 27.35  | 3  |
-| 34 | Abhishek Mathews   | Word of Life Assembly                     | Springfield, VA       | 445   | 26.18  | 2  |
-| 35 | Maia Britton       | First A/G \"Friends of the High Priest\"  | Wilkes-Barre, PA      | 420   | 24.71  | 1  |
-| 36 | Jessica Rodriguez  | First A/G \"Friends of the High Priest\"  | Wilkes-Barre, PA      | 415   | 24.41  | 2  |
-| 37 | Andrea Graziano    | Bethany Assembly of God                   | Agawam, MA            | 220   | 12.94  |    |
-| 38 | David Inyangson    | Word of Life Assembly                     | Springfield, VA       | 185   | 10.88  | 1  |
-| 39 | Megan Steves       | LHWC - \"The Real Deal\"                  | Swedesboro, NJ        | 175   | 10.29  | 1  |
-| 40 | Trey Sederwall     | Praise Assembly \"The End of All Things\" | Garfield, NJ          | 175   | 10.29  |    |
-| 41 | Holly Steigerwald  | New Hope Bible Church                     | Front Royal, Virginia | 170   | 10.00  | 1  |
-| 42 | Alec Rosen         | Monmouth Worship Center                   | Marlboro, NJ          | 170   | 10.00  |    |
-| 43 | Noah Holmes        | First Assembly of God                     | Houlton, ME           | 100   | 5.88   |    |
-| 44 | Erick Paras        | Church of the Risen King \"Seeking Him\"  | Gloucester City, NJ   | 95    | 5.59   |    |
-| 45 | Caleb Jones        | Manassas A/G                              | Bristow, VA           | 90    | 5.29   |    |
-| 46 | Phillip Tran       | Manassas A/G                              | Bristow, VA           | 60    | 3.53   |    |
-| 47 | Duncan McLeod      | Bethany Church \"Family of God\"          | Wyckoff, NJ           | 30    | 1.76   |    |
-| 48 | Mariah Thompson    | Cornerstone A/G                           | Bowie, MD             | 25    | 1.47   |    |
-| 49 | Maggie Thompson    | Cornerstone A/G                           | Bowie, MD             | 20    | 1.18   |    |
-| 50 | Nana Opare-Sem     | Monmouth Worship Center                   | Marlboro, NJ          | 10    | .59    |    |
-| 50 | Brandon Watt       | Bethany Assembly of God                   | Agawam, MA            | 10    | .59    |    |
-| 50 | Sadya Ouedraogo    | Word of Life Assembly                     | Springfield, VA       | 10    | .59    |    |
-| 51 | Sequoia Poths      | New Hope Bible Church                     | Front Royal, Virginia | 5     | .29    |    |
-| 51 | Selena DeSilva     | Bethlehem Church                          | Richmond Hill, NY     | 5     | .29    |    |
-| 51 | Jeremiah Tran      | Manassas A/G                              | Bristow, VA           | 5     | .29    |    |
-| 52 | Porsche            | Journey A/G \"Inexpressible\"             | Bridgeville,PA        |       | .00    |    |
-| 52 | Amber              | Journey A/G \"Inexpressible\"             | Bridgeville,PA        |       | .00    |    |
-| 52 | Abbey Ellis        | First Assembly of God                     | Binghamton, NY        |       | .00    |    |
-| 52 | Tim Straub         | LHWC - \"The Real Deal\"                  | Swedesboro, NJ        |       | .00    |    |
-| 52 | Jared              | Pocono Community Church \"Black Sheep\"   | Mt. Pocono, PA        |       | .00    |    |
-| 52 | Gianina Ragodo     | Church of the Risen King \"Seeking Him\"  | Gloucester City, NJ   |       | .00    |    |
-| 52 | Liza Reynes        | Church of the Risen King \"Seeking Him\"  | Gloucester City, NJ   |       | .00    |    |
-| 52 | Rebekah Welesko    | Journey A/G \"Inexpressible\"             | Bridgeville,PA        |       | .00    |    |
-| 52 | Tim                | Walnut Grove A/G \"Greater Than Gold\"    | West Mifflin, PA      |       | .00    |    |
-| 52 | Joelle Doroseau    | Bethany Church \"Family of God\"          | Wyckoff, NJ           |       | .00    |    |
-| 52 | Aaron Holmes       | First Assembly of God                     | Houlton, ME           |       | .00    |    |
-| 52 | Daniel Hernandez   | Bethany Church \"Family of God\"          | Wyckoff, NJ           |       | .00    |    |
-| 52 | Gabrielle Schell   | LHWC - \"The Real Deal\"                  | Swedesboro, NJ        |       | .00    |    |
-| 52 | Victoria Holmes    | First Assembly of God                     | Houlton, ME           |       | .00    |    |
-| 53 | Zerubabbel Tessema | Word of Life Assembly                     | Springfield, VA       | -25   | -1.47  |    |
-| 54 | David Brower       | Manassas A/G                              | Bristow, VA           | -20   | -1.18  |    |
-| 54 | Christina Okafor   | Bethlehem Church                          | Richmond Hill, NY     | -20   | -1.18  |    |
-| 55 | Kevin Jemiolo      | Bethany Assembly of God                   | Agawam, MA            | -5    | -0.29  |    |
-
-
-## Middle School
-
-### Teams
-
-*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
-
-| #  | Team                                     | Church            | W/L  | Total | Avg    |
-|---:|------------------------------------------|-------------------|------|------:|-------:|
-| 1  | Word of Life Assembly                    | Springfield, VA   | 12/1 | 2545  | 195.77 |
-| 2  | South Hills A/G \"4 J?s 4 Jesus\"        | Bethel Park, PA   | 11/2 | 3000  | 230.77 |
-| 3  | Redeemer Church                          | Utica, NY         | 10/3 | 2780  | 213.85 |
-| 4  | South Hills A/G \"No Ordinary Child\"    | Bethel Park, PA   | 10/3 | 2820  | 216.92 |
-| 5  | Journey A/G \"Figuratively Speaking\"    | Bridgeville, PA   | 8/5  | 2425  | 186.54 |
-| 6  | Christian Life A/G \"Flames of Fire\"    | Chambersburg, PA  | 8/5  | 2585  | 198.85 |
-| 7  | Vailsburg Assembly of God                | Newark, NJ        | 6/7  | 1245  | 95.77  |
-| 8  | Bethany Church \"People of God\"         | Wyckoff, NJ       | 6/7  | 1945  | 149.62 |
-| 9  | Emmanuel A/G \"Cloud of Witnesses\"      | Allentown, PA     | 5/8  | 1490  | 114.62 |
-| 10 | Evangel Church - \"Courageous Avengers\" | Scotch Plains, NJ | 5/8  | 1200  | 92.31  |
-| 11 | LHWC - \"Dear Friends\"                  | Swedesboro, NJ    | 3/10 | 1225  | 94.23  |
-| 12 | Prince of Peace                          | Sanford, ME       | 3/10 | 1050  | 80.77  |
-| 13 | Metuchen Assembly of God                 | Metuchen, NJ      | 3/10 | 805   | 61.92  |
-| 14 | Bethany A/G                              | Agawam, MA        | 1/12 | 410   | 31.54  |
+|    # | Team                                    | Church              |    W |    L | Tiebreaker  | Total |    Avg |
+| ---: | --------------------------------------- | ------------------- | ---: | ---: | ----------- | ----: | -----: |
+|    1 | Praise Assembly "The End of All Things" | Garfield, NJ        |   14 |    1 |             |  3955 | 232.65 |
+|    2 | Journey A/G "Inexpressible"             | Bridgeville,PA      |   13 |    2 |             |  3365 | 197.94 |
+|    3 | LHWC - "The Real Deal"                  | Swedesboro, NJ      |   11 |    4 | 1-1/Pts     |  2760 | 162.35 |
+|    4 | Manassas A/G                            | Bristow, VA         |   11 |    4 | 1-1/Pts     |  2620 | 154.12 |
+|    5 | Word of Life Assembly                   | Springfield, VA     |   11 |    4 | 1-1/Pts     |  2470 | 145.29 |
+|    6 | 1st Assembly of God                     | Binghamton, NY      |   10 |    5 | Playoff W   |  3035 | 178.53 |
+|    7 | Pocono Community Church "Black Sheep"   | Mt. Pocono, PA      |   10 |    5 | Playoff L   |  2890 | 170.00 |
+|    8 | Bethlehem Church                        | Richmond Hill, NY   |    9 |    6 |             |  2420 | 142.35 |
+|    9 | Walnut Grove A/G "Greater Than Gold"    | West Mifflin, PA    |    7 |    8 | Head-Head W |  1605 |  94.41 |
+|   10 | First A/G "Friends of the High Priest"  | Wilkes-Barre, PA    |    7 |    8 | Head-Head L |  2145 | 126.18 |
+|   11 | Bethany Church "Family of God"          | Wyckoff, NJ         |    6 |    9 |             |  1305 |  76.76 |
+|   12 | Church of the Risen King "Seeking Him"  | Gloucester City, NJ |    4 |   11 |             |  1065 |  62.65 |
+|   13 | First Assembly of God                   | Houlton, ME         |    3 |   12 |             |   645 |  37.94 |
+|   14 | Cornerstone A/G                         | Bowie, MD           |    2 |   13 |             |   790 |  46.47 |
+|   15 | Monmouth Worship Center                 | Marlboro, NJ        |    1 |   14 | Head-Head W |   690 |  40.59 |
+|   16 | Bethany Assembly of God                 | Agawam, MA          |    1 |   14 | Head-Head L |   225 |  13.24 |
 
 ### Individuals
 
-*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+*Ties broken by Quiz Outs. Scores sorted by Total.*
 
-| #  | Quizzer              | Team                                     | Church            | Total | Avg    | QO |
-|---:|----------------------|------------------------------------------|-------------------|------:|-------:|---:|
-| 1  | Kyle O'Keefe         | Journey A/G \"Figuratively Speaking\"    | Bridgeville, PA   | 1800  | 138.46 | 13 |
-| 2  | Hannah Tower         | South Hills A/G \"No Ordinary Child\"    | Bethel Park, PA   | 1700  | 130.77 | 12 |
-| 3  | Solomon Stevens      | Redeemer Church                          | Utica, NY         | 1450  | 111.54 | 10 |
-| 4  | James Khor           | South Hills A/G \"4 J?s 4 Jesus\"        | Bethel Park, PA   | 1285  | 98.85  | 11 |
-| 5  | Joey Lemley          | South Hills A/G \"4 J?s 4 Jesus\"        | Bethel Park, PA   | 1200  | 92.31  | 9  |
-| 6  | Jacob Connerly       | Word of Life Assembly                    | Springfield, VA   | 1155  | 88.85  | 7  |
-| 7  | Natalie Borzone      | Bethany Church \"People of God\"         | Wyckoff, NJ       | 1070  | 82.31  | 8  |
-| 8  | Chad Sederwall       | Vailsburg Assembly of God                | Newark, NJ        | 1045  | 80.38  | 6  |
-| 9  | Divya Mathews        | Word of Life Assembly                    | Springfield, VA   | 1040  | 80.00  | 8  |
-| 10 | Zachary Berthiaume   | Prince of Peace                          | Sanford, ME       | 1005  | 77.31  | 9  |
-| 11 | Natalie Carlson      | Christian Life A/G \"Flames of Fire\"    | Chambersburg, PA  | 1000  | 76.92  | 8  |
-| 12 | Trey Binkley         | Christian Life A/G \"Flames of Fire\"    | Chambersburg, PA  | 930   | 71.54  | 7  |
-| 13 | Nathaniel Stuart     | Emmanuel A/G \"Cloud of Witnesses\"      | Allentown, PA     | 920   | 70.77  | 9  |
-| 14 | Hannah Hill          | LHWC - \"Dear Friends\"                  | Swedesboro, NJ    | 910   | 70.00  | 4  |
-| 15 | Ethan Hoffmann       | Redeemer Church                          | Utica, NY         | 820   | 63.08  | 6  |
-| 16 | David Sikes          | South Hills A/G \"No Ordinary Child\"    | Bethel Park, PA   | 735   | 56.54  | 6  |
-| 17 | Stephen Thomas       | Evangel Church - \"Courageous Avengers\" | Scotch Plains, NJ | 700   | 53.85  | 6  |
-| 18 | Stephanie Barnett    | Christian Life A/G \"Flames of Fire\"    | Chambersburg, PA  | 655   | 50.38  | 5  |
-| 19 | Rachel Girimonte     | Bethany Church \"People of God\"         | Wyckoff, NJ       | 625   | 48.08  | 3  |
-| 20 | Robin Solomon        | Metuchen Assembly of God                 | Metuchen, NJ      | 545   | 41.92  | 3  |
-| 21 | Eli Martinez         | Redeemer Church                          | Utica, NY         | 515   | 39.62  | 4  |
-| 21 | Josh Fuller          | South Hills A/G \"4 J?s 4 Jesus\"        | Bethel Park, PA   | 515   | 39.62  | 4  |
-| 22 | Elaine Robertson     | Journey A/G \"Figuratively Speaking\"    | Bridgeville, PA   | 500   | 38.46  | 5  |
-| 23 | Ben Fenstermaker     | Emmanuel A/G \"Cloud of Witnesses\"      | Allentown, PA     | 470   | 36.15  | 2  |
-| 24 | Sydney Misak         | South Hills A/G \"No Ordinary Child\"    | Bethel Park, PA   | 385   | 29.62  | 2  |
-| 25 | Gerald Koon          | Word of Life Assembly                    | Springfield, VA   | 350   | 26.92  | 2  |
-| 26 | Julia Graziano       | Bethany A/G                              | Agawam, MA        | 240   | 18.46  |    |
-| 27 | Alethea Poornaselvan | Metuchen Assembly of God                 | Metuchen, NJ      | 205   | 15.77  | 1  |
-| 28 | Kim Rivera           | Evangel Church - \"Courageous Avengers\" | Scotch Plains, NJ | 205   | 15.77  |    |
-| 29 | Breann Watt          | Bethany A/G                              | Agawam, MA        | 170   | 13.08  |    |
-| 30 | Jeffrey Sampson      | Evangel Church - \"Courageous Avengers\" | Scotch Plains, NJ | 165   | 12.69  | 1  |
-| 31 | Katrina Dowdy        | LHWC - \"Dear Friends\"                  | Swedesboro, NJ    | 160   | 12.31  |    |
-| 32 | Brian Carty          | LHWC - \"Dear Friends\"                  | Swedesboro, NJ    | 155   | 11.92  | 1  |
-| 33 | Kayla Williams       | Vailsburg Assembly of God                | Newark, NJ        | 140   | 10.77  | 1  |
-| 34 | Victoria Stewart     | Bethany Church \"People of God\"         | Wyckoff, NJ       | 135   | 10.38  |    |
-| 35 | Daniel Persaud       | Evangel Church - \"Courageous Avengers\" | Scotch Plains, NJ | 130   | 10.00  |    |
-| 36 | Katherine Marra      | Journey A/G \"Figuratively Speaking\"    | Bridgeville, PA   | 125   | 9.62   |    |
-| 37 | Alexis Adelmann      | Bethany Church \"People of God\"         | Wyckoff, NJ       | 115   | 8.85   |    |
-| 38 | Hannah Binkley       | Emmanuel A/G \"Cloud of Witnesses\"      | Allentown, PA     | 100   | 7.69   |    |
-| 39 | David Mouwon         | Vailsburg Assembly of God                | Newark, NJ        | 70    | 5.38   |    |
-| 40 | Olufemi Oladipo      | Metuchen Assembly of God                 | Metuchen, NJ      | 65    | 5.00   |    |
-| 41 | Katie Createau       | Prince of Peace                          | Sanford, ME       | 35    | 2.69   |    |
-| 42 | Lydia Pulkinen       | Prince of Peace                          | Sanford, ME       | 10    | .77    |    |
-| 43 | Sarah Lawrence       | Prince of Peace                          | Sanford, ME       |       | .00    |    |
-| 43 | Alexandra Rivera     | Evangel Church - \"Courageous Avengers\" | Scotch Plains, NJ |       | .00    |    |
-| 43 | Leah Thomas          | Word of Life Assembly                    | Springfield, VA   |       | .00    |    |
-| 43 | Chinedu Onwuzuruike  | Vailsburg Assembly of God                | Newark, NJ        |       | .00    |    |
-| 43 | Daniel Green, Jr.    | Vailsburg Assembly of God                | Newark, NJ        |       | .00    |    |
-| 43 | Elizabeth Carrera    | Bethany A/G                              | Agawam, MA        |       | .00    |    |
+|    # | Quizzer           | Team                                    | Church              | Total |    Avg |   QO |
+| ---: | ----------------- | --------------------------------------- | ------------------- | ----: | -----: | ---: |
+|    1 | Isaac Ward        | 1st Assembly of God                     | Binghamton, NY      |  1910 | 112.35 |   13 |
+|    2 | Joseph Chacra     | Pocono Community Church "Black Sheep"   | Mt. Pocono, PA      |  1885 | 110.88 |   12 |
+|    3 | Catherine Hains   | Manassas A/G                            | Bristow, VA         |  1755 | 103.24 |   15 |
+|    4 | Kyler Sederwall   | Praise Assembly "The End of All Things" | Garfield, NJ        |  1675 |  98.53 |   14 |
+|    5 | Colton Bononi     | Journey A/G "Inexpressible"             | Bridgeville,PA      |  1655 |  97.35 |   15 |
+|    6 | Justin Czubkowski | Praise Assembly "The End of All Things" | Garfield, NJ        |  1430 |  84.12 |   10 |
+|    7 | Jared Hill        | LHWC - "The Real Deal"                  | Swedesboro, NJ      |  1385 |  81.47 |   11 |
+|    8 | Caleb Hoffman     | Redeemer Church                         | Utica, NY           |  1315 |  77.35 |   11 |
+|    9 | Julia Rodriguez   | First A/G "Friends of the High Priest"  | Wilkes-Barre, PA    |  1315 |  77.35 |    9 |
+|   10 | Chase Hill        | LHWC - "The Real Deal"                  | Swedesboro, NJ      |  1200 |  70.59 |   11 |
+|   11 | Joshua Inyangson  | Word of Life Assembly                   | Springfield, VA     |  1155 |  67.94 |    6 |
+|   12 | Aaron Scarinzi    | 1st Assembly of God                     | Binghamton, NY      |  1135 |  66.76 |   10 |
+|   13 | Rachel Singh      | Bethlehem Church                        | Richmond Hill, NY   |  1000 |  58.82 |    7 |
+|   14 | Jonathan Brown    | Walnut Grove A/G "Greater Than Gold"    | West Mifflin, PA    |   960 |  56.47 |    5 |
+|   15 | Dana Warnock      | Journey A/G "Inexpressible"             | Bridgeville,PA      |   890 |  52.35 |    4 |
+|   16 | Tyler Adelmann    | Bethany Church "Family of God"          | Wyckoff, NJ         |   840 |  49.41 |    6 |
+|   17 | Connor O'Keefe    | Journey A/G "Inexpressible"             | Bridgeville,PA      |   820 |  48.24 |   10 |
+|   18 | Jacob Martinez    | Redeemer Church                         | Utica, NY           |   820 |  48.24 |    6 |
+|   19 | Bethany York      | Cornerstone A/G                         | Bowie, MD           |   745 |  43.82 |    6 |
+|   20 | Omari Dixon       | Bethlehem Church                        | Richmond Hill, NY   |   740 |  43.53 |    6 |
+|   21 | Kristyn Jones     | Manassas A/G                            | Bristow, VA         |   730 |  42.94 |    9 |
+|   22 | Sam York          | Word of Life Assembly                   | Springfield, VA     |   705 |  41.47 |    6 |
+|   23 | Rebecca Ford      | Bethlehem Church                        | Richmond Hill, NY   |   700 |  41.18 |    5 |
+|   24 | Christopher Galea | Praise Assembly "The End of All Things" | Garfield, NJ        |   675 |  39.71 |    6 |
+|   25 | Abby Weatherholtz | New Hope Bible Church                   | Front Royal, VA     |   650 |  38.24 |    2 |
+|   26 | Jonathan Kelly    | Walnut Grove A/G "Greater Than Gold"    | West Mifflin, PA    |   645 |  37.94 |    5 |
+|   27 | Elijah Coryell    | Pocono Community Church "Black Sheep"   | Mt. Pocono, PA      |   565 |  33.24 |    4 |
+|   28 | Ethan Holmes      | First Assembly of God                   | Houlton, ME         |   545 |  32.06 |    4 |
+|   29 | Dylan Marmion     | Monmouth Worship Center                 | Marlboro, NJ        |   520 |  30.59 |    4 |
+|   30 | Jhenny Jayme      | Church of the Risen King "Seeking Him"  | Gloucester City, NJ |   500 |  29.41 |    1 |
+|   31 | April Balobalo    | Church of the Risen King "Seeking Him"  | Gloucester City, NJ |   480 |  28.24 |    1 |
+|   32 | Amanda Persaud    | Pocono Community Church "Black Sheep"   | Mt. Pocono, PA      |   475 |  27.94 |    4 |
+|   33 | Rachel Stewart    | Bethany Church "Family of God"          | Wyckoff, NJ         |   465 |  27.35 |    3 |
+|   34 | Abhishek Mathews  | Word of Life Assembly                   | Springfield, VA     |   445 |  26.18 |    2 |
+|   35 | Maia Britton      | First A/G "Friends of the High Priest"  | Wilkes-Barre, PA    |   420 |  24.71 |    1 |
+|   36 | Jessica Rodriguez | First A/G "Friends of the High Priest"  | Wilkes-Barre, PA    |   415 |  24.41 |    2 |
+|   37 | Andrea Graziano   | Bethany Assembly of God                 | Agawam, MA          |   220 |  12.94 |      |
+|   38 | David Inyangson   | Word of Life Assembly                   | Springfield, VA     |   185 |  10.88 |    1 |
+|   39 | Megan Steves      | LHWC - "The Real Deal"                  | Swedesboro, NJ      |   175 |  10.29 |    1 |
+|   40 | Trey Sederwall    | Praise Assembly "The End of All Things" | Garfield, NJ        |   175 |  10.29 |      |
+|   41 | Holly Steigerwald | New Hope Bible Church                   | Front Royal, VA     |   170 |     10 |    1 |
+|   42 | Alec Rosen        | Monmouth Worship Center                 | Marlboro, NJ        |   170 |     10 |      |
+|   43 | Noah Holmes       | First Assembly of God                   | Houlton, ME         |   100 |   5.88 |      |
+|   44 | Erick Paras       | Church of the Risen King "Seeking Him"  | Gloucester City, NJ |    95 |   5.59 |      |
+|   45 | Caleb Jones       | Manassas A/G                            | Bristow, VA         |    90 |   5.29 |      |
+|   46 | Phillip Tran      | Manassas A/G                            | Bristow, VA         |    60 |   3.53 |      |
+|   47 | Duncan McLeod     | Bethany Church "Family of God"          | Wyckoff, NJ         |    30 |   1.76 |      |
+|   48 | Mariah Thompson   | Cornerstone A/G                         | Bowie, MD           |    25 |   1.47 |      |
+|   49 | Maggie Thompson   | Cornerstone A/G                         | Bowie, MD           |    20 |   1.18 |      |
+|   50 | Nana Opare-Sem    | Monmouth Worship Center                 | Marlboro, NJ        |    10 |   0.59 |      |
+|   50 | Sadya Ouedraogo   | Word of Life Assembly                   | Springfield, VA     |    10 |   0.59 |      |
+|   50 | Brandon Watt      | Bethany Assembly of God                 | Agawam, MA          |    10 |   0.59 |      |
+|   51 | Jeremiah Tran     | Manassas A/G                            | Bristow, VA         |     5 |   0.29 |      |
+|   51 | Selena DeSilva    | Bethlehem Church                        | Richmond Hill, NY   |     5 |   0.29 |      |
+|   51 | Sequoia Poths     | New Hope Bible Church                   | Front Royal, VA     |     5 |   0.29 |      |
+
+## Middle School Division
+
+### Teams
+
+|    # | Team                                   | Church            | W\L  | Total |    Avg |
+| ---: | -------------------------------------- | ----------------- | ---- | ----: | -----: |
+|    1 | Word of Life Assembly                  | Springfield, VA   | 12\1 |  2545 | 195.77 |
+|    2 | South Hills A/G "4 J’s 4 Jesus"        | Bethel Park, PA   | 11\2 |  3000 | 230.77 |
+|    3 | Redeemer Church                        | Utica, NY         | 10\3 |  2780 | 213.85 |
+|    4 | South Hills A/G "No Ordinary Child"    | Bethel Park, PA   | 10\3 |  2820 | 216.92 |
+|    5 | Journey A/G "Figuratively Speaking"    | Bridgeville, PA   | 8\5  |  2425 | 186.54 |
+|    6 | Christian Life A/G "Flames of Fire"    | Chambersburg, PA  | 8\5  |  2585 | 198.85 |
+|    7 | Vailsburg Assembly of God              | Newark, NJ        | 6\7  |  1245 |  95.77 |
+|    8 | Bethany Church "People of God"         | Wyckoff, NJ       | 6\7  |  1945 | 149.62 |
+|    9 | Emmanuel A/G "Cloud of Witnesses"      | Allentown, PA     | 5\8  |  1490 | 114.62 |
+|   10 | Evangel Church - "Courageous Avengers" | Scotch Plains, NJ | 5\8  |  1200 |  92.31 |
+|   11 | LHWC - "Dear Friends"                  | Swedesboro, NJ    | 3\10 |  1225 |  94.23 |
+|   12 | Prince of Peace                        | Sanford, ME       | 3\10 |  1050 |  80.77 |
+|   13 | Metuchen Assembly of God               | Metuchen, NJ      | 3\10 |   805 |  61.92 |
+|   14 | Bethany A/G                            | Agawam, MA        | 1\12 |   410 |  31.54 |
+
+### Individuals
+
+*Ties broken by Quiz Outs. Scores sorted by Total.*
+
+| #   | Quizzer              | Team                                   | Church            | Total | AVG    | QO  |
+| --- | -------------------- | -------------------------------------- | ----------------- | ----- | ------ | --- |
+| 1   | Kyle O'Keefe         | Journey A/G "Figuratively Speaking"    | Bridgeville, PA   | 1800  | 138.46 | 13  |
+| 2   | Hannah Tower         | South Hills A/G "No Ordinary Child"    | Bethel Park, PA   | 1700  | 130.77 | 12  |
+| 3   | Solomon Stevens      | Redeemer Church                        | Utica, NY         | 1450  | 111.54 | 10  |
+| 4   | James Khor           | South Hills A/G "4 J’s 4 Jesus"        | Bethel Park, PA   | 1285  | 98.85  | 11  |
+| 5   | Joey Lemley          | South Hills A/G "4 J’s 4 Jesus"        | Bethel Park, PA   | 1200  | 92.31  | 9   |
+| 6   | Jacob Connerly       | Word of Life Assembly                  | Springfield, VA   | 1155  | 88.85  | 7   |
+| 7   | Natalie Borzone      | Bethany Church "People of God"         | Wyckoff, NJ       | 1070  | 82.31  | 8   |
+| 8   | Chad Sederwall       | Vailsburg Assembly of God              | Newark, NJ        | 1045  | 80.38  | 6   |
+| 9   | Divya Mathews        | Word of Life Assembly                  | Springfield, VA   | 1040  | 80     | 8   |
+| 10  | Zachary Berthiaume   | Prince of Peace                        | Sanford, ME       | 1005  | 77.31  | 9   |
+| 11  | Natalie Carlson      | Christian Life A/G "Flames of Fire"    | Chambersburg, PA  | 1000  | 76.92  | 8   |
+| 12  | Trey Binkley         | Christian Life A/G "Flames of Fire"    | Chambersburg, PA  | 930   | 71.54  | 7   |
+| 13  | Nathaniel Stuart     | Emmanuel A/G "Cloud of Witnesses"      | Allentown, PA     | 920   | 70.77  | 9   |
+| 14  | Hannah Hill          | LHWC - "Dear Friends"                  | Swedesboro, NJ    | 910   | 70     | 4   |
+| 15  | Ethan Hoffmann       | Redeemer Church                        | Utica, NY         | 820   | 63.08  | 6   |
+| 16  | David Sikes          | South Hills A/G "No Ordinary Child"    | Bethel Park, PA   | 735   | 56.54  | 6   |
+| 17  | Stephen Thomas       | Evangel Church - "Courageous Avengers" | Scotch Plains, NJ | 700   | 53.85  | 6   |
+| 18  | Stephanie Barnett    | Christian Life A/G "Flames of Fire"    | Chambersburg, PA  | 655   | 50.38  | 5   |
+| 19  | Rachel Girimonte     | Bethany Church "People of God"         | Wyckoff, NJ       | 635   | 48.85  | 3   |
+| 20  | Robin Solomon        | Metuchen Assembly of God               | Metuchen, NJ      | 545   | 41.92  | 3   |
+| 21  | Eli Martinez         | Redeemer Church                        | Utica, NY         | 515   | 39.62  | 4   |
+| 21  | Josh Fuller          | South Hills A/G "4 J’s 4 Jesus"        | Bethel Park, PA   | 515   | 39.62  | 4   |
+| 22  | Elaine Robertson     | Journey A/G "Figuratively Speaking"    | Bridgeville, PA   | 500   | 38.46  | 5   |
+| 23  | Ben Fenstermaker     | Emmanuel A/G "Cloud of Witnesses"      | Allentown, PA     | 470   | 36.15  | 2   |
+| 24  | Sydney Misak         | South Hills A/G "No Ordinary Child"    | Bethel Park, PA   | 385   | 29.62  | 2   |
+| 25  | Gerald Koon          | Word of Life Assembly                  | Springfield, VA   | 350   | 26.92  | 2   |
+| 26  | Julia Graziano       | Bethany A/G                            | Agawam, MA        | 240   | 18.46  |     |
+| 27  | Alethea Poornaselvan | Metuchen Assembly of God               | Metuchen, NJ      | 205   | 15.77  | 1   |
+| 28  | Kim Rivera           | Evangel Church - "Courageous Avengers" | Scotch Plains, NJ | 205   | 15.77  |     |
+| 29  | Breann Watt          | Bethany A/G                            | Agawam, MA        | 170   | 13.08  |     |
+| 30  | Jeffrey Sampson      | Evangel Church - "Courageous Avengers" | Scotch Plains, NJ | 165   | 12.69  | 1   |
+| 31  | Katrina Dowdy        | LHWC - "Dear Friends"                  | Swedesboro, NJ    | 160   | 12.31  |     |
+| 32  | Brian Carty          | LHWC - "Dear Friends"                  | Swedesboro, NJ    | 155   | 11.92  | 1   |
+| 33  | Kayla Williams       | Vailsburg Assembly of God              | Newark, NJ        | 140   | 10.77  | 1   |
+| 34  | Daniel Persaud       | Evangel Church - "Courageous Avengers" | Scotch Plains, NJ | 130   | 10     |     |
+| 35  | Katherine Marra      | Journey A/G "Figuratively Speaking"    | Bridgeville, PA   | 125   | 9.62   |     |
+| 35  | Victoria Stewart     | Bethany Church "People of God"         | Wyckoff, NJ       | 125   | 9.62   |     |
+| 36  | Alexis Adelmann      | Bethany Church "People of God"         | Wyckoff, NJ       | 115   | 8.85   |     |
+| 37  | Hannah Binkley       | Emmanuel A/G "Cloud of Witnesses"      | Allentown, PA     | 100   | 7.69   |     |
+| 38  | David Mouwon         | Vailsburg Assembly of God              | Newark, NJ        | 70    | 5.38   |     |
+| 39  | Olufemi Oladipo      | Metuchen Assembly of God               | Metuchen, NJ      | 65    | 5      |     |
+| 40  | Katie Createau       | Prince of Peace                        | Sanford, ME       | 35    | 2.69   |     |
+| 41  | Lydia Pulkinen       | Prince of Peace                        | Sanford, ME       | 10    | 0.77   |     |

--- a/_pages/history/2012/regionals/northwest.md
+++ b/_pages/history/2012/regionals/northwest.md
@@ -1,0 +1,113 @@
+---
+layout: page
+title: "2012 Northwest Regionals"
+permalink: /history/2012/regionals/northwest/
+date: "2012-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2012 Season
+    link: /history/2012/
+    icon: fas fa-home
+---
+
+## A Level
+
+### Teams
+
+|    # | Team                             |    W |    L | Total |  Avg |
+| ---: | -------------------------------- | ---: | ---: | ----: | ---: |
+|    1 | Bellevue, WA- Obedient Children  |    9 |      | 2,060 |  229 |
+|   2* | Nyssa, OR - Christian Fellowship |    7 |    2 |   910 |  101 |
+|   3* | Bothell, WA- Prepared for Action |    7 |    2 | 1,445 |  161 |
+|   4* | Spokane, WA- Consuming Fire      |    6 |    3 | 1,245 |  138 |
+|   5* | Wilder, ID- Four Brothers        |    4 |    5 |   790 |   88 |
+|    6 | Renton, WA- Committed            |    4 |    5 |   495 |   55 |
+|    7 | Kuna, ID- As Good as Dead        |    3 |    6 |   300 |   33 |
+|    8 | Deer Lodge, MT- Hard to Explain  |    2 |    7 |   265 |   29 |
+|    9 | Meridian, ID- The Reckoned       |    2 |    7 |   235 |   26 |
+|   10 | Tacoma, WA- Looking for Someone  |    1 |    8 |   135 |   15 |
+
+\* 2nd - 5th determined from head-to-head results.
+
+### Individuals
+
+|    # | Quizzer           | Team                     | Total |  Avg |
+| ---: | ----------------- | ------------------------ | ----: | ---: |
+|    1 | Damon Comfort     | BNC- Obedient Children   |   940 |  104 |
+|    2 | Kelsi Hardy       | NCF- Nyssa Christian     |   750 |   83 |
+|    3 | Adi Purohith      | MVA- Consuming Fire      |   695 |   77 |
+|    4 | Josh Gallo        | BNC- Obedient Children   |   650 |   72 |
+|    5 | E J Olsen         | CPC- Prepared for Action |   575 |   64 |
+|    6 | Ani Purohith      | MVA- Consuming Fire      |   550 |   61 |
+|    7 | Kara Gallo        | BNC- Obedient Children   |   475 |   53 |
+|    8 | Jacob Schumacher  | CPC- Prepared for Action |   450 |   50 |
+|    9 | Anita Jaganath    | CPC- Prepared for Action |   355 |   39 |
+|   10 | Sarah Barr        | NLR- Committed           |   330 |   37 |
+|   11 | Andrew Van Horn   | CAW- Four Brothers       |   330 |   37 |
+|   12 | Michael Van Horn  | CAW- Four Brothers       |   325 |   36 |
+|   13 | Keaton Gillihan   | KLC- As Good as Dead     |   220 |   24 |
+|   14 | Jaime Baker       | DLA- Hard to Explain     |   180 |   20 |
+|   15 | Cassie Staub      | TLC- Looking for Someone |   140 |   16 |
+|   16 | J.B. Van Horn     | CAW- Four Brothers       |   135 |   15 |
+|   17 | Seth Larson       | NCF- Nyssa Christian     |   115 |   13 |
+|   18 | Marissa Emerson   | MAG- The Reckoned        |   115 |   13 |
+|   19 | Arie Emerson      | MAG- The Reckoned        |   110 |   12 |
+|   20 | Liana Papini      | NLR- Committed           |   100 |   11 |
+|   21 | Kristina Hisel    | KLC- As Good as Dead     |    80 |    9 |
+|   22 | Samuel Schumacher | CPC- Prepared for Action |    60 |    7 |
+|   23 | Mitch Clements    | DLA- Hard to Explain     |    50 |    6 |
+|   24 | Iva Papini        | NLR- Committed           |    40 |    4 |
+|   25 | Maggy Warner      | NLR- Committed           |    35 |    4 |
+|   26 | Evan Burgess      | DLA- Hard to Explain     |    35 |    4 |
+|   27 | Elijah Larson     | NCF- Nyssa Christian     |    30 |    3 |
+|   28 | Chance Temple     | NCF- Nyssa Christian     |    15 |    2 |
+|   29 | Paloma Betrisey   | BNC- Obedient Children   |    10 |    1 |
+|   30 | Abby Fruechte     | MAG- The Reckoned        |    10 |    1 |
+|   31 | Jonathan Roberts  | CPC- Prepared for Action |     5 |    1 |
+|   32 | Diana Dvorak      | TLC- Looking for Someone |     5 |    1 |
+|   33 | Andre' Nicolov    | CPC- Prepared for Action |     0 |      |
+|   34 | Jessica Dawson    | BNC- Obedient Children   |     0 |      |
+|   35 | Anna Gallo        | BNC- Obedient Children   |     0 |      |
+|   36 | Enrique Yanez     | TLC- Looking for Someone |     0 |      |
+|   37 | Brian Anderson    | TLC- Looking for Someone |     0 |      |
+|   38 | Stuart Jacobs     | NLR- Committed           |     0 |      |
+|   39 | Kyler Beck        | NCF- Nyssa Christian     |     0 |      |
+|   40 | Jake Yanez        | TLC- Looking for Someone |   -10 |   -1 |
+
+## Middle School Level
+
+### Teams
+
+|    # | Team                                 |    W |    L | Total |  Avg |
+| ---: | ------------------------------------ | ---: | ---: | ----: | ---: |
+|   1* | Bothell, WA- Raging Fire             |    7 |    1 | 1,940 |  243 |
+|   2* | Tacoma, WA- Joyful Assembly          |    7 |    1 | 1,615 |  202 |
+|    3 | Meridian, ID- Without Doubt          |    4 |    4 |   970 |  121 |
+|    4 | Kalispell, MT- The Restrained Beasts |    2 |    6 |   335 |   42 |
+|    5 | Kuna, ID- Flames of Fire             |    0 |    8 |   345 |   43 |
+
+\* Bothell, WA-Raging Fire defeated Tacoma, WA-Joyful Assembly in playoff.
+
+### Individuals
+
+|    # | Quizzer             | Team                       | Total |  Avg |
+| ---: | ------------------- | -------------------------- | ----: | ---: |
+|    1 | Abigail Peterson    | TLC- Joyful Assembly       | 1,020 |  128 |
+|    2 | Jackson Houser      | CPC- Raging Fire           |   815 |  102 |
+|    3 | Joshua Roberts      | CPC- Raging Fire           |   775 |   97 |
+|    4 | Ashlen Staub        | TLC- Joyful Assembly       |   460 |   58 |
+|    5 | Nicole Kreiner      | MAG- Without Doubt         |   415 |   52 |
+|    6 | Cameron Hale        | MAG- Without Doubt         |   365 |   46 |
+|    7 | Jake Wright         | KLC- Flames of Fire        |   225 |   28 |
+|    8 | Oliva May           | CPC- Raging Fire           |   225 |   28 |
+|    9 | Christopher Kreiner | MAG- Without Doubt         |   190 |   24 |
+|   10 | Christina Kirchner  | KCC- The Restrained Beasts |   165 |   21 |
+|   11 | Alyssa Staub        | TLC- Joyful Assembly       |   140 |   18 |
+|   12 | Kaylie Burback      | KCC- The Restrained Beasts |   140 |   18 |
+|   13 | Johan West          | CPC- Raging Fire           |   115 |   14 |
+|   14 | Brayden Olsen       | KLC- Flames of Fire        |   105 |   13 |
+|   15 | Cassidy Wiley       | KCC- The Restrained Beasts |    30 |    4 |
+|   16 | Danielle Ellsworth  | KLC- Flames of Fire        |    15 |    2 |
+|   17 | Nicholas Schumacher | CPC- Raging Fire           |    10 |    1 |

--- a/_pages/history/2012/regionals/south-central.md
+++ b/_pages/history/2012/regionals/south-central.md
@@ -18,54 +18,53 @@ menubar_toc_static:
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
-| #  | Team                | Church            | W/L | Total | Avg    |
-|---:|---------------------|-------------------|-----|------:|-------:|
-| 1  | Owasso 1st          | Owasso 1st        | 9/0 | 2395  | 266.11 |
-| 2  | Highpointe          | Highpointe        | 7/2 | 1510  | 167.78 |
-| 3  | CT Church           | CT Church         | 7/2 | 1465  | 162.78 |
-| 4  | Braeswood           | Braeswood         | 6/3 | 1075  | 119.44 |
-| 5  | Muskogee A          | Muskogee 1st      | 6/3 | 1205  | 133.89 |
-| 6  | Overland Park 1st   | Overland Park 1st | 4/5 | 785   | 87.22  |
-| 7  | Understand Slowness | Harvest Assembly  | 3/6 | 645   | 71.67  |
-| 8  | By Faith            | Abundant Life     | 2/7 | 465   | 51.67  |
-| 9  | Fredonia 1st        | Fredonia 1st      | 1/8 | 135   | 15.00  |
-| 10 | Humble 1st          | Humble 1st        | 0/9 | 155   | 17.22  |
+|    # | Team                | Church            | W/L   | Total |    Avg |
+| ---: | ------------------- | ----------------- | ----- | ----: | -----: |
+|    1 | Owasso 1st          | Owasso 1st        | 7 / 0 |  1810 | 258.57 |
+|    2 | Highpointe          | Highpointe        | 5 / 2 |  1195 | 170.71 |
+|    3 | CT Church           | CT Church         | 5 / 2 |  1065 | 152.14 |
+|    4 | Muskogee A          | Muskogee 1st      | 5 / 2 |   975 | 139.29 |
+|    5 | Braeswood           | Braeswood         | 5 / 2 |   845 | 120.71 |
+|    6 | Overland Park 1st   | Overland Park 1st | 3 / 4 |   680 |  97.14 |
+|    7 | Understand Slowness | Harvest Assembly  | 2 / 5 |   520 |  74.29 |
+|    8 | By Faith            | Abundant Life     | 2 / 5 |   425 |  60.71 |
+|    9 | Fredonia 1st        | Fredonia 1st      | 1 / 6 |   125 |  17.86 |
+|   10 | Humble 1st          | Humble 1st        | 0 / 7 |   105 |     15 |
 
 ### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
-| #  | Quizzer           | Team                | Church            | Total | Avg    | QO |
-|---:|-------------------|---------------------|-------------------|------:|-------:|---:|
-| 1  | Daniel Wagner     | Owasso 1st          | Owasso 1st        | 1185  | 131.67 | 8  |
-| 2  | Micah Samuelson   | Highpointe          | Highpointe        | 995   | 110.56 | 8  |
-| 3  | Andrew Forsman    | CT Church           | CT Church         | 890   | 98.89  | 5  |
-| 4  | David Meddaugh    | Muskogee A          | Muskogee 1st      | 885   | 98.33  | 7  |
-| 5  | Luke Wagner       | Owasso 1st          | Owasso 1st        | 760   | 84.44  | 8  |
-| 6  | Tim Pyle          | CT Church           | CT Church         | 540   | 60.00  | 5  |
-| 7  | Bridgett Donnells | Understand Slowness | Harvest Assembly  | 475   | 52.78  | 3  |
-| 8  | Aaron Jackson     | Owasso 1st          | Owasso 1st        | 450   | 50.00  | 4  |
-| 9  | Zach Brookbank    | Overland Park 1st   | Overland Park 1st | 445   | 49.44  | 4  |
-| 10 | Bryson Cobb       | By Faith            | Abundant Life     | 430   | 47.78  | 4  |
-| 11 | David Kpando      | Braeswood           | Braeswood         | 400   | 44.44  | 2  |
-| 12 | Kenny Ukoh        | Braeswood           | Braeswood         | 385   | 42.78  | 2  |
-| 13 | Conner McGraw     | Highpointe          | Highpointe        | 345   | 38.33  | 1  |
-| 14 | Jed Brookbank     | Overland Park 1st   | Overland Park 1st | 340   | 37.78  | 3  |
-| 15 | Paul Meddaugh     | Muskogee A          | Muskogee 1st      | 320   | 35.56  | 3  |
-| 16 | Deborah Okoro     | Braeswood           | Braeswood         | 280   | 31.11  | 3  |
-| 17 | Renee Raines      | Humble 1st          | Humble 1st        | 200   | 22.22  | 1  |
-| 18 | Matthew Samuelson | Highpointe          | Highpointe        | 170   | 18.89  | 1  |
-| 19 | Wayne Elkins      | Understand Slowness | Harvest Assembly  | 105   | 11.67  |    |
-| 20 | Michaela Tindle   | Fredonia 1st        | Fredonia 1st      | 85    | 9.44   |    |
-| 21 | Shayla Puckett    | Fredonia 1st        | Fredonia 1st      | 65    | 7.22   |    |
-| 22 | Trey Bentley      | Understand Slowness | Harvest Assembly  | 50    | 5.56   |    |
-| 23 | David Brauchler   | By Faith            | Abundant Life     | 40    | 4.44   |    |
-| 24 | Andrew Roach      | CT Church           | CT Church         | 35    | 3.89   |    |
-| 25 | Annie Bentley     | Understand Slowness | Harvest Assembly  | 30    | 3.33   |    |
-| 26 | Mary Meddaugh     | Muskogee A          | Muskogee 1st      | 20    | 2.22   |    |
-| 27 | Tirzah Brookbank  | Overland Park 1st   | Overland Park 1st | 15    | 1.67   |    |
-| 27 | Uzondu Okoro      | Braeswood           | Braeswood         | 15    | 1.67   |    |
-| 28 | Daniel Raines     | Humble 1st          | Humble 1st        | 5     | .56    |    |
+|    # | Quizzer           | Team                | Church            | Total |    Avg |   QO |
+| ---: | ----------------- | ------------------- | ----------------- | ----: | -----: | ---: |
+|    1 | Daniel Wagner     | Owasso 1st          | Owasso 1st        |   915 | 130.71 |    6 |
+|    2 | Micah Samuelson   | Highpointe          | Highpointe        |   790 | 112.86 |    6 |
+|    3 | David Meddaugh    | Muskogee A          | Muskogee 1st      |   730 | 104.29 |    6 |
+|    4 | Andrew Forsman    | CT Church           | CT Church         |   680 |  97.14 |    4 |
+|    5 | Luke Wagner       | Owasso 1st          | Owasso 1st        |   570 |  81.43 |    6 |
+|    6 | Bryson Cobb       | By Faith            | Abundant Life     |   380 |  54.29 |    4 |
+|    7 | Zach Brookbank    | Overland Park 1st   | Overland Park 1st |   365 |  52.14 |    3 |
+|    8 | David Kpando      | Braeswood           | Braeswood         |   360 |  51.43 |    2 |
+|    9 | Tim Pyle          | CT Church           | CT Church         |   355 |  50.71 |    3 |
+|   10 | Bridgett Donnells | Understand Slowness | Harvest Assembly  |   355 |  50.71 |    2 |
+|   11 | Aaron Jackson     | Owasso 1st          | Owasso 1st        |   325 |  46.43 |    3 |
+|   12 | Jed Brookbank     | Overland Park 1st   | Overland Park 1st |   315 |     45 |    3 |
+|   13 | Kenny Ukoh        | Braeswood           | Braeswood         |   285 |  40.71 |    2 |
+|   14 | Conner McGraw     | Highpointe          | Highpointe        |   255 |  36.43 |    1 |
+|   15 | Paul Meddaugh     | Muskogee A          | Muskogee 1st      |   240 |  34.29 |    2 |
+|   16 | Deborah Okoro     | Braeswood           | Braeswood         |   190 |  27.14 |    2 |
+|   17 | Renee Raines      | Humble 1st          | Humble 1st        |   165 |  23.57 |    1 |
+|   18 | Matthew Samuelson | Highpointe          | Highpointe        |   150 |  21.43 |    1 |
+|   19 | Michaela Tindle   | Fredonia 1st        | Fredonia 1st      |    80 |  11.43 |      |
+|   19 | Wayne Elkins      | Understand Slowness | Harvest Assembly  |    80 |  11.43 |      |
+|   20 | Trey Bentley      | Understand Slowness | Harvest Assembly  |    60 |   8.57 |      |
+|   21 | Shayla Puckett    | Fredonia 1st        | Fredonia 1st      |    55 |   7.86 |      |
+|   22 | David Brauchler   | By Faith            | Abundant Life     |    50 |   7.14 |      |
+|   23 | Andrew Roach      | CT Church           | CT Church         |    40 |   5.71 |      |
+|   24 | Annie Bentley     | Understand Slowness | Harvest Assembly  |    30 |   4.29 |      |
+|   25 | Mary Meddaugh     | Muskogee A          | Muskogee 1st      |    20 |   2.86 |      |
+|   26 | Uzondu Okoro      | Braeswood           | Braeswood         |    15 |   2.14 |      |
+|   26 | Tirzah Brookbank  | Overland Park 1st   | Overland Park 1st |    15 |   2.14 |      |
 
 ## MSQ League
 
@@ -73,28 +72,28 @@ menubar_toc_static:
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
-| # | Team              | Church              | W/L | Total | Avg    |
-|--:|-------------------|---------------------|-----|------:|-------:|
-| 1 | Czech Tech        | Muskogee 1st        | 4/2 | 745   | 124.17 |
-| 2 | Unfading Beauty   | Noble Assembly      | 4/2 | 795   | 132.50 |
-| 3 | Braeswood MSQ     | Braeswood           | 2/4 | 610   | 101.67 |
-| 4 | No Ordinary Child | The Oaks Fellowship | 2/4 | 590   | 98.33  |
+|    # | Team              | Church              | W/L   | Total |  Avg |
+| ---: | ----------------- | ------------------- | ----- | ----: | ---: |
+|    1 | Unfading Beauty   | Noble Assembly      | 4 / 1 |   770 |  154 |
+|    2 | Czech Tech        | Muskogee 1st        | 3 / 2 |   570 |  114 |
+|    3 | No Ordinary Child | The Oaks Fellowship | 2 / 3 |   560 |  112 |
+|    4 | Braeswood MSQ     | Braeswood           | 1 / 4 |   450 |   90 |
 
 ### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
-| #  | Quizzer        | Team              | Church              | Total | Avg   | QO |
-|---:|----------------|-------------------|---------------------|------:|------:|---:|
-| 1  | Oom Strickland | Unfading Beauty   | Noble Assembly      | 560   | 93.33 | 3  |
-| 2  | Josiah Schwarz | Czech Tech        | Muskogee 1st        | 530   | 88.33 | 4  |
-| 3  | Jeremy Mgbeike | Braeswood MSQ     | Braeswood           | 515   | 85.83 | 5  |
-| 4  | Cameron Berta  | No Ordinary Child | The Oaks Fellowship | 355   | 59.17 | 3  |
-| 5  | Zach Schwarz   | Czech Tech        | Muskogee 1st        | 225   | 37.50 | 1  |
-| 6  | David Saunders | No Ordinary Child | The Oaks Fellowship | 210   | 35.00 |    |
-| 7  | Grace Smith    | Unfading Beauty   | Noble Assembly      | 205   | 34.17 | 1  |
-| 8  | Jose Lopez     | Braeswood MSQ     | Braeswood           | 65    | 10.83 |    |
-| 9  | Taylor Baker   | Unfading Beauty   | Noble Assembly      | 30    | 5.00  |    |
-| 9  | Osinachi Nwogu | Braeswood MSQ     | Braeswood           | 30    | 5.00  |    |
-| 10 | Solomon Stitt  | No Ordinary Child | The Oaks Fellowship | 25    | 4.17  |    |
-| 11 | Parker Harris  | Czech Tech        | Muskogee 1st        | 10    | 1.67  |    |
+|    # | Quizzer          | Team                | Church                |   Total |   Avg |   QO |
+| ---: | ---------------- | ------------------- | --------------------- | ------: | ----: | ---: |
+|    1 | Oom Strickland   | Unfading Beauty     | Noble Assembly        |     540 |   108 |    3 |
+|    2 | Josiah Schwarz   | Czech Tech          | Muskogee 1st          |     405 |    81 |    3 |
+|    3 | Jeremy Mgbeike   | Braeswood MSQ       | Braeswood             |     395 |    79 |    4 |
+|    4 | Cameron Berta    | No Ordinary Child   | The Oaks Fellowship   |     370 |    74 |    3 |
+|    5 | Grace Smith      | Unfading Beauty     | Noble Assembly        |     200 |    40 |    1 |
+|    6 | Zach Schwarz     | Czech Tech          | Muskogee 1st          |     175 |    35 |    1 |
+|    7 | David Saunders   | No Ordinary Child   | The Oaks Fellowship   |     150 |    30 |      |
+|    8 | Jose Lopez       | Braeswood MSQ       | Braeswood             |      45 |     9 |      |
+|    9 | Solomon Stitt    | No Ordinary Child   | The Oaks Fellowship   |      40 |     8 |      |
+|   10 | Taylor Baker     | Unfading Beauty     | Noble Assembly        |      30 |     6 |      |
+|   11 | Osinachi Nwogu   | Braeswood MSQ       | Braeswood             |      10 |     2 |      |
+|   11 | Parker Harris    | Czech Tech          | Muskogee 1st          |      10 |     2 |      |

--- a/_pages/history/2012/regionals/southeast.md
+++ b/_pages/history/2012/regionals/southeast.md
@@ -18,56 +18,56 @@ menubar_toc_static:
 
 *Final team rank was determined by playoffs..*
 
-| #  | Team                   | Church                   | W/L | Total | Avg    |
-|---:|------------------------|--------------------------|-----|------:|-------:|
-| 1  | Wesley Chapel, FL - A1 | Victorious Life Church   | 9/0 | 2285  | 253.89 |
-| 2  | Toccoa, GA             | Toccoa Assembly of God   | 8/1 | 1465  | 162.78 |
-| 3  | Montgomery, AL         | First Assembly           | 7/2 | 1615  | 179.44 |
-| 4  | Fort Lauderdale, FL    | Christian Life Center    | 6/3 | 835   | 92.78  |
-| 5  | Snellville, GA         | Evangel Community Church | 4/5 | 535   | 59.44  |
-| 6  | Raleigh, NC            | First Assembly           | 4/5 | 630   | 70.00  |
-| 7  | Griffin, GA            | First Assembly           | 4/5 | 775   | 86.11  |
-| 8  | Warner Robins, GA      | First Assembly of God    | 2/7 | 290   | 32.22  |
-| 9  | Wesley Chapel, FL - A2 | Victorious Life Church   | 1/8 | 95    | 10.56  |
-| 10 | North Fort Myers, FL   | Faith Assembly           | 0/9 | 195   | 21.67  |
+|    # | Team                   | Church                   | W/L | Total |    Avg |
+| ---: | ---------------------- | ------------------------ | --- | ----: | -----: |
+|    1 | Wesley Chapel, FL - A1 | Victorious Life Church   | 9/0 |  2285 | 253.89 |
+|    2 | Toccoa, GA             | Toccoa Assembly of God   | 8/1 |  1465 | 162.78 |
+|    3 | Montgomery, AL         | First Assembly           | 7/2 |  1615 | 179.44 |
+|    4 | Fort Lauderdale, FL    | Christian Life Center    | 6/3 |   835 |  92.78 |
+|    5 | Snellville, GA         | Evangel Community Church | 4/5 |   535 |  59.44 |
+|    6 | Raleigh, NC            | First Assembly           | 4/5 |   630 |  70.00 |
+|    7 | Griffin, GA            | First Assembly           | 4/5 |   775 |  86.11 |
+|    8 | Warner Robins, GA      | First Assembly of God    | 2/7 |   290 |  32.22 |
+|    9 | Wesley Chapel, FL - A2 | Victorious Life Church   | 1/8 |    95 |  10.56 |
+|   10 | North Fort Myers, FL   | Faith Assembly           | 0/9 |   195 |  21.67 |
 
 ### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
-| #  | Quizzer            | Team                   | Church                   | Total | Avg    | QO |
-|---:|--------------------|------------------------|--------------------------|------:|-------:|---:|
-| 1  | Abby Rogers        | Wesley Chapel, FL - A1 | Victorious Life Church   | 1350  | 150.00 | 9  |
-| 2  | Hudson Kelley      | Montgomery, AL         | First Assembly           | 1085  | 120.56 | 8  |
-| 3  | Lindsay Cowan      | Toccoa, GA             | Toccoa Assembly of God   | 850   | 94.44  | 6  |
-| 4  | Erinn Wolf         | Wesley Chapel, FL - A1 | Victorious Life Church   | 630   | 70.00  | 5  |
-| 5  | Silas Mims         | Montgomery, AL         | First Assembly           | 485   | 53.89  | 6  |
-| 6  | Allison Johnson    | Toccoa, GA             | Toccoa Assembly of God   | 485   | 53.89  | 5  |
-| 7  | Bryce Landers      | Griffin, GA            | First Assembly           | 425   | 47.22  | 4  |
-| 8  | Ben Coleman        | Raleigh, NC            | First Assembly           | 420   | 46.67  | 3  |
-| 9  | Charlie McDermitt  | Griffin, GA            | First Assembly           | 330   | 36.67  | 2  |
-| 10 | Tobi Morakinyo     | Fort Lauderdale, FL    | Christian Life Center    | 305   | 33.89  | 1  |
-| 11 | Emily Herron       | Warner Robins, GA      | First Assembly of God    | 280   | 31.11  | 1  |
-| 12 | Reesie Owens       | Wesley Chapel, FL - A1 | Victorious Life Church   | 270   | 30.00  | 2  |
-| 13 | Oore Morakinyo     | Fort Lauderdale, FL    | Christian Life Center    | 265   | 29.44  | 1  |
-| 14 | Ceiran Beasley     | Snellville, GA         | Evangel Community Church | 260   | 28.89  | 2  |
-| 15 | Summer McDaniel    | North Fort Myers, FL   | Faith Assembly           | 235   | 26.11  |    |
-| 16 | David Barnes       | Raleigh, NC            | First Assembly           | 225   | 25.00  | 2  |
-| 17 | Daniel Notman      | Fort Lauderdale, FL    | Christian Life Center    | 165   | 18.33  | 1  |
-| 18 | Andy Okala         | Snellville, GA         | Evangel Community Church | 165   | 18.33  |    |
-| 19 | Lacey Cowan        | Toccoa, GA             | Toccoa Assembly of God   | 130   | 14.44  | 1  |
-| 20 | David Notman       | Fort Lauderdale, FL    | Christian Life Center    | 85    | 9.44   |    |
-| 21 | Rowojo Okala       | Snellville, GA         | Evangel Community Church | 80    | 8.89   |    |
-| 22 | Elizabeth Olatunji | Wesley Chapel, FL - A2 | Victorious Life Church   | 50    | 5.56   |    |
-| 23 | Judy Oranika       | Montgomery, AL         | First Assembly           | 45    | 5.00   |    |
-| 24 | Mo Adewunmi        | Wesley Chapel, FL - A2 | Victorious Life Church   | 40    | 4.44   | 1  |
-| 25 | Shannon Wolf       | Wesley Chapel, FL - A1 | Victorious Life Church   | 35    | 3.89   |    |
-| 26 | Sarah Swales       | Snellville, GA         | Evangel Community Church | 30    | 3.33   |    |
-| 27 | Lola Babatola      | Warner Robins, GA      | First Assembly of God    | 30    | 3.33   |    |
-| 28 | Marcus Johnson     | Griffin, GA            | First Assembly           | 20    | 2.22   |    |
-| 29 | Ope Morakinyo      | Fort Lauderdale, FL    | Christian Life Center    | 20    | 2.22   |    |
-| 30 | Emmie Chambers     | Montgomery, AL         | First Assembly           | 5     | .56    |    |
-| 31 | Daniel Olatunji    | Wesley Chapel, FL - A2 | Victorious Life Church   | 5     | .56    |    |
+|    # | Quizzer            | Team                   | Church                   | Total |    Avg |   QO |
+| ---: | ------------------ | ---------------------- | ------------------------ | ----: | -----: | ---: |
+|    1 | Abby Rogers        | Wesley Chapel, FL - A1 | Victorious Life Church   |  1350 | 150.00 |    9 |
+|    2 | Hudson Kelley      | Montgomery, AL         | First Assembly           |  1085 | 120.56 |    8 |
+|    3 | Lindsay Cowan      | Toccoa, GA             | Toccoa Assembly of God   |   850 |  94.44 |    6 |
+|    4 | Erinn Wolf         | Wesley Chapel, FL - A1 | Victorious Life Church   |   630 |  70.00 |    5 |
+|    5 | Silas Mims         | Montgomery, AL         | First Assembly           |   485 |  53.89 |    6 |
+|    6 | Allison Johnson    | Toccoa, GA             | Toccoa Assembly of God   |   485 |  53.89 |    5 |
+|    7 | Bryce Landers      | Griffin, GA            | First Assembly           |   425 |  47.22 |    4 |
+|    8 | Ben Coleman        | Raleigh, NC            | First Assembly           |   420 |  46.67 |    3 |
+|    9 | Charlie McDermitt  | Griffin, GA            | First Assembly           |   330 |  36.67 |    2 |
+|   10 | Tobi Morakinyo     | Fort Lauderdale, FL    | Christian Life Center    |   305 |  33.89 |    1 |
+|   11 | Emily Herron       | Warner Robins, GA      | First Assembly of God    |   280 |  31.11 |    1 |
+|   12 | Reesie Owens       | Wesley Chapel, FL - A1 | Victorious Life Church   |   270 |  30.00 |    2 |
+|   13 | Oore Morakinyo     | Fort Lauderdale, FL    | Christian Life Center    |   265 |  29.44 |    1 |
+|   14 | Ceiran Beasley     | Snellville, GA         | Evangel Community Church |   260 |  28.89 |    2 |
+|   15 | Summer McDaniel    | North Fort Myers, FL   | Faith Assembly           |   235 |  26.11 |      |
+|   16 | David Barnes       | Raleigh, NC            | First Assembly           |   225 |  25.00 |    2 |
+|   17 | Daniel Notman      | Fort Lauderdale, FL    | Christian Life Center    |   165 |  18.33 |    1 |
+|   18 | Andy Okala         | Snellville, GA         | Evangel Community Church |   165 |  18.33 |      |
+|   19 | Lacey Cowan        | Toccoa, GA             | Toccoa Assembly of God   |   130 |  14.44 |    1 |
+|   20 | David Notman       | Fort Lauderdale, FL    | Christian Life Center    |    85 |   9.44 |      |
+|   21 | Rowojo Okala       | Snellville, GA         | Evangel Community Church |    80 |   8.89 |      |
+|   22 | Elizabeth Olatunji | Wesley Chapel, FL - A2 | Victorious Life Church   |    50 |   5.56 |      |
+|   23 | Judy Oranika       | Montgomery, AL         | First Assembly           |    45 |   5.00 |      |
+|   24 | Mo Adewunmi        | Wesley Chapel, FL - A2 | Victorious Life Church   |    40 |   4.44 |    1 |
+|   25 | Shannon Wolf       | Wesley Chapel, FL - A1 | Victorious Life Church   |    35 |   3.89 |      |
+|   26 | Sarah Swales       | Snellville, GA         | Evangel Community Church |    30 |   3.33 |      |
+|   27 | Lola Babatola      | Warner Robins, GA      | First Assembly of God    |    30 |   3.33 |      |
+|   28 | Marcus Johnson     | Griffin, GA            | First Assembly           |    20 |   2.22 |      |
+|   29 | Ope Morakinyo      | Fort Lauderdale, FL    | Christian Life Center    |    20 |   2.22 |      |
+|   30 | Emmie Chambers     | Montgomery, AL         | First Assembly           |     5 |    .56 |      |
+|   31 | Daniel Olatunji    | Wesley Chapel, FL - A2 | Victorious Life Church   |     5 |    .56 |      |
 
 ## MSQ League
 
@@ -75,38 +75,38 @@ menubar_toc_static:
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
-| # | Team                 | Church                   | W/L | Total | Avg    |
-|--:|----------------------|--------------------------|-----|------:|-------:|
-| 1 | Griffin, GA          | First Assembly           | 7/1 | 1190  | 148.75 |
-| 2 | Snellville, GA       | Evangel Community Church | 6/2 | 945   | 118.13 |
-| 3 | Orlando, FL          | Faith Assembly           | 4/4 | 565   | 70.63  |
-| 4 | Wesley Chapel, FL    | Victorious Life Church   | 3/5 | 500   | 62.50  |
-| 5 | North Fort Myers, FL | Faith Assembly           | 0/8 | 130   | 16.25  |
+|    # | Team                 | Church                   | W/L | Total |    Avg |
+| ---: | -------------------- | ------------------------ | --- | ----: | -----: |
+|    1 | Griffin, GA          | First Assembly           | 7/1 |  1190 | 148.75 |
+|    2 | Snellville, GA       | Evangel Community Church | 6/2 |   945 | 118.13 |
+|    3 | Orlando, FL          | Faith Assembly           | 4/4 |   565 |  70.63 |
+|    4 | Wesley Chapel, FL    | Victorious Life Church   | 3/5 |   500 |  62.50 |
+|    5 | North Fort Myers, FL | Faith Assembly           | 0/8 |   130 |  16.25 |
 
 ### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
-| #  | Quizzer           | Team                 | Church                   | Total | Avg    | QO |
-|---:|-------------------|----------------------|--------------------------|------:|-------:|---:|
-| 1  | Veronica Johnson  | Griffin, GA          | First Assembly           | 845   | 105.63 | 6  |
-| 2  | Casey Bailey      | Snellville, GA       | Evangel Community Church | 625   | 78.13  | 5  |
-| 3  | Dakarai Cherefant | Orlando, FL          | Faith Assembly           | 305   | 38.13  | 3  |
-| 4  | Brielle Smith     | Snellville, GA       | Evangel Community Church | 280   | 35.00  | 1  |
-| 5  | Cassidy Powell    | Griffin, GA          | First Assembly           | 265   | 33.13  |    |
-| 6  | Olupero Adewumni  | Wesley Chapel, FL    | Victorious Life Church   | 230   | 28.75  | 1  |
-| 7  | Emily Freer       | Orlando, FL          | Faith Assembly           | 160   | 20.00  |    |
-| 8  | Daniel Adewunmi   | Wesley Chapel, FL    | Victorious Life Church   | 155   | 19.38  |    |
-| 9  | Kelso Morant      | Wesley Chapel, FL    | Victorious Life Church   | 120   | 15.00  |    |
-| 10 | Chan Creswell     | Griffin, GA          | First Assembly           | 80    | 10.00  |    |
-| 11 | Josh Arnold       | North Fort Myers, FL | Faith Assembly           | 70    | 8.75   |    |
-| 11 | Joel Keva         | Orlando, FL          | Faith Assembly           | 70    | 8.75   |    |
-| 12 | Christiana Fimbel | North Fort Myers, FL | Faith Assembly           | 40    | 5.00   |    |
-| 12 | Amy Bailey        | Snellville, GA       | Evangel Community Church | 40    | 5.00   |    |
-| 13 | Asiah King        | Orlando, FL          | Faith Assembly           | 25    | 3.13   |    |
-| 14 | Natalie Flecha    | North Fort Myers, FL | Faith Assembly           | 20    | 2.50   |    |
-| 15 | Brandon Halloway  | Orlando, FL          | Faith Assembly           | 5     | .63    |    |
-| 16 | Miciah Taylor     | Snellville, GA       | Evangel Community Church |       | .00    |    |
-| 16 | Keanna Clark      | Snellville, GA       | Evangel Community Church |       | .00    |    |
-| 16 | Joseph Steward    | Orlando, FL          | Faith Assembly           |       | .00    |    |
-| 17 | Shea Ireland      | Wesley Chapel, FL    | Victorious Life Church   | -5    | -0.63  |    |
+|    # | Quizzer           | Team                 | Church                   | Total |    Avg |   QO |
+| ---: | ----------------- | -------------------- | ------------------------ | ----: | -----: | ---: |
+|    1 | Veronica Johnson  | Griffin, GA          | First Assembly           |   845 | 105.63 |    6 |
+|    2 | Casey Bailey      | Snellville, GA       | Evangel Community Church |   625 |  78.13 |    5 |
+|    3 | Dakarai Cherefant | Orlando, FL          | Faith Assembly           |   305 |  38.13 |    3 |
+|    4 | Brielle Smith     | Snellville, GA       | Evangel Community Church |   280 |  35.00 |    1 |
+|    5 | Cassidy Powell    | Griffin, GA          | First Assembly           |   265 |  33.13 |      |
+|    6 | Olupero Adewumni  | Wesley Chapel, FL    | Victorious Life Church   |   230 |  28.75 |    1 |
+|    7 | Emily Freer       | Orlando, FL          | Faith Assembly           |   160 |  20.00 |      |
+|    8 | Daniel Adewunmi   | Wesley Chapel, FL    | Victorious Life Church   |   155 |  19.38 |      |
+|    9 | Kelso Morant      | Wesley Chapel, FL    | Victorious Life Church   |   120 |  15.00 |      |
+|   10 | Chan Creswell     | Griffin, GA          | First Assembly           |    80 |  10.00 |      |
+|   11 | Josh Arnold       | North Fort Myers, FL | Faith Assembly           |    70 |   8.75 |      |
+|   11 | Joel Keva         | Orlando, FL          | Faith Assembly           |    70 |   8.75 |      |
+|   12 | Christiana Fimbel | North Fort Myers, FL | Faith Assembly           |    40 |   5.00 |      |
+|   12 | Amy Bailey        | Snellville, GA       | Evangel Community Church |    40 |   5.00 |      |
+|   13 | Asiah King        | Orlando, FL          | Faith Assembly           |    25 |   3.13 |      |
+|   14 | Natalie Flecha    | North Fort Myers, FL | Faith Assembly           |    20 |   2.50 |      |
+|   15 | Brandon Halloway  | Orlando, FL          | Faith Assembly           |     5 |    .63 |      |
+|   16 | Miciah Taylor     | Snellville, GA       | Evangel Community Church |       |    .00 |      |
+|   16 | Keanna Clark      | Snellville, GA       | Evangel Community Church |       |    .00 |      |
+|   16 | Joseph Steward    | Orlando, FL          | Faith Assembly           |       |    .00 |      |
+|   17 | Shea Ireland      | Wesley Chapel, FL    | Victorious Life Church   |    -5 |  -0.63 |      |

--- a/_pages/history/2012/regionals/southwest.md
+++ b/_pages/history/2012/regionals/southwest.md
@@ -1,0 +1,32 @@
+---
+layout: page
+title: "2012 Southwest Regionals"
+permalink: /history/2012/regionals/southwest/
+date: "2012-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2012 Season
+    link: /history/2012/
+    icon: fas fa-home
+---
+
+## Teams
+
+|    # | Team                                      | W / L  |
+| ---: | ----------------------------------------- | ------ |
+|    1 | Costa Mesa, CA                            | 12 / 2 |
+|    2 | Living Hope, Colorado Springs, CO         | 12 / 2 |
+|    3 | Irvine, CA                                | 8 / 6  |
+|    4 | Phoenix, AZ                               | 8 / 6  |
+|    5 | Scottsdale, AZ                            | 6 / 8  |
+|    6 | Church at Briargate, Colorado Springs, CO | 4 / 10 |
+
+## Individuals
+
+1. Zach Mang, Costa Mesa, CA
+2. Tiffany Wu, Irvine, CA
+3. Chad Stogner, Phoenix, AZ
+4. Meg Pace, Living Hope, Colorado Springs, CO
+5. Stephen Moses, Scottsdale, AZ

--- a/_pages/history/2013/regionals/great-lakes.md
+++ b/_pages/history/2013/regionals/great-lakes.md
@@ -1,0 +1,131 @@
+---
+layout: page
+title: "2013 Great Lakes Regionals"
+permalink: /history/2013/regionals/great-lakes/
+date: "2013-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2013 Season
+    link: /history/2013/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+|    # | Team                                    |   Avg | Total |    W |    L |
+| ---: | --------------------------------------- | ----: | ----: | ---: | ---: |
+|    1 | New Life Assembly - White Cloud         |   262 |  3930 |   15 |    0 |
+|    2 | Southgate Church - South Bend           |   180 |  2700 |   14 |    1 |
+|    3 | Dayspring Church - Bowling Green        |   162 |  2430 |   13 |    2 |
+|    4 | Lakeview - Indianapolis                 | 121.7 |  1825 |   11 |    4 |
+|    5 | First Assembly - East Lansing           |  95.3 |  1430 |   10 |    5 |
+|    6 | First Assembly - Lexington #1           |  83.7 |  1255 |    9 |    6 |
+|    7 | Painesville Assembly - Painesville      |  37.3 |   560 |    8 |    7 |
+|    8 | Radiant Life Church - Dublin            |    95 |  1425 |    7 |    8 |
+|    9 | Christian Celebration Center - Midland  |    78 |  1170 |    6 |    9 |
+|   10 | Brightmoor Christian Church - Novi      |    58 |   870 |    6 |    9 |
+|   11 | Stone Church - Orland Park              |  64.3 |   965 |    5 |   10 |
+|   12 | New Song - Plymouth                     |  52.7 |   790 |    5 |   10 |
+|   13 | Trinity Assembly - Georgetown           |  65.7 |   985 |    4 |   11 |
+|   14 | Covenant Life Fellowship - Hubbard      |  42.7 |   640 |    4 |   11 |
+|   15 | Southwest Community Church - Plainfield |  17.3 |   260 |    2 |   13 |
+|   16 | First Assembly - Lexington #2           |    24 |   360 |    1 |   14 |
+
+### Individuals
+
+|    # | Quizzer            | Church                                  |   Avg | Total | QO Fwd | QO Bk |
+| ---: | ------------------ | --------------------------------------- | ----: | ----: | -----: | ----: |
+|    1 | Samuel Pryer       | New Life Assembly - White Cloud         |   128 |  1920 |     14 |     1 |
+|    2 | James Carey        | Lakeview - Indianapolis                 |   110 |  1650 |     14 |     1 |
+|    3 | Aaron Smith        | Dayspring Church - Bowling Green        | 108.7 |  1630 |     13 |     0 |
+|    4 | Claire Convis      | First Assembly - East Lansing           |  77.7 |  1165 |     10 |     4 |
+|    5 | Keilah Rogers      | Radiant Life Church - Dublin            |    72 |  1080 |      7 |     2 |
+|    6 | Faith Pryer        | New Life Assembly - White Cloud         |  70.7 |  1060 |      9 |     1 |
+|    7 | Ethan Grabill      | Christian Celebration Center - Midland  |    69 |  1035 |      7 |     2 |
+|    8 | Kenadee Schrock    | Southgate Church - South Bend           |    61 |   915 |      8 |     3 |
+|    9 | Makena Schrock     | Southgate Church - South Bend           |    61 |   915 |      7 |     0 |
+|   10 | David Pryer        | New Life Assembly - White Cloud         |    60 |   900 |     13 |     0 |
+|   11 | Kyla Schrock       | Southgate Church - South Bend           |    59 |   885 |      9 |     0 |
+|   12 | Brianna Albrecht   | Dayspring Church - Bowling Green        |  52.3 |   785 |      9 |     0 |
+|   13 | Caleb Czaja        | Stone Church - Orland Park              |    52 |   780 |      1 |     0 |
+|   14 | Brayden Laakkonen  | First Assembly - Lexington #1           |  51.7 |   775 |      4 |     1 |
+|   15 | Josh Schieber      | New Song - Plymouth                     |  47.7 |   715 |      6 |     3 |
+|   16 | Will Turner        | Trinity Assembly - Georgetown           |    42 |   630 |      2 |     0 |
+|   17 | Deanna Davenport   | Brightmoor Christian Church - Novi      |  37.7 |   565 |      3 |     0 |
+|   18 | Sam Dickson        | Covenant Life Fellowship - Hubbard      |    30 |   450 |      4 |     2 |
+|   19 | Emily Brown        | Painesville Assembly - Painesville      |  24.7 |   370 |      0 |     0 |
+|   20 | Courtney Turner    | Trinity Assembly - Georgetown           |  23.7 |   355 |      0 |     0 |
+|   21 | Matthew Walker     | First Assembly - Lexington #2           |  20.7 |   310 |      1 |     0 |
+|   22 | Geddy Walker       | First Assembly - Lexington #1           |    17 |   255 |      0 |     1 |
+|   23 | Kyle Benson        | Southwest Community Church - Plainfield |    15 |   225 |      1 |     2 |
+|   24 | Christen Smith     | First Assembly - Lexington #1           |    15 |   225 |      0 |     0 |
+|   25 | Aaron Tharsius     | Radiant Life Church - Dublin            |    14 |   210 |      0 |     0 |
+|   26 | Caleb Rogenthien   | Painesville Assembly - Painesville      |  12.7 |   190 |      0 |     0 |
+|   27 | Lauren Chapman     | Brightmoor Christian Church - Novi      |  12.7 |   190 |      0 |     2 |
+|   28 | Mike Klein         | First Assembly - East Lansing           |  12.3 |   185 |      1 |     0 |
+|   29 | Tabitha DiBacco    | Covenant Life Fellowship - Hubbard      |    12 |   180 |      0 |     0 |
+|   30 | Sunny Kim          | Christian Celebration Center - Midland  |     9 |   135 |      0 |     0 |
+|   31 | Cody Stuart        | Stone Church - Orland Park              |   8.3 |   125 |      0 |     0 |
+|   32 | Tim Lester         | Brightmoor Christian Church - Novi      |   8.3 |   125 |      0 |     0 |
+|   33 | Eric Bradford      | Radiant Life Church - Dublin            |   6.3 |    95 |      0 |     0 |
+|   34 | Beth Schieber      | New Song - Plymouth                     |   5.3 |    80 |      0 |     0 |
+|   35 | Katie Dowers       | Lakeview - Indianapolis                 |   5.3 |    80 |      0 |     0 |
+|   36 | Kiley Dowers       | Lakeview - Indianapolis                 |   4.7 |    70 |      0 |     0 |
+|   37 | Faithful Oladeji   | Stone Church - Orland Park              |   4.3 |    65 |      0 |     0 |
+|   38 | Drew Harr          | First Assembly - East Lansing           |   4.3 |    65 |      0 |     0 |
+|   39 | Alex McCracken     | First Assembly - Lexington #2           |   3.7 |    55 |      0 |     0 |
+|   40 | Tyler Benson       | Southwest Community Church - Plainfield |   2.3 |    35 |      0 |     0 |
+|   41 | Phillip Ochieng    | Radiant Life Church - Dublin            |   2.3 |    35 |      0 |     0 |
+|   42 | Brooke Garcia      | Lakeview - Indianapolis                 |   2.3 |    35 |      0 |     1 |
+|   43 | Ashlynn Schrock    | Southgate Church - South Bend           |   0.7 |    10 |      0 |     0 |
+|   44 | Danny Kim          | Christian Celebration Center - Midland  |   0.7 |    10 |      0 |     0 |
+|   45 | Caleb Wolfe        | Christian Celebration Center - Midland  |   0.7 |    10 |      0 |     0 |
+|   46 | Emma First-Kanning | Covenant Life Fellowship - Hubbard      |   0.7 |    10 |      0 |     0 |
+|   47 | Austin Harr        | First Assembly - East Lansing           |   0.3 |     5 |      0 |     0 |
+
+## Middle School League
+
+### Teams
+
+|    # | Team                                   |   Avg | Total |    W |    L |
+| ---: | -------------------------------------- | ----: | ----: | ---: | ---: |
+|    1 | First Assembly - Lexington             | 244.6 |  3425 |   13 |    1 |
+|    2 | Trinity Assembly - Georgetown          | 191.4 |  2680 |   12 |    2 |
+|    3 | Columbiaville Assembly - Columbiaville | 190.4 |  2665 |   11 |    3 |
+|    4 | First Assembly - East Lansing          | 129.3 |  1810 |    7 |    7 |
+|    5 | Stone Church - Orland Park             | 102.1 |  1430 |    7 |    7 |
+|    6 | Southwest Assembly - Fort Wayne        |    65 |   910 |    3 |   11 |
+|    7 | Grass Lake Assembly - Grass Lake       |  37.9 |   530 |    3 |   11 |
+|    8 | Covenant Life Fellowship - Hubbard     |  13.6 |   190 |    0 |   14 |
+
+### Individuals
+
+|    # | Quizzer          |   Avg | Total | QO Fwd | QO Bk |
+| ---: | ---------------- | ----: | ----: | -----: | ----: |
+|    1 | Chris Turner     | 134.6 |  1885 |     13 |     1 |
+|    2 | Seth Smith       | 112.9 |  1580 |     11 |     3 |
+|    3 | Celah Convis     |  98.6 |  1380 |     10 |     0 |
+|    4 | Joey Huntley     |  93.9 |  1315 |     10 |     2 |
+|    5 | Josiah Smith     |  70.4 |   985 |      9 |     0 |
+|    6 | Alex Peters      |  61.8 |   865 |      6 |     1 |
+|    7 | Elijah Pettit    |  56.8 |   795 |      6 |     1 |
+|    8 | Tom McGarry      |  48.2 |   675 |      5 |     4 |
+|    9 | Mikaela Disinger |  46.8 |   655 |      6 |     3 |
+|   10 | Sopulu Anidobu   |  37.9 |   530 |      3 |     3 |
+|   11 | Mike Galliers    |  36.8 |   515 |      4 |     0 |
+|   12 | Hudson Hollin    |  35.4 |   495 |      3 |     2 |
+|   13 | Nahom Ghebredngl |  30.7 |   430 |      2 |     5 |
+|   14 | Tyler McCracken  |    25 |   350 |      2 |     0 |
+|   15 | Samantha Roth    |  19.6 |   275 |      2 |     0 |
+|   16 | Naomi Czaja      |  18.9 |   265 |      1 |     0 |
+|   17 | Matthew Lester   |  16.8 |   235 |      1 |     4 |
+|   18 | Makenzie Hall    |  11.1 |   155 |      0 |     0 |
+|   19 | Aiden Disinger   |   9.3 |   130 |      0 |     1 |
+|   20 | Will Imus        |   8.9 |   125 |      0 |     0 |
+|   21 | Kaleb Hong       |   3.6 |    50 |      0 |     0 |
+|   22 | Grace Estep      |   2.5 |    35 |      0 |     0 |
+|   23 | Montana Sager    |   2.1 |    30 |      0 |     0 |

--- a/_pages/history/2013/regionals/gulf.md
+++ b/_pages/history/2013/regionals/gulf.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: "2013 Gulf Regionals"
+permalink: /history/2013/regionals/gulf/
+date: "2013-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2013 Season
+    link: /history/2013/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+| Church                       | City            | W / L  |
+| ---------------------------- | --------------- | ------ |
+| James River A/G              | Ozark, MO       | 5 / 1* |
+| Central A/G                  | Springfield, MO | 5 / 1* |
+| Evangel Church               | Kansas City, MO | 2 / 4  |
+| Sheffield Family Life Center | Kansas City, MO | 0 / 6  |
+
+\* Tie broken by playoff
+
+### Individuals
+
+|    # | Quizzer          | Team        |
+| ---: | ---------------- | ----------- |
+|    1 | Devon Colegrove  | James River |
+|    2 | Hannah Quick     | Central     |
+|    3 | Daniel Quick     | Central     |
+|    4 | Kacie Garrison   | James River |
+|    5 | Zach Brookbank   | Evangel     |
+|    6 | Natalie Garrison | James River |
+|    7 | Jed Brookbank    | Evangel     |
+|    8 | Brock Peters     | Central     |
+
+## Middle School Division
+
+### Teams
+
+| Team              | Church          | City            | W / L  |
+| ----------------- | --------------- | --------------- | ------ |
+| Shrewd and Snakes | James River A/G | Ozark, MO       | 3 / 1* |
+| Wolf Among Sheep  | James River A/G | Ozark, MO       | 3 / 1* |
+| Full of Darkness  | Central A/G     | Springfield, MO | 3 / 1* |
+| Unquenchable Fire | James River A/G | Ozark, MO       | 1 / 3  |
+|                   | McArthur A/G    | McArthur, AR    | 0 / 4  |
+
+\* Tie broken by playoff
+
+### Individuals
+
+|    # | Quizzer          | Team              |
+| ---: | ---------------- | ----------------- |
+|    1 | Leisl Jansen     | Wolf Among Sheep  |
+|    1 | Jillian Griffith | Shrewd as Snakes  |
+|    3 | Kara Peters      | Full of Darkness  |
+|    4 | Zara Rethman     | Unquenchable Fire |
+|    5 | Travis Griessel  | Wolf Among Sheep  |
+|    6 | Janon Klassen    | Shrewd as Snakes  |
+|    7 | Lucas Clark      | Full of Darkness  |
+|    8 | Christina Burks  | Shrewd            |

--- a/_pages/history/2013/regionals/north-central.md
+++ b/_pages/history/2013/regionals/north-central.md
@@ -1,0 +1,193 @@
+---
+layout: page
+title: "2013 North Central Regionals"
+permalink: /history/2013/regionals/north-central/
+date: "2013-05-18"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2013 Season
+    link: /history/2013/
+    icon: fas fa-home
+---
+
+## A & Middle School Combined
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points. Scores sorted by Average.*
+
+|    # | Team             | Church                           |  W\L | Total |    Avg |
+| ---: | ---------------- | -------------------------------- | ---: | ----: | -----: |
+|    1 | Cedar Rapids, IA | First Assembly of God            | 10\1 |  2245 | 204.09 |
+|    2 | Sioux Falls, SD  | Falls Church                     |  9\2 |  1610 | 146.36 |
+|    3 | Rapid City, SD   | Bethel Assembly of God           |  9\2 |  1605 | 145.91 |
+|    4 | Gering, NE       | Northfield Assembly of God       |  7\4 |  1590 | 144.55 |
+|    5 | Racine, WI       | Racine Assembly of God           |  7\4 |  1410 | 128.18 |
+|    6 | Knox City, MO    | Knox City Assembly of God        |  7\4 |  1200 | 109.09 |
+|    7 | Moberly, MO      | Moberly First Assembly of God    |  6\5 |  1690 | 153.64 |
+|    8 | Brookfield, WI   | Victory International Fellowship |  4\7 |   265 |  24.09 |
+|    9 | Plymouth, WI     | Christian Life Assembly of God   |  3\8 |   590 |  53.64 |
+|   10 | Bismarck, ND     | Evangel Assembly of God          |  2\9 |   570 |  51.82 |
+|   11 | Grand Island, NE | Ev. Free Church of Grand Island  |  2\9 |   230 |  20.91 |
+|   12 | St Cloud, MN     | Good News Church                 | 0\11 |   220 |     20 |
+
+### Individuals
+
+*Ties broken by Quiz Outs. Scores sorted by Average.*
+
+|    # | Quizzer             | Team             | Church                           | Total |    Avg |   QO |
+| ---: | ------------------- | ---------------- | -------------------------------- | ----: | -----: | ---: |
+|    1 | Luke Hamilton       | Gering, NE       | Northfield Assembly of God       |  1525 | 138.64 |   10 |
+|    2 | Selena Rodriguez    | Sioux Falls, SD  | Falls Church                     |  1335 | 121.36 |   11 |
+|    3 | Josiah Coder        | Cedar Rapids, IA | First Assembly of God            |  1265 |    115 |    9 |
+|    4 | Spenser Wilhelm     | Rapid City, SD   | Bethel Assembly of God           |  1060 |  96.36 |    9 |
+|    5 | Ryan Toeller        | Racine, WI       | Racine Assembly of God           |  1000 |  90.91 |    8 |
+|    6 | Lucas Hying         | Moberly, MO      | Moberly First Assembly of God    |   875 |  79.55 |    9 |
+|    7 | Jennifer Maki       | Cedar Rapids, IA | First Assembly of God            |   775 |  70.45 |    8 |
+|    8 | Anna Plank          | Moberly, MO      | Moberly First Assembly of God    |   685 |  62.27 |    5 |
+|    9 | Charlie Wilhelm     | Rapid City, SD   | Bethel Assembly of God           |   505 |  45.91 |    4 |
+|   10 | Zachariah Turnage   | Plymouth, WI     | Christian Life Assembly of God   |   485 |  44.09 |    3 |
+|   11 | Michael Van Horn    | Knox City, MO    | Knox City Assembly of God        |   465 |  42.27 |    2 |
+|   12 | Sean Daniels        | Racine, WI       | Racine Assembly of God           |   410 |  37.27 |    5 |
+|   13 | Andrew Van Horn     | Knox City, MO    | Knox City Assembly of God        |   400 |  36.36 |    2 |
+|   14 | Danelle Ragains     | Bismarck, ND     | Evangel Assembly of God          |   395 |  35.91 |    1 |
+|   15 | J.B. Van Horn       | Knox City, MO    | Knox City Assembly of God        |   340 |  30.91 |      |
+|   16 | Luke Troxel         | Brookfield, WI   | Victory International Fellowship |   235 |  21.36 |    2 |
+|   17 | Victoria Anderson   | St Cloud, MN     | Good News Church                 |   210 |  19.09 |      |
+|   18 | Matthew Coder       | Cedar Rapids, IA | First Assembly of God            |   205 |  18.64 |      |
+|   19 | Rachel Schoon       | Sioux Falls, SD  | Falls Church                     |   185 |  16.82 |    1 |
+|   20 | Lucas Bender        | Bismarck, ND     | Evangel Assembly of God          |   170 |  15.45 |      |
+|   21 | Joshua Frederick    | Grand Island, NE | Ev. Free Church of Grand Island  |   130 |  11.82 |      |
+|   21 | Chasey Knepler      | Moberly, MO      | Moberly First Assembly of God    |   130 |  11.82 |      |
+|   22 | Chad Schwartz       | Sioux Falls, SD  | Falls Church                     |   115 |  10.45 |      |
+|   23 | Alexi Turnage       | Plymouth, WI     | Christian Life Assembly of God   |   105 |   9.55 |      |
+|   24 | Abigail Swanson     | Grand Island, NE | Ev. Free Church of Grand Island  |    85 |   7.73 |      |
+|   25 | Celine Cotton       | Brookfield, WI   | Victory International Fellowship |    55 |      5 |      |
+|   26 | Bethia Hamilton     | Gering, NE       | God                              |    50 |   4.55 |      |
+|   27 | Curtis Svenson      | Rapid City, SD   | Bethel Assembly of God           |    30 |   2.73 |      |
+|   28 | Kayla Buettner      | Grand Island, NE | Grand Island                     |    20 |   1.82 |      |
+|   28 | Hadessah Loven      | St Cloud, MN     | Good News Church                 |    20 |   1.82 |      |
+|   29 | Levi Hamilton       | Gering, NE       | Northfield Assembly of God       |    15 |   1.36 |      |
+|   30 | Micah Pennel        | Rapid City, SD   | Bethel Assembly of God           |    10 |   0.91 |      |
+|   30 | Levi Sundby         | Bismarck, ND     | Evangel Assembly of God          |    10 |   0.91 |      |
+|   30 | Bri McKenley        | Sioux Falls, SD  | Falls Church                     |    10 |   0.91 |      |
+|   31 | Christian Frederick | Grand Island, NE | Ev. Free Church of Grand Island  |     5 |   0.45 |      |
+|   32 | Megan Neish         | Rapid City, SD   | Bethel Assembly of God           |       |      0 |      |
+|   32 | Cyera Young         | Moberly, MO      | Moberly First Assembly of God    |       |      0 |      |
+|   32 | Bri James           | Moberly, MO      | Moberly First Assembly of God    |       |      0 |      |
+|   32 | Rachel Maki         | Cedar Rapids, IA | Assembly of God                  |       |      0 |      |
+|   32 | John Boeckers       | Plymouth, WI     | Assembly of God                  |       |      0 |      |
+|   32 | Johanna Nick        | Plymouth, WI     | Christian Life Assembly of God   |       |      0 |      |
+|   32 | Jeremiah Schulz     | Brookfield, WI   | Victory International Fellowship |       |      0 |      |
+|   32 | Philip Sideras      | Brookfield, WI   | International Fellowship         |       |      0 |      |
+|   32 | Micah Toeller       | Plymouth, WI     | Assembly of God                  |       |      0 |      |
+|   33 | Mia Cotton          | Plymouth, WI     | Victory International Fellowship |   -25 |  -2.27 |      |
+|   33 | Lilly Mallett       | Sioux Falls, SD  | Falls Church                     |   -25 |  -2.27 |      |
+|   34 | Jasmine Larson      | St Cloud, MN     | Good News Church                 |   -10 |  -0.91 |      |
+
+## A Division Only
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points. Scores sorted by Average.*
+
+|    # | Team             | Church                           |  W\L | Total |   Avg |
+| ---: | ---------------- | -------------------------------- | ---: | ----: | ----: |
+|    1 | Cedar Rapids, IA | First Assembly of God            |  9\1 |  2035 | 203.5 |
+|    2 | Sioux Falls, SD  | Falls Church                     |  8\2 |  1470 |   147 |
+|    3 | Rapid City, SD   | Bethel Assembly of God           |  8\2 |  1505 | 150.5 |
+|    4 | Gering, NE       | Northfield Assembly of God       |  6\4 |  1450 |   145 |
+|    5 | Racine, WI       | Racine Assembly of God           |  6\4 |  1230 |   123 |
+|    6 | Knox City, MO    | Knox City Assembly of God        |  6\4 |  1095 | 109.5 |
+|    7 | Moberly, MO      | Moberly First Assembly of God    |  5\5 |  1580 |   158 |
+|    8 | Brookfield, WI   | Victory International Fellowship |  3\7 |   235 |  23.5 |
+|    9 | Plymouth, WI     | Christian Life Assembly of God   |  3\7 |   545 |  54.5 |
+|   10 | Bismarck, ND     | Evangel Assembly of God          |  1\9 |   535 |  53.5 |
+|   11 | St Cloud, MN     | Good News Church                 | 0\10 |   215 |  21.5 |
+
+### Individuals
+
+*Ties broken by Quiz Outs. Scores sorted by Average.*
+
+|    # | Quizzer           | Team             | Church                           | Total |   Avg |   QO |
+| ---: | ----------------- | ---------------- | -------------------------------- | ----: | ----: | ---: |
+|    1 | Luke Hamilton     | Gering, NE       | Northfield Assembly of God       |  1385 | 138.5 |   10 |
+|    2 | Selena Rodriguez  | Sioux Falls, SD  | Falls Church                     |  1205 | 120.5 |   10 |
+|    3 | Josiah Coder      | Cedar Rapids, IA | First Assembly of God            |  1145 | 114.5 |    8 |
+|    4 | Spenser Wilhelm   | Rapid City, SD   | Bethel Assembly of God           |  1050 |   105 |    8 |
+|    5 | Ryan Toeller      | Racine, WI       | Racine Assembly of God           |   885 |  88.5 |    6 |
+|    6 | Lucas Hying       | Moberly, MO      | Moberly First Assembly of God    |   785 |  78.5 |    7 |
+|    7 | Jennifer Maki     | Cedar Rapids, IA | First Assembly of God            |   695 |  69.5 |    7 |
+|    8 | Anna Plank        | Moberly, MO      | Moberly First Assembly of God    |   675 |  67.5 |    5 |
+|    9 | Michael Van Horn  | Knox City, MO    | Knox City Assembly of God        |   475 |  47.5 |    2 |
+|   10 | Zachariah Turnage | Plymouth, WI     | Christian Life Assembly of God   |   470 |    47 |    2 |
+|   11 | Charlie Wilhelm   | Rapid City, SD   | Bethel Assembly of God           |   415 |  41.5 |    3 |
+|   12 | Danelle Ragains   | Bismarck, ND     | Evangel Assembly of God          |   365 |  36.5 |    1 |
+|   13 | Sean Daniels      | Racine, WI       | Racine Assembly of God           |   345 |  34.5 |    4 |
+|   14 | Andrew Van Horn   | Knox City, MO    | Knox City Assembly of God        |   320 |    32 |    1 |
+|   15 | J.B. Van Horn     | Knox City, MO    | Knox City Assembly of God        |   305 |  30.5 |      |
+|   16 | Luke Troxel       | Brookfield, WI   | Victory International Fellowship |   215 |  21.5 |    1 |
+|   17 | Rachel Schoon     | Sioux Falls, SD  | Falls Church                     |   195 |  19.5 |    1 |
+|   18 | Matthew Coder     | Cedar Rapids, IA | First Assembly of God            |   195 |  19.5 |      |
+|   19 | Victoria Anderson | St Cloud, MN     | Good News Church                 |   180 |    18 |      |
+|   20 | Lucas Bender      | Bismarck, ND     | Evangel Assembly of God          |   160 |    16 |      |
+|   21 | Chasey Knepler    | Moberly, MO      | Moberly First Assembly of God    |   120 |    12 |      |
+|   22 | Chad Schwartz     | Sioux Falls, SD  | Falls Church                     |    95 |   9.5 |      |
+|   23 | Alexi Turnage     | Plymouth, WI     | Christian Life Assembly of God   |    75 |   7.5 |      |
+|   24 | Celine Cotton     | Brookfield, WI   | Victory International Fellowship |    55 |   5.5 |      |
+|   25 | Bethia Hamilton   | Gering, NE       | Northfield Assembly of God       |    50 |     5 |      |
+|   26 | Hadessah Loven    | St Cloud, MN     | Good News Church                 |    45 |   4.5 |      |
+|   27 | Curtis Svenson    | Rapid City, SD   | Bethel Assembly of God           |    30 |     3 |      |
+|   28 | Levi Hamilton     | Gering, NE       | Northfield Assembly of God       |    15 |   1.5 |      |
+|   29 | Micah Pennel      | Rapid City, SD   | Bethel Assembly of God           |    10 |     1 |      |
+|   29 | Levi Sundby       | Bismarck, ND     | Evangel Assembly of God          |    10 |     1 |      |
+|   29 | Bri McKenley      | Sioux Falls, SD  | Falls Church                     |    10 |     1 |      |
+|   30 | Bri James         | Moberly, MO      | Moberly First Assembly of God    |       |     0 |      |
+|   30 | Megan Neish       | Rapid City, SD   | Bethel Assembly of God           |       |     0 |      |
+|   30 | John Boeckers     | Plymouth, WI     | Christian Life Assembly of God   |       |     0 |      |
+|   30 | Rachel Maki       | Cedar Rapids, IA | First Assembly of God            |       |     0 |      |
+|   30 | Cyera Young       | Moberly, MO      | Moberly First Assembly of God    |       |     0 |      |
+|   30 | Johanna Nick      | Plymouth, WI     | Christian Life Assembly of God   |       |     0 |      |
+|   30 | Jeremiah Schulz   | Brookfield, WI   | Victory International Fellowship |       |     0 |      |
+|   30 | Philip Sideras    | Brookfield, WI   | Victory International Fellowship |       |     0 |      |
+|   30 | Micah Toeller     | Plymouth, WI     | Christian Life Assembly of God   |       |     0 |      |
+|   31 | Mia Cotton        | Brookfield, WI   | Victory International Fellowship |   -35 |  -3.5 |      |
+|   32 | Lilly Mallett     | Sioux Falls, SD  | Falls Church                     |   -25 |  -2.5 |      |
+|   33 | Jasmine Larson    | St Cloud, MN     | Good News Church                 |   -10 |    -1 |      |
+
+## Middle School Division Only
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points. Scores sorted by Average.*
+
+|    # | Team             | Church                 |  W\L | Total |    Avg |
+| ---: | ---------------- | ---------------------- | ---: | ----: | -----: |
+|    1 | Cedar Rapids, IA | First Assembly of God  | 10\2 |  1730 | 144.17 |
+|    2 | Hill City, SD    | Little White Church    |  6\6 |  1345 | 112.08 |
+|    3 | Rapid City, SD   | Bethel Assembly of God |  5\7 |  1150 |  95.83 |
+|    4 | Sioux Falls, SD  | 1st Evangelical Free   |  3\9 |   800 |  66.67 |
+
+### Individuals
+
+*Ties broken by Quiz Outs. Scores sorted by Average.*
+
+|    # | Quizzer              | Team             | Church                 | Total |   Avg |   QO |
+| ---: | -------------------- | ---------------- | ---------------------- | ----: | ----: | ---: |
+|    1 | Derek Kunkle         | Cedar Rapids, IA | First Assembly of God  |  1160 | 96.67 |    8 |
+|    2 | Victoria Lind        | Hill City, SD    | Little White Church    |   745 | 62.08 |    5 |
+|    3 | Isabel Wilhelm       | Rapid City, SD   | Bethel Assembly of God |   580 | 48.33 |    3 |
+|    4 | Merisa Rodriguez     | Sioux Falls, SD  | 1st Evangelical Free   |   515 | 42.92 |    2 |
+|    5 | Carson Sehr          | Rapid City, SD   | Bethel Assembly of God |   460 | 38.33 |    2 |
+|    6 | Jeffrey Coder        | Cedar Rapids, IA | First Assembly of God  |   395 | 32.92 |    5 |
+|    7 | Sammy Fowler         | Hill City, SD    | Little White Church    |   395 | 32.92 |      |
+|    8 | Romario Rodriguez    | Sioux Falls, SD  | 1st Evangelical Free   |   295 | 24.58 |      |
+|    9 | Amara Pennel         | Hill City, SD    | Little White Church    |   205 | 17.08 |      |
+|   10 | Jonah Boentoro       | Cedar Rapids, IA | First Assembly of God  |   130 | 10.83 |      |
+|   11 | Connor McCormick     | Rapid City, SD   | Bethel Assembly of God |   110 |  9.17 |      |
+|   12 | Dakota LaBarr        | Cedar Rapids, IA | First Assembly of God  |    60 |     5 |      |
+|   13 | Kayondra Szczawinski | Sioux Falls, SD  | 1st Evangelical Free   |     0 |     0 |      |
+|   14 | Jacob Kopp           | Cedar Rapids, IA | First Assembly of God  |   -10 | -0.83 |      |
+|   14 | Elisha Hopkins       | Sioux Falls, SD  | 1st Evangelical Free   |   -10 | -0.83 |      |

--- a/_pages/history/2013/regionals/northeast.md
+++ b/_pages/history/2013/regionals/northeast.md
@@ -12,179 +12,179 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## A League
+## A Division
 
 ### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
-| #  | Team                                         | Church             | W/L  | Total | Avg    |
-|---:|----------------------------------------------|--------------------|------|------:|-------:|
-| 1  | Pocono Community Church \"Ferocious Sheep\"  | Mt. Pocono, PA     | 13/2 | 2880  | 192.00 |
-| 2  | Redeemer Church                              | Utica, NY          | 12/3 | 2840  | 189.33 |
-| 3  | South Hills A/G \"Ferocious Sheep\"          | Bethel Park, PA    | 12/3 | 2595  | 173.00 |
-| 4  | Bethlehem Church                             | Richmond HIll, NY  | 12/3 | 2300  | 153.33 |
-| 5  | Living Hope Worship Center \"The Real Deal\" | Swedesboro, NJ     | 10/5 | 2230  | 148.67 |
-| 6  | Journey A/G\"Saltiness\"                     | Bridgeville, PA    | 10/5 | 2185  | 145.67 |
-| 7  | Bethany Church                               | Wyckoff, NJ        | 9/6  | 1885  | 125.67 |
-| 8  | Vailsburg A/G \"Cheesers and Shavers\"       | Newark, NJ         | 8/7  | 1870  | 124.67 |
-| 9  | Word of Life Assembly                        | Springfield, VA    | 8/7  | 1500  | 100.00 |
-| 10 | Newport A/G \"Midnight Cry\"                 | Newport, PA        | 6/9  | 1020  | 68.00  |
-| 11 | First Assembly of God                        | Binghamton, NY     | 6/9  | 1810  | 120.67 |
-| 12 | First A/G \"Seventy-Seven Times\"            | Wilkes-Barre, PA   | 4/11 | 1290  | 86.00  |
-| 13 | Mechanicsville Christian Center              | Mechanicsville, VA | 4/11 | 1040  | 69.33  |
-| 14 | Manassas Assembly of God                     | Bristow, VA        | 4/11 | 1030  | 68.67  |
-| 15 | Grace Assembly of God                        | Syracuse, NY       | 2/13 | 630   | 42.00  |
-| 16 | Prince of Peace Christian Church             | Sanford, ME        | 0/15 | 200   | 13.33  |
+|    # | Team                                       | Church             |        AG Placement | W\L AG |  W\L | Total |    Avg |
+| ---: | ------------------------------------------ | ------------------ | ------------------: | -----: | ---: | ----: | -----: |
+|    1 | Pocono Community Church "Ferocious Sheep"  | Mt. Pocono, PA     |     1st-Won PlayOff |   11\2 | 13\2 |  2880 | 192.00 |
+|    2 | Bethlehem Church                           | Richmond HIll, NY  |    2nd-Lost PlayOff |   11\2 | 12\3 |  2300 | 153.33 |
+|    3 | South Hills A/G "Ferocious Sheep"          | Bethel Park, PA    |                 3rd |   10\3 | 12\3 |  2595 | 173.00 |
+|    4 | Redeemer Church                            | Utica, NY          |                  NA |     NA | 12\3 |  2840 | 189.33 |
+|    5 | Living Hope Worship Center "The Real Deal" | Swedesboro, NJ     |                 4th |    9\4 | 10\5 |  2230 | 148.67 |
+|    6 | Journey A/G"Saltiness"                     | Bridgeville, PA    |     5th-Won PlayOff |    8\5 | 10\5 |  2185 | 145.67 |
+|    7 | Bethany Church                             | Wyckoff, NJ        |    6th-Lost PlayOff |    8\5 |  9\6 |  1885 | 125.67 |
+|    8 | Vailsburg A/G "Cheesers and Shavers"       | Newark, NJ         |   7th-Won Head-Head |    7\6 |  8\7 |  1870 | 124.67 |
+|    9 | Word of Life Assembly                      | Springfield, VA    |  8th-Lost Head-Head |    7\6 |  8\7 |  1500 | 100.00 |
+|   10 | Newport A/G "Midnight Cry"                 | Newport, PA        |   9th-Won Head-Head |    5\8 |  6\9 |  1020 |  68.00 |
+|   11 | First Assembly of God                      | Binghamton, NY     | 10th-Lost Head-Head |    5\8 |  6\9 |  1810 | 120.67 |
+|   12 | First A/G "Seventy-Seven Times"            | Wilkes-Barre, PA   |   11th 2-0 in Group |   3\10 | 4\11 |  1290 |  86.00 |
+|   13 | Mechanicsville Christian Center            | Mechanicsville, VA |   12th 1-1 in Group |   3\10 | 4\11 |  1040 |  69.33 |
+|   14 | Manassas Assembly of God                   | Bristow, VA        |   13th 0-2 in Group |   3\10 | 4\11 |  1030 |  68.67 |
+|   15 | Grace Assembly of God                      | Syracuse, NY       |                14th |   1\12 | 2\13 |   630 |  42.00 |
+|   16 | Prince of Peace Christian Church           | Sanford, ME        |                  NA |     NA | 0\15 |   200 |  13.33 |
 
 ### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
-| #  | Quizzer            | Team                                         | Church             | Total | Avg    | QO |
-|---:|--------------------|----------------------------------------------|--------------------|------:|-------:|---:|
-| 1  | Joe Chacra         | Pocono Community Church \"Ferocious Sheep\"  | Mt. Pocono, PA     | 1770  | 118.00 | 14 |
-| 2  | Aaron Scarinzi     | First Assembly of God                        | Binghamton, NY     | 1685  | 112.33 | 14 |
-| 3  | Jared Hill         | Living Hope Worship Center \"The Real Deal\" | Swedesboro, NJ     | 1555  | 103.67 | 14 |
-| 4  | Jonathan Brown     | South Hills A/G \"Ferocious Sheep\"          | Bethel Park, PA    | 1545  | 103.00 | 12 |
-| 5  | Tyler Adelmann     | Bethany Church                               | Wyckoff, NJ        | 1440  | 96.00  | 13 |
-| 6  | Caleb Hoffmann     | Redeemer Church                              | Utica, NY          | 1405  | 93.67  | 13 |
-| 7  | Colton Bononi      | Journey A/G\"Saltiness\"                     | Bridgeville, PA    | 1400  | 93.33  | 13 |
-| 8  | Rachael Singh      | Bethlehem Church                             | Richmond HIll, NY  | 1375  | 91.67  | 10 |
-| 9  | Julia Rodriguez    | First A/G \"Seventy-Seven Times\"            | Wilkes-Barre, PA   | 1040  | 69.33  | 7  |
-| 10 | Nick DePasquale    | Vailsburg A/G \"Cheesers and Shavers\"       | Newark, NJ         | 965   | 64.33  | 8  |
-| 11 | Solomon Stevens    | Redeemer Church                              | Utica, NY          | 950   | 63.33  | 6  |
-| 12 | Hannah Sproull     | Newport A/G \"Midnight Cry\"                 | Newport, PA        | 775   | 51.67  | 7  |
-| 13 | Dana Warnock       | Journey A/G\"Saltiness\"                     | Bridgeville, PA    | 760   | 50.67  | 7  |
-| 14 | Trey Sederwall     | Vailsburg A/G \"Cheesers and Shavers\"       | Newark, NJ         | 670   | 44.67  | 5  |
-| 15 | Joshua Inyangson   | Word of Life Assembly                        | Springfield, VA    | 645   | 43.00  | 5  |
-| 16 | Joey Lemley        | South Hills A/G \"Ferocious Sheep\"          | Bethel Park, PA    | 620   | 41.33  | 6  |
-| 16 | Amanda Persaud     | Pocono Community Church \"Ferocious Sheep\"  | Mt. Pocono, PA     | 620   | 41.33  | 6  |
-| 17 | Kristyn Jones      | Manassas Assembly of God                     | Bristow, VA        | 610   | 40.67  | 2  |
-| 18 | Chase Hill         | Living Hope Worship Center \"The Real Deal\" | Swedesboro, NJ     | 595   | 39.67  | 6  |
-| 19 | Rebecca Ford       | Bethlehem Church                             | Richmond HIll, NY  | 510   | 34.00  | 3  |
-| 20 | Sarah Tomlinson    | Pocono Community Church \"Ferocious Sheep\"  | Mt. Pocono, PA     | 500   | 33.33  | 2  |
-| 21 | Holly Bowen        | Mechanicsville Christian Center              | Mechanicsville, VA | 490   | 32.67  | 1  |
-| 22 | Ethan Hoffmann     | Redeemer Church                              | Utica, NY          | 485   | 32.33  | 3  |
-| 23 | Abhishek Mathews   | Word of Life Assembly                        | Springfield, VA    | 450   | 30.00  | 4  |
-| 24 | Benjamin Beckering | Grace Assembly of God                        | Syracuse, NY       | 440   | 29.33  | 2  |
-| 25 | Hannah Tower       | South Hills A/G \"Ferocious Sheep\"          | Bethel Park, PA    | 430   | 28.67  | 2  |
-| 26 | Joshua KuKuvka     | Mechanicsville Christian Center              | Mechanicsville, VA | 420   | 28.00  | 2  |
-| 27 | Gabriel Flores     | Bethany Church                               | Wyckoff, NJ        | 390   | 26.00  | 3  |
-| 28 | Omari Dixon        | Bethlehem Church                             | Richmond HIll, NY  | 365   | 24.33  |    |
-| 29 | Phillip Tran       | Manassas Assembly of God                     | Bristow, VA        | 345   | 23.00  | 1  |
-| 30 | Shane Brown        | Vailsburg A/G \"Cheesers and Shavers\"       | Newark, NJ         | 235   | 15.67  |    |
-| 31 | Zachary Berthiaume | Prince of Peace Christian Church             | Sanford, ME        | 210   | 14.00  | 1  |
-| 32 | Maia Britton       | First A/G \"Seventy-Seven Times\"            | Wilkes-Barre, PA   | 210   | 14.00  |    |
-| 33 | Jordan Ennis       | Grace Assembly of God                        | Syracuse, NY       | 190   | 12.67  |    |
-| 34 | David Inyangson    | Word of Life Assembly                        | Springfield, VA    | 165   | 11.00  |    |
-| 35 | Alyssa Walker      | Mechanicsville Christian Center              | Mechanicsville, VA | 155   | 10.33  |    |
-| 36 | Ethan Sproull      | Newport A/G \"Midnight Cry\"                 | Newport, PA        | 145   | 9.67   | 1  |
-| 36 | Zerubabbel Tessema | Word of Life Assembly                        | Springfield, VA    | 145   | 9.67   | 1  |
-| 37 | Kevin Sanders      | First Assembly of God                        | Binghamton, NY     | 105   | 7.00   |    |
-| 37 | Hunter Langel      | Newport A/G \"Midnight Cry\"                 | Newport, PA        | 105   | 7.00   |    |
-| 37 | Jacob Conerly      | Word of Life Assembly                        | Springfield, VA    | 105   | 7.00   |    |
-| 38 | Megan Steves       | Living Hope Worship Center \"The Real Deal\" | Swedesboro, NJ     | 80    | 5.33   |    |
-| 38 | Caleb Jones        | Manassas Assembly of God                     | Bristow, VA        | 80    | 5.33   |    |
-| 39 | Rachel Girimonte   | Bethany Church                               | Wyckoff, NJ        | 60    | 4.00   |    |
-| 40 | Sara Singh         | Bethlehem Church                             | Richmond HIll, NY  | 40    | 2.67   |    |
-| 40 | Michael Rodriguez  | First A/G \"Seventy-Seven Times\"            | Wilkes-Barre, PA   | 40    | 2.67   |    |
-| 41 | Kyle O'Keefe       | Journey A/G\"Saltiness\"                     | Bridgeville, PA    | 25    | 1.67   |    |
-| 42 | Kera Churchill     | Prince of Peace Christian Church             | Sanford, ME        | 20    | 1.33   |    |
-| 42 | Anthony Sanders    | First Assembly of God                        | Binghamton, NY     | 20    | 1.33   |    |
-| 43 | Lydia Pulkinenn    | Prince of Peace Christian Church             | Sanford, ME        | 10    | .67    |    |
-| 43 | Alexis Adelmann    | Bethany Church                               | Wyckoff, NJ        | 10    | .67    |    |
-| 43 | Kimara Davis       | Bethlehem Church                             | Richmond HIll, NY  | 10    | .67    |    |
-| 44 | Rebekah Welesko    | Journey A/G\"Saltiness\"                     | Bridgeville, PA    |       | .00    |    |
-| 44 | Nathan Isner       | Mechanicsville Christian Center              | Mechanicsville, VA |       | .00    |    |
-| 44 | Connor O'Keefe     | Journey A/G\"Saltiness\"                     | Bridgeville, PA    |       | .00    |    |
-| 44 | Abbey Ellis        | First Assembly of God                        | Binghamton, NY     |       | .00    |    |
-| 44 | Gabrielle Schell   | Living Hope Worship Center \"The Real Deal\" | Swedesboro, NJ     |       | .00    |    |
-| 45 | Callie Gamble      | Prince of Peace Christian Church             | Sanford, ME        | -40   | -2.67  |    |
-| 46 | Sadya Ouedraogo    | Word of Life Assembly                        | Springfield, VA    | -5    | -0.33  |    |
+|    # | Quizzer            | Team                                       | Church             | Total |    Avg |   QO |
+| ---: | ------------------ | ------------------------------------------ | ------------------ | ----: | -----: | ---: |
+|    1 | Joe Chacra         | Pocono Community Church "Ferocious Sheep"  | Mt. Pocono, PA     |  1770 | 118.00 |   14 |
+|    2 | Aaron Scarinzi     | First Assembly of God                      | Binghamton, NY     |  1685 | 112.33 |   14 |
+|    3 | Jared Hill         | Living Hope Worship Center "The Real Deal" | Swedesboro, NJ     |  1555 | 103.67 |   14 |
+|    4 | Jonathan Brown     | South Hills A/G "Ferocious Sheep"          | Bethel Park, PA    |  1545 | 103.00 |   12 |
+|    5 | Tyler Adelmann     | Bethany Church                             | Wyckoff, NJ        |  1440 |  96.00 |   13 |
+|    6 | Caleb Hoffmann     | Redeemer Church                            | Utica, NY          |  1405 |  93.67 |   13 |
+|    7 | Colton Bononi      | Journey A/G"Saltiness"                     | Bridgeville, PA    |  1400 |  93.33 |   13 |
+|    8 | Rachael Singh      | Bethlehem Church                           | Richmond HIll, NY  |  1375 |  91.67 |   10 |
+|    9 | Julia Rodriguez    | First A/G "Seventy-Seven Times"            | Wilkes-Barre, PA   |  1040 |  69.33 |    7 |
+|   10 | Nick DePasquale    | Vailsburg A/G "Cheesers and Shavers"       | Newark, NJ         |   965 |  64.33 |    8 |
+|   11 | Solomon Stevens    | Redeemer Church                            | Utica, NY          |   950 |  63.33 |    6 |
+|   12 | Hannah Sproull     | Newport A/G "Midnight Cry"                 | Newport, PA        |   775 |  51.67 |    7 |
+|   13 | Dana Warnock       | Journey A/G"Saltiness"                     | Bridgeville, PA    |   760 |  50.67 |    7 |
+|   14 | Trey Sederwall     | Vailsburg A/G "Cheesers and Shavers"       | Newark, NJ         |   670 |  44.67 |    5 |
+|   15 | Joshua Inyangson   | Word of Life Assembly                      | Springfield, VA    |   645 |  43.00 |    5 |
+|   16 | Joey Lemley        | South Hills A/G "Ferocious Sheep"          | Bethel Park, PA    |   620 |  41.33 |    6 |
+|   16 | Amanda Persaud     | Pocono Community Church "Ferocious Sheep"  | Mt. Pocono, PA     |   620 |  41.33 |    6 |
+|   17 | Kristyn Jones      | Manassas Assembly of God                   | Bristow, VA        |   610 |  40.67 |    2 |
+|   18 | Chase Hill         | Living Hope Worship Center "The Real Deal" | Swedesboro, NJ     |   595 |  39.67 |    6 |
+|   19 | Rebecca Ford       | Bethlehem Church                           | Richmond HIll, NY  |   510 |  34.00 |    3 |
+|   20 | Sarah Tomlinson    | Pocono Community Church "Ferocious Sheep"  | Mt. Pocono, PA     |   500 |  33.33 |    2 |
+|   21 | Holly Bowen        | Mechanicsville Christian Center            | Mechanicsville, VA |   490 |  32.67 |    1 |
+|   22 | Ethan Hoffmann     | Redeemer Church                            | Utica, NY          |   485 |  32.33 |    3 |
+|   23 | Abhishek Mathews   | Word of Life Assembly                      | Springfield, VA    |   450 |  30.00 |    4 |
+|   24 | Benjamin Beckering | Grace Assembly of God                      | Syracuse, NY       |   440 |  29.33 |    2 |
+|   25 | Hannah Tower       | South Hills A/G "Ferocious Sheep"          | Bethel Park, PA    |   430 |  28.67 |    2 |
+|   26 | Joshua KuKuvka     | Mechanicsville Christian Center            | Mechanicsville, VA |   420 |  28.00 |    2 |
+|   27 | Gabriel Flores     | Bethany Church                             | Wyckoff, NJ        |   390 |  26.00 |    3 |
+|   28 | Omari Dixon        | Bethlehem Church                           | Richmond HIll, NY  |   365 |  24.33 |      |
+|   29 | Phillip Tran       | Manassas Assembly of God                   | Bristow, VA        |   345 |  23.00 |    1 |
+|   30 | Shane Brown        | Vailsburg A/G "Cheesers and Shavers"       | Newark, NJ         |   235 |  15.67 |      |
+|   31 | Zachary Berthiaume | Prince of Peace Christian Church           | Sanford, ME        |   210 |  14.00 |    1 |
+|   32 | Maia Britton       | First A/G "Seventy-Seven Times"            | Wilkes-Barre, PA   |   210 |  14.00 |      |
+|   33 | Jordan Ennis       | Grace Assembly of God                      | Syracuse, NY       |   190 |  12.67 |      |
+|   34 | David Inyangson    | Word of Life Assembly                      | Springfield, VA    |   165 |  11.00 |      |
+|   35 | Alyssa Walker      | Mechanicsville Christian Center            | Mechanicsville, VA |   155 |  10.33 |      |
+|   36 | Ethan Sproull      | Newport A/G "Midnight Cry"                 | Newport, PA        |   145 |   9.67 |    1 |
+|   36 | Zerubabbel Tessema | Word of Life Assembly                      | Springfield, VA    |   145 |   9.67 |    1 |
+|   37 | Kevin Sanders      | First Assembly of God                      | Binghamton, NY     |   105 |   7.00 |      |
+|   37 | Hunter Langel      | Newport A/G "Midnight Cry"                 | Newport, PA        |   105 |   7.00 |      |
+|   37 | Jacob Conerly      | Word of Life Assembly                      | Springfield, VA    |   105 |   7.00 |      |
+|   38 | Megan Steves       | Living Hope Worship Center "The Real Deal" | Swedesboro, NJ     |    80 |   5.33 |      |
+|   38 | Caleb Jones        | Manassas Assembly of God                   | Bristow, VA        |    80 |   5.33 |      |
+|   39 | Rachel Girimonte   | Bethany Church                             | Wyckoff, NJ        |    60 |   4.00 |      |
+|   40 | Sara Singh         | Bethlehem Church                           | Richmond HIll, NY  |    40 |   2.67 |      |
+|   40 | Michael Rodriguez  | First A/G "Seventy-Seven Times"            | Wilkes-Barre, PA   |    40 |   2.67 |      |
+|   41 | Kyle O'Keefe       | Journey A/G"Saltiness"                     | Bridgeville, PA    |    25 |   1.67 |      |
+|   42 | Kera Churchill     | Prince of Peace Christian Church           | Sanford, ME        |    20 |   1.33 |      |
+|   42 | Anthony Sanders    | First Assembly of God                      | Binghamton, NY     |    20 |   1.33 |      |
+|   43 | Lydia Pulkinenn    | Prince of Peace Christian Church           | Sanford, ME        |    10 |   0.67 |      |
+|   43 | Alexis Adelmann    | Bethany Church                             | Wyckoff, NJ        |    10 |   0.67 |      |
+|   43 | Kimara Davis       | Bethlehem Church                           | Richmond HIll, NY  |    10 |   0.67 |      |
+|   44 | Rebekah Welesko    | Journey A/G"Saltiness"                     | Bridgeville, PA    |       |   0.00 |      |
+|   44 | Nathan Isner       | Mechanicsville Christian Center            | Mechanicsville, VA |       |   0.00 |      |
+|   44 | Connor O'Keefe     | Journey A/G"Saltiness"                     | Bridgeville, PA    |       |   0.00 |      |
+|   44 | Abbey Ellis        | First Assembly of God                      | Binghamton, NY     |       |   0.00 |      |
+|   44 | Gabrielle Schell   | Living Hope Worship Center "The Real Deal" | Swedesboro, NJ     |       |   0.00 |      |
+|   45 | Callie Gamble      | Prince of Peace Christian Church           | Sanford, ME        |   -40 |  -2.67 |      |
+|   46 | Sadya Ouedraogo    | Word of Life Assembly                      | Springfield, VA    |    -5 |  -0.33 |      |
 
-## Middle School League
+## Middle School Division
 
 ### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
-| #  | Team                                          | Church           | W/L  | Total | Avg    |
-|---:|-----------------------------------------------|------------------|------|------:|-------:|
-| 1  | Vailsburg A/G \"Hungry and Thirsty\"          | Newark, NJ       | 13/2 | 2690  | 179.33 |
-| 2  | South Hills A/G \"UnquenchableFire\"          | Bethel Park, PA  | 12/3 | 2655  | 177.00 |
-| 3  | Evangel Heights A/G \"Matthews Angels\"       | Sarver, PA       | 12/3 | 2505  | 167.00 |
-| 4  | Christian Life A/G \"Path Finders\"           | Chambersburg, PA | 11/4 | 2565  | 171.00 |
-| 5  | Pocono Community Church \"Midnight Shadows\"  | Mt Pocono, PA    | 11/4 | 2615  | 174.33 |
-| 6  | Bethany Church \"Pearl of Great Price\"       | Wyckoff, NJ      | 10/5 | 2525  | 168.33 |
-| 7  | South Hills A/G \"Blessed Wings of Faith\"    | Bethel Park, PA  | 9/6  | 2540  | 169.33 |
-| 8  | Cornerstone A/G                               | Bouie, MD        | 8/7  | 2180  | 145.33 |
-| 9  | Fountain of Life Center                       | Burlington, NJ   | 8/7  | 2395  | 159.67 |
-| 10 | Allison Park A/G \"Mustard Seeds\"            | Allison Park PA  | 7/8  | 2390  | 159.33 |
-| 11 | Living Hope Worship Center \"The Two Rebels\" | Swedesboro, NJ   | 6/9  | 1925  | 128.33 |
-| 12 | Maple Lane Assembly of God                    | Deposit, NY      | 4/11 | 1735  | 115.67 |
-| 13 | First A/G                                     | Binghamton, NY   | 4/11 | 1215  | 81.00  |
-| 14 | Word of Life A/G                              | Springfield, VA  | 3/12 | 1535  | 102.33 |
-| 15 | Prince of Peace Church                        | Sanford,ME       | 1/14 | 355   | 23.67  |
-| 16 | Kennebec Valley A/G                           | Chelsea, ME      | 1/14 | 915   | 61.00  |
+|    # | Team                                        | Church           |  W\L | Tie Breaker    | Total |    Avg |
+| ---: | ------------------------------------------- | ---------------- | ---: | -------------- | ----: | -----: |
+|    1 | Vailsburg A/G "Hungry and Thirsty"          | Newark, NJ       | 13\2 |                |  2690 | 179.33 |
+|    2 | South Hills A/G "UnquenchableFire"          | Bethel Park, PA  | 12\3 | Won Head-Head  |  2655 | 177.00 |
+|    3 | Evangel Heights A/G "Matthews Angels"       | Sarver, PA       | 12\3 | Lost Head-Head |  2505 | 167.00 |
+|    4 | Christian Life A/G "Path Finders"           | Chambersburg, PA | 11\4 | Won Head-Head  |  2565 | 171.00 |
+|    5 | Pocono Community Church "Midnight Shadows"  | Mt Pocono, PA    | 11\4 | Lost Head-Head |  2615 | 174.33 |
+|    6 | Bethany Church "Pearl of Great Price"       | Wyckoff, NJ      | 10\5 |                |  2525 | 168.33 |
+|    7 | South Hills A/G "Blessed Wings of Faith"    | Bethel Park, PA  |  9\6 |                |  2540 | 169.33 |
+|    8 | Cornerstone A/G                             | Bouie, MD        |  8\7 | Won Head-Head  |  2180 | 145.33 |
+|    9 | Fountain of Life Center                     | Burlington, NJ   |  8\7 | Lost Head-Head |  2395 | 159.67 |
+|   10 | Allison Park A/G "Mustard Seeds"            | Allison Park PA  |  7\8 |                |  2390 | 159.33 |
+|   11 | Living Hope Worship Center "The Two Rebels" | Swedesboro, NJ   |  6\9 |                |  1925 | 128.33 |
+|   12 | Maple Lane Assembly of God                  | Deposit, NY      | 4\11 | Won Head-Head  |  1735 | 115.67 |
+|   13 | First A/G                                   | Binghamton, NY   | 4\11 | Lost Head-Head |  1215 |  81.00 |
+|   14 | Word of Life A/G                            | Springfield, VA  | 3\12 |                |  1535 | 102.33 |
+|   15 | Prince of Peace Church                      | Sanford,ME       | 1\14 | Won Head-Head  |   355 |  23.67 |
+|   16 | Kennebec Valley A/G                         | Chelsea, ME      | 1\14 | Lost Head-Head |   915 |  61.00 |
 
 ### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
-| #  | Quizzer                   | Team                                          | Church           | Total | Avg    | QO |
-|---:|---------------------------|-----------------------------------------------|------------------|------:|-------:|---:|
-| 1  | Hava Parker               | Pocono Community Church \"Midnight Shadows\"  | Mt Pocono, PA    | 1975  | 131.67 | 14 |
-| 2  | Natalie Borzone           | Bethany Church \"Pearl of Great Price\"       | Wyckoff, NJ      | 1820  | 121.33 | 14 |
-| 3  | Brooklyne Sederwall       | Vailsburg A/G \"Hungry and Thirsty\"          | Newark, NJ       | 1555  | 103.67 | 11 |
-| 4  | Divya Mathews             | Word of Life A/G                              | Springfield, VA  | 1535  | 102.33 | 12 |
-| 5  | Marc Smith                | Cornerstone A/G                               | Bouie, MD        | 1485  | 99.00  | 12 |
-| 6  | Joel Larson               | Allison Park A/G \"Mustard Seeds\"            | Allison Park PA  | 1340  | 89.33  | 10 |
-| 7  | Natalie Carlson           | Christian Life A/G \"Path Finders\"           | Chambersburg, PA | 1325  | 88.33  | 12 |
-| 8  | Emma Powers               | South Hills A/G \"Blessed Wings of Faith\"    | Bethel Park, PA  | 1325  | 88.33  | 10 |
-| 9  | Wesley White              | Fountain of Life Center                       | Burlington, NJ   | 1170  | 78.00  | 9  |
-| 10 | Madison Holcomb           | Evangel Heights A/G \"Matthews Angels\"       | Sarver, PA       | 1135  | 75.67  | 7  |
-| 11 | Josh Fuller               | South Hills A/G \"UnquenchableFire\"          | Bethel Park, PA  | 1120  | 74.67  | 9  |
-| 12 | David Sikes               | South Hills A/G \"UnquenchableFire\"          | Bethel Park, PA  | 1060  | 70.67  | 10 |
-| 13 | Katrina Dowdy             | Living Hope Worship Center \"The Two Rebels\" | Swedesboro, NJ   | 1000  | 66.67  | 7  |
-| 14 | Hannah Hill               | Living Hope Worship Center \"The Two Rebels\" | Swedesboro, NJ   | 925   | 61.67  | 7  |
-| 15 | Josh Larson               | Allison Park A/G \"Mustard Seeds\"            | Allison Park PA  | 920   | 61.33  | 5  |
-| 16 | Aidan McIntire            | Evangel Heights A/G \"Matthews Angels\"       | Sarver, PA       | 915   | 61.00  | 8  |
-| 17 | Trey Binkley              | Christian Life A/G \"Path Finders\"           | Chambersburg, PA | 800   | 53.33  | 6  |
-| 18 | Ethan Mitchell            | Maple Lane Assembly of God                    | Deposit, NY      | 785   | 52.33  | 5  |
-| 19 | Mik'kalah Patterson       | Fountain of Life Center                       | Burlington, NJ   | 740   | 49.33  | 6  |
-| 20 | Chad Sederwall            | Vailsburg A/G \"Hungry and Thirsty\"          | Newark, NJ       | 720   | 48.00  | 4  |
-| 21 | Maggie Thompson           | Cornerstone A/G                               | Bouie, MD        | 695   | 46.33  | 8  |
-| 22 | Shayann Meyers            | South Hills A/G \"Blessed Wings of Faith\"    | Bethel Park, PA  | 675   | 45.00  | 3  |
-| 23 | Kenyon Carroll            | Pocono Community Church \"Midnight Shadows\"  | Mt Pocono, PA    | 640   | 42.67  | 5  |
-| 24 | Ally Waller               | Kennebec Valley A/G                           | Chelsea, ME      | 635   | 42.33  | 2  |
-| 25 | Alex Thornton             | South Hills A/G \"Blessed Wings of Faith\"    | Bethel Park, PA  | 540   | 36.00  | 2  |
-| 26 | Danielle Seymour          | Maple Lane Assembly of God                    | Deposit, NY      | 535   | 35.67  | 5  |
-| 27 | Nick Congdon              | First A/G                                     | Binghamton, NY   | 495   | 33.00  | 4  |
-| 28 | Alex Stewart              | Bethany Church \"Pearl of Great Price\"       | Wyckoff, NJ      | 460   | 30.67  | 4  |
-| 29 | Stephanie Barnett         | Christian Life A/G \"Path Finders\"           | Chambersburg, PA | 440   | 29.33  | 2  |
-| 30 | Joshua Schellinger        | Maple Lane Assembly of God                    | Deposit, NY      | 415   | 27.67  | 3  |
-| 31 | David Mouwon              | Vailsburg A/G \"Hungry and Thirsty\"          | Newark, NJ       | 385   | 25.67  | 4  |
-| 32 | Naomi Torres              | Fountain of Life Center                       | Burlington, NJ   | 330   | 22.00  | 1  |
-| 33 | Jesse Bennett             | First A/G                                     | Binghamton, NY   | 290   | 19.33  | 1  |
-| 34 | Alyssa Bogaczyk           | Evangel Heights A/G \"Matthews Angels\"       | Sarver, PA       | 270   | 18.00  | 1  |
-| 35 | Rachel Adelmann           | Bethany Church \"Pearl of Great Price\"       | Wyckoff, NJ      | 245   | 16.33  | 1  |
-| 35 | Seth Misak                | South Hills A/G \"UnquenchableFire\"          | Bethel Park, PA  | 245   | 16.33  | 1  |
-| 36 | Kyra Pulkinen             | Prince of Peace Church                        | Sanford,ME       | 240   | 16.00  |    |
-| 37 | James Khor                | South Hills A/G \"UnquenchableFire\"          | Bethel Park, PA  | 230   | 15.33  | 1  |
-| 38 | Julie-Anna Cherednichenko | First A/G                                     | Binghamton, NY   | 220   | 14.67  | 1  |
-| 39 | Veronica Cherednichenko   | First A/G                                     | Binghamton, NY   | 210   | 14.00  |    |
-| 40 | Morgan Young              | Kennebec Valley A/G                           | Chelsea, ME      | 205   | 13.67  |    |
-| 41 | Renee Thiele              | Evangel Heights A/G \"Matthews Angels\"       | Sarver, PA       | 185   | 12.33  |    |
-| 42 | Annabelle Gabsi           | Fountain of Life Center                       | Burlington, NJ   | 145   | 9.67   |    |
-| 43 | Kathleen Creteau          | Prince of Peace Church                        | Sanford,ME       | 125   | 8.33   |    |
-| 44 | Martha Layne              | Allison Park A/G \"Mustard Seeds\"            | Allison Park PA  | 120   | 8.00   | 1  |
-| 45 | Justin Audet              | Kennebec Valley A/G                           | Chelsea, ME      | 75    | 5.00   |    |
-| 46 | Kayla Williams            | Vailsburg A/G \"Hungry and Thirsty\"          | Newark, NJ       | 30    | 2.00   |    |
-| 47 | Matthew Wright            | Fountain of Life Center                       | Burlington, NJ   | 10    | .67    |    |
-| 47 | Tirzah Ryssel             | Allison Park A/G \"Mustard Seeds\"            | Allison Park PA  | 10    | .67    |    |
-| 48 | Jackson Smith             | Kennebec Valley A/G                           | Chelsea, ME      |       | .00    |    |
-| 48 | Sydney Avery              | Kennebec Valley A/G                           | Chelsea, ME      |       | .00    |    |
-| 48 | Casey Thurber             | Pocono Community Church \"Midnight Shadows\"  | Mt Pocono, PA    |       | .00    |    |
-| 48 | Abriana Todd              | Vailsburg A/G \"Hungry and Thirsty\"          | Newark, NJ       |       | .00    |    |
-| 49 | Sarah Lawrence            | Prince of Peace Church                        | Sanford,ME       | -10   | -0.67  |    |
+|    # | Quizzer                   | Team                                        | Church           | Total |    Avg |   QO |
+| ---: | ------------------------- | ------------------------------------------- | ---------------- | ----: | -----: | ---: |
+|    1 | Hava Parker               | Pocono Community Church "Midnight Shadows"  | Mt Pocono, PA    |  1975 | 131.67 |   14 |
+|    2 | Natalie Borzone           | Bethany Church "Pearl of Great Price"       | Wyckoff, NJ      |  1820 | 121.33 |   14 |
+|    3 | Brooklyne Sederwall       | Vailsburg A/G "Hungry and Thirsty"          | Newark, NJ       |  1555 | 103.67 |   11 |
+|    4 | Divya Mathews             | Word of Life A/G                            | Springfield, VA  |  1535 | 102.33 |   12 |
+|    5 | Marc Smith                | Cornerstone A/G                             | Bouie, MD        |  1485 |  99.00 |   12 |
+|    6 | Joel Larson               | Allison Park A/G "Mustard Seeds"            | Allison Park PA  |  1340 |  89.33 |   10 |
+|    7 | Natalie Carlson           | Christian Life A/G "Path Finders"           | Chambersburg, PA |  1325 |  88.33 |   12 |
+|    8 | Emma Powers               | South Hills A/G "Blessed Wings of Faith"    | Bethel Park, PA  |  1325 |  88.33 |   10 |
+|    9 | Wesley White              | Fountain of Life Center                     | Burlington, NJ   |  1170 |  78.00 |    9 |
+|   10 | Madison Holcomb           | Evangel Heights A/G "Matthews Angels"       | Sarver, PA       |  1135 |  75.67 |    7 |
+|   11 | Josh Fuller               | South Hills A/G "UnquenchableFire"          | Bethel Park, PA  |  1120 |  74.67 |    9 |
+|   12 | David Sikes               | South Hills A/G "UnquenchableFire"          | Bethel Park, PA  |  1060 |  70.67 |   10 |
+|   13 | Katrina Dowdy             | Living Hope Worship Center "The Two Rebels" | Swedesboro, NJ   |  1000 |  66.67 |    7 |
+|   14 | Hannah Hill               | Living Hope Worship Center "The Two Rebels" | Swedesboro, NJ   |   925 |  61.67 |    7 |
+|   15 | Josh Larson               | Allison Park A/G "Mustard Seeds"            | Allison Park PA  |   920 |  61.33 |    5 |
+|   16 | Aidan McIntire            | Evangel Heights A/G "Matthews Angels"       | Sarver, PA       |   915 |  61.00 |    8 |
+|   17 | Trey Binkley              | Christian Life A/G "Path Finders"           | Chambersburg, PA |   800 |  53.33 |    6 |
+|   18 | Ethan Mitchell            | Maple Lane Assembly of God                  | Deposit, NY      |   785 |  52.33 |    5 |
+|   19 | Mik'kalah Patterson       | Fountain of Life Center                     | Burlington, NJ   |   740 |  49.33 |    6 |
+|   20 | Chad Sederwall            | Vailsburg A/G "Hungry and Thirsty"          | Newark, NJ       |   720 |  48.00 |    4 |
+|   21 | Maggie Thompson           | Cornerstone A/G                             | Bouie, MD        |   695 |  46.33 |    8 |
+|   22 | Shayann Meyers            | South Hills A/G "Blessed Wings of Faith"    | Bethel Park, PA  |   675 |  45.00 |    3 |
+|   23 | Kenyon Carroll            | Pocono Community Church "Midnight Shadows"  | Mt Pocono, PA    |   640 |  42.67 |    5 |
+|   24 | Ally Waller               | Kennebec Valley A/G                         | Chelsea, ME      |   635 |  42.33 |    2 |
+|   25 | Alex Thornton             | South Hills A/G "Blessed Wings of Faith"    | Bethel Park, PA  |   540 |  36.00 |    2 |
+|   26 | Danielle Seymour          | Maple Lane Assembly of God                  | Deposit, NY      |   535 |  35.67 |    5 |
+|   27 | Nick Congdon              | First A/G                                   | Binghamton, NY   |   495 |  33.00 |    4 |
+|   28 | Alex Stewart              | Bethany Church "Pearl of Great Price"       | Wyckoff, NJ      |   460 |  30.67 |    4 |
+|   29 | Stephanie Barnett         | Christian Life A/G "Path Finders"           | Chambersburg, PA |   440 |  29.33 |    2 |
+|   30 | Joshua Schellinger        | Maple Lane Assembly of God                  | Deposit, NY      |   415 |  27.67 |    3 |
+|   31 | David Mouwon              | Vailsburg A/G "Hungry and Thirsty"          | Newark, NJ       |   385 |  25.67 |    4 |
+|   32 | Naomi Torres              | Fountain of Life Center                     | Burlington, NJ   |   330 |  22.00 |    1 |
+|   33 | Jesse Bennett             | First A/G                                   | Binghamton, NY   |   290 |  19.33 |    1 |
+|   34 | Alyssa Bogaczyk           | Evangel Heights A/G "Matthews Angels"       | Sarver, PA       |   270 |  18.00 |    1 |
+|   35 | Rachel Adelmann           | Bethany Church "Pearl of Great Price"       | Wyckoff, NJ      |   245 |  16.33 |    1 |
+|   35 | Seth Misak                | South Hills A/G "UnquenchableFire"          | Bethel Park, PA  |   245 |  16.33 |    1 |
+|   36 | Kyra Pulkinen             | Prince of Peace Church                      | Sanford,ME       |   240 |  16.00 |      |
+|   37 | James Khor                | South Hills A/G "UnquenchableFire"          | Bethel Park, PA  |   230 |  15.33 |    1 |
+|   38 | Julie-Anna Cherednichenko | First A/G                                   | Binghamton, NY   |   220 |  14.67 |    1 |
+|   39 | Veronica Cherednichenko   | First A/G                                   | Binghamton, NY   |   210 |  14.00 |      |
+|   40 | Morgan Young              | Kennebec Valley A/G                         | Chelsea, ME      |   205 |  13.67 |      |
+|   41 | Renee Thiele              | Evangel Heights A/G "Matthews Angels"       | Sarver, PA       |   185 |  12.33 |      |
+|   42 | Annabelle Gabsi           | Fountain of Life Center                     | Burlington, NJ   |   145 |   9.67 |      |
+|   43 | Kathleen Creteau          | Prince of Peace Church                      | Sanford,ME       |   125 |   8.33 |      |
+|   44 | Martha Layne              | Allison Park A/G "Mustard Seeds"            | Allison Park PA  |   120 |   8.00 |    1 |
+|   45 | Justin Audet              | Kennebec Valley A/G                         | Chelsea, ME      |    75 |   5.00 |      |
+|   46 | Kayla Williams            | Vailsburg A/G "Hungry and Thirsty"          | Newark, NJ       |    30 |   2.00 |      |
+|   47 | Matthew Wright            | Fountain of Life Center                     | Burlington, NJ   |    10 |   0.67 |      |
+|   47 | Tirzah Ryssel             | Allison Park A/G "Mustard Seeds"            | Allison Park PA  |    10 |   0.67 |      |
+|   48 | Jackson Smith             | Kennebec Valley A/G                         | Chelsea, ME      |       |   0.00 |      |
+|   48 | Sydney Avery              | Kennebec Valley A/G                         | Chelsea, ME      |       |   0.00 |      |
+|   48 | Casey Thurber             | Pocono Community Church "Midnight Shadows"  | Mt Pocono, PA    |       |   0.00 |      |
+|   48 | Abriana Todd              | Vailsburg A/G "Hungry and Thirsty"          | Newark, NJ       |       |   0.00 |      |
+|   49 | Sarah Lawrence            | Prince of Peace Church                      | Sanford,ME       |   -10 |  -0.67 |      |

--- a/_pages/history/2013/regionals/northwest.md
+++ b/_pages/history/2013/regionals/northwest.md
@@ -1,0 +1,103 @@
+---
+layout: page
+title: "2013 Northwest Regionals"
+permalink: /history/2013/regionals/northwest/
+date: "2013-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2013 Season
+    link: /history/2013/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team                   |    W |    L | Total |  Avg |
+| ---: | ---------------------- | ---: | ---: | ----: | ---: |
+|    1 | CPC-The A Team         |   10 |    - | 2,630 |  263 |
+|    2 | BNC-The 7th Drachma    |    7 |    3 | 2,295 |  230 |
+|    3 | CPC-Loosed on Earth    |    7 |    3 | 1,960 |  196 |
+|    4 | TLC-1*                 |    4 |    6 |   810 |   81 |
+|    5 | NLR-Not Here           |    5 |    5 |   455 |   46 |
+|    6 | MAG-Chicks Under Wing  |    3 |    7 |   275 |   28 |
+|    7 | KLC-When Trouble Comes |    3 |    7 |   270 |   27 |
+|    8 | MAG-Unquenchable Fire  |    1 |    9 |   195 |   20 |
+
+\* Due to partial double round robin format, TLC-1 could finish no lower than 4th.
+
+### Individuals
+
+|    # | Quizzer             | Team                  | Total |  Avg |
+| ---: | ------------------- | --------------------- | ----: | ---: |
+|    1 | Abby Rogers         | CPC-The A Team        | 1,360 |  136 |
+|    2 | Josh Gallo          | BNC-The 7th Drachma   | 1,135 |  114 |
+|    3 | E J Olsen           | CPC-Loosed on Earth   |   795 |   80 |
+|    4 | Jacob Schumacher    | CPC-Loosed on Earth   |   780 |   78 |
+|    5 | Adi Purohith        | CPC-The A Team        |   765 |   77 |
+|    6 | Abigail Peterson    | TLC-1                 |   690 |   69 |
+|    7 | Damon Comfort       | BNC-The 7th Drachma   |   650 |   65 |
+|    8 | Ani Purohith        | CPC-The A Team        |   510 |   51 |
+|    9 | Kara Gallo          | BNC-The 7th Drachma   |   500 |   50 |
+|   10 | Samuel Schumacher   | CPC-Loosed on Earth   |   315 |   32 |
+|   11 | Liana Papini        | NLR-Not Here          |   190 |   19 |
+|   12 | Keaton Gillihan     | KLC-When Trouble      |   170 |   17 |
+|   13 | Wesley Jacobs       | NLR-Not Here          |   160 |   16 |
+|   14 | Marissa Emerson     | MAG-Chicks Under Wing |   145 |   15 |
+|   15 | Arie Emerson        | MAG-Chicks Under Wing |   130 |   13 |
+|   16 | Christopher Kreiner | MAG-Unquenchable Fire |    95 |   10 |
+|   17 | Iva Papini          | NLR-Not Here          |    95 |   10 |
+|   18 | Missa Quintana      | KLC-When Trouble      |    80 |    8 |
+|   19 | Nicole Kreiner      | MAG-Unquenchable Fire |    80 |    8 |
+|   20 | Ashlen Staub        | TLC-1                 |    70 |    7 |
+|   21 | Jacob Yanez         | TLC-1                 |    60 |    6 |
+|   22 | Andre' Nicolov      | CPC-Loosed on Earth   |    50 |    5 |
+|   23 | Cameron Hale        | MAG-Unquenchable Fire |    20 |    2 |
+|   24 | Jonathan Roberts    | CPC-Loosed on Earth   |    20 |    2 |
+|   25 | Macy Olson          | KLC-When Trouble      |    20 |    2 |
+|   26 | Nolan Griggs        | NLR-Not Here          |    10 |    1 |
+|   27 | Daniel Gallo        | BNC-The 7th Drachma   |     5 |    1 |
+|   28 | Paloma Betrisey     | BNC-The 7th Drachma   |     5 |    1 |
+|   29 | Anita Jaganath      | CPC-Loosed on Earth   |     - |    - |
+|   30 | Enrique Yanez       | TLC-1                 |     - |    - |
+|   31 | Gabriella Umphenour | TLC-1                 |     - |    - |
+|   32 | Kristina Hisel      | KLC-When Trouble      |     - |    - |
+|   33 | Stuart Jacobs       | NLR-Not Here          |     - |    - |
+|   34 | Toree Hale          | MAG-Chicks Under Wing |     - |    - |
+
+## Middle School Division
+
+### Teams
+
+|    # | Team                    |    W |    L | Total |  Avg |
+| ---: | ----------------------- | ---: | ---: | ----: | ---: |
+|    1 | CPC-Widely Circulated   |   10 |    - | 2,760 |  276 |
+|    2 | CPC-Well Known          |    8 |    2 | 1,445 |  145 |
+|    3 | MAG-Well Known Prisoner |    5 |    5 |   835 |   84 |
+|    4 | KLC-Armed With Swords   |    4 |    6 |   520 |   52 |
+|    5 | TLC-2                   |    3 |    7 |   435 |   44 |
+|    6 | SAG-Skinny Jeans        |    - |   10 |   120 |   12 |
+
+### Individuals
+
+|    # | Quizzer           | Team                    | Total |  Avg |
+| ---: | ----------------- | ----------------------- | ----: | ---: |
+|    1 | Jackson Houser    | CPC-Widely Circulated   | 1,165 |  117 |
+|    2 | Joshua Roberts    | CPC-Widely Circulated   |   965 |   97 |
+|    3 | Johan West        | CPC-Widely Circulated   |   630 |   63 |
+|    4 | Raychael Bertrand | CPC-Well Known          |   595 |   60 |
+|    5 | Jessica Kreiner   | MAG-Well Known Prisoner |   450 |   45 |
+|    6 | Jenna Roberts     | CPC-Well Known          |   445 |   45 |
+|    7 | Eva Baldwin       | CPC-Well Known          |   415 |   42 |
+|    8 | Hadassah Gurn     | MAG-Well Known Prisoner |   385 |   39 |
+|    9 | Jake Wright       | KLC-Armed With Swords   |   355 |   36 |
+|   10 | Seth Donaldson    | TLC-2                   |   220 |   22 |
+|   11 | Samuel Dawson     | TLC-2                   |   215 |   22 |
+|   12 | Miguel Lopez      | KLC-Armed With Swords   |   165 |   17 |
+|   13 | Laura Elmore      | SAG-Skinny Jeans        |    85 |    9 |
+|   14 | Hannah Feliciano  | SAG-Skinny Jeans        |    50 |    5 |
+|   15 | Bekah Thiessen    | KLC-Armed With Swords   |     - |    - |
+|   16 | Jazmine Hodge     | SAG-Skinny Jeans        |   -15 |   -2 |

--- a/_pages/history/2013/regionals/south-central.md
+++ b/_pages/history/2013/regionals/south-central.md
@@ -18,54 +18,63 @@ menubar_toc_static:
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
-| #  | Team                   | Church                | W/L | Total | Avg    |
-|---:|------------------------|-----------------------|-----|------:|-------:|
-| 1  | The Coming Wrath       | Owasso First          | 9/0 | 2170  | 241.11 |
-| 2  | Spring First Assembly  | Spring First Assembly | 7/2 | 1660  | 184.44 |
-| 3  | Purple Ducks           | Highpointe            | 7/2 | 1840  | 204.44 |
-| 4  | They Don't Wash        | Muskogee First        | 6/3 | 1660  | 184.44 |
-| 5  | Christian Temple       | Christian Temple      | 6/3 | 1050  | 116.67 |
-| 6  | Trinity                | Trinity               | 4/5 | 765   | 85.00  |
-| 7  | Braeswood A            | Braeswood A/G         | 3/6 | 475   | 52.78  |
-| 8  | The Bridge             | The Bridge            | 2/7 | 160   | 17.78  |
-| 9  | Lakeshore Lightning    | Lakeshore Church      | 1/8 | 145   | 16.11  |
-| 10 | GracePointe Bible Quiz | Winfield, KS          | 0/9 | 60    | 6.67   |
+|    # | Team                   | Church                | W/L | Total |    Avg |
+| ---: | ---------------------- | --------------------- | --- | ----: | -----: |
+|    1 | The Coming Wrath       | Owasso First          | 9/0 |  2170 | 241.11 |
+|    2 | Spring First Assembly  | Spring First Assembly | 7/2 |  1660 | 184.44 |
+|    3 | Purple Ducks           | Highpointe            | 7/2 |  1840 | 204.44 |
+|    4 | They Don't Wash        | Muskogee First        | 6/3 |  1660 | 184.44 |
+|    5 | Christian Temple       | Christian Temple      | 6/3 |  1050 | 116.67 |
+|    6 | Trinity                | Trinity               | 4/5 |   765 |  85.00 |
+|    7 | Braeswood A            | Braeswood A/G         | 3/6 |   475 |  52.78 |
+|    8 | The Bridge             | The Bridge            | 2/7 |   160 |  17.78 |
+|    9 | Lakeshore Lightning    | Lakeshore Church      | 1/8 |   145 |  16.11 |
+|   10 | GracePointe Bible Quiz | Winfield, KS          | 0/9 |    60 |   6.67 |
 
 ### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
-| #  | Quizzer             | Team                   | Church                | Total | Avg    | QO |
-|---:|---------------------|------------------------|-----------------------|------:|-------:|---:|
-| 1  | Daniel Wagner       | The Coming Wrath       | Owasso First          | 1245  | 138.33 | 9  |
-| 2  | Jacob Wyatt         | Spring First Assembly  | Spring First Assembly | 1045  | 116.11 | 8  |
-| 3  | David Meddaugh      | They Don't Wash        | Muskogee First        | 1030  | 114.44 | 9  |
-| 4  | Micah Samuelson     | Purple Ducks           | Highpointe            | 1025  | 113.89 | 9  |
-| 5  | Luke Wagner         | The Coming Wrath       | Owasso First          | 835   | 92.78  | 8  |
-| 6  | Sabrina Burkhaltder | Trinity                | Trinity               | 715   | 79.44  | 6  |
-| 7  | Tim Pyle            | Christian Temple       | Christian Temple      | 570   | 63.33  | 5  |
-| 8  | Paul Meddaugh       | They Don't Wash        | Muskogee First        | 495   | 55.00  | 5  |
-| 9  | Connor McGraw       | Purple Ducks           | Highpointe            | 480   | 53.33  | 5  |
-| 10 | Andrew Roach        | Christian Temple       | Christian Temple      | 470   | 52.22  | 6  |
-| 11 | Mitt Wyatt          | Spring First Assembly  | Spring First Assembly | 340   | 37.78  | 3  |
-| 12 | John David Sullivan | Spring First Assembly  | Spring First Assembly | 280   | 31.11  | 3  |
-| 13 | Deborah Okoro       | Braeswood A            | Braeswood A/G         | 210   | 23.33  | 1  |
-| 14 | Deborah Odefey      | Purple Ducks           | Highpointe            | 190   | 21.11  | 1  |
-| 15 | Matthew Samuelson   | Purple Ducks           | Highpointe            | 145   | 16.11  |    |
-| 16 | Mary Meddaugh       | They Don't Wash        | Muskogee First        | 140   | 15.56  |    |
-| 17 | Joy Umoekpo         | Braeswood A            | Braeswood A/G         | 135   | 15.00  |    |
-| 18 | Uzondu Okoro        | Braeswood A            | Braeswood A/G         | 130   | 14.44  | 1  |
-| 19 | Matthew Garman      | The Coming Wrath       | Owasso First          | 90    | 10.00  |    |
-| 20 | Daniel Holland      | GracePointe Bible Quiz | Winfield, KS          | 75    | 8.33   |    |
-| 21 | Samuel Galloway     | Lakeshore Lightning    | Lakeshore Church      | 70    | 7.78   |    |
-| 22 | JJ Campbell         | The Bridge             | The Bridge            | 60    | 6.67   |    |
-| 23 | Susanna Ferguson    | Trinity                | Trinity               | 55    | 6.11   |    |
-| 24 | Hannah Moer         | Lakeshore Lightning    | Lakeshore Church      | 50    | 5.56   |    |
-| 24 | Alyssa Campbell     | The Bridge             | The Bridge            | 50    | 5.56   |    |
-| 24 | Audrey Campbell     | The Bridge             | The Bridge            | 50    | 5.56   |    |
-| 25 | Katie Galloway      | Lakeshore Lightning    | Lakeshore Church      | 30    | 3.33   |    |
-| 26 | Sarak Phillips      | Christian Temple       | Christian Temple      | 10    | 1.11   |    |
-
+|    # | Quizzer             | Team                   | Church                | Total |    Avg |   QO |
+| ---: | ------------------- | ---------------------- | --------------------- | ----: | -----: | ---: |
+|    1 | Daniel Wagner       | The Coming Wrath       | Owasso First          |  1245 | 138.33 |    9 |
+|    2 | Jacob Wyatt         | Spring First Assembly  | Spring First Assembly |  1045 | 116.11 |    8 |
+|    3 | David Meddaugh      | They Don't Wash        | Muskogee First        |  1030 | 114.44 |    9 |
+|    4 | Micah Samuelson     | Purple Ducks           | Highpointe            |  1025 | 113.89 |    9 |
+|    5 | Luke Wagner         | The Coming Wrath       | Owasso First          |   835 |  92.78 |    8 |
+|    6 | Sabrina Burkhaltder | Trinity                | Trinity               |   715 |  79.44 |    6 |
+|    7 | Tim Pyle            | Christian Temple       | Christian Temple      |   570 |  63.33 |    5 |
+|    8 | Paul Meddaugh       | They Don't Wash        | Muskogee First        |   495 |     55 |    5 |
+|    9 | Connor McGraw       | Purple Ducks           | Highpointe            |   480 |  53.33 |    5 |
+|   10 | Andrew Roach        | Christian Temple       | Christian Temple      |   470 |  52.22 |    6 |
+|   11 | Mitt Wyatt          | Spring First Assembly  | Spring First Assembly |   340 |  37.78 |    3 |
+|   12 | John David Sullivan | Spring First Assembly  | Spring First Assembly |   280 |  31.11 |    3 |
+|   13 | Deborah Okoro       | Braeswood A            | Braeswood A/G         |   210 |  23.33 |    1 |
+|   14 | Deborah Odefey      | Purple Ducks           | Highpointe            |   190 |  21.11 |    1 |
+|   15 | Matthew Samuelson   | Purple Ducks           | Highpointe            |   145 |  16.11 |      |
+|   16 | Mary Meddaugh       | They Don't Wash        | Muskogee First        |   140 |  15.56 |      |
+|   17 | Joy Umoekpo         | Braeswood A            | Braeswood A/G         |   135 |     15 |      |
+|   18 | Uzondu Okoro        | Braeswood A            | Braeswood A/G         |   130 |  14.44 |    1 |
+|   19 | Matthew Garman      | The Coming Wrath       | Owasso First          |    90 |     10 |      |
+|   20 | Daniel Holland      | GracePointe Bible Quiz | Winfield, KS          |    75 |   8.33 |      |
+|   21 | Samuel Galloway     | Lakeshore Lightning    | Lakeshore Church      |    70 |   7.78 |      |
+|   22 | JJ Campbell         | The Bridge             | The Bridge            |    60 |   6.67 |      |
+|   23 | Susanna Ferguson    | Trinity                | Trinity               |    55 |   6.11 |      |
+|   24 | Hannah Moer         | Lakeshore Lightning    | Lakeshore Church      |    50 |   5.56 |      |
+|   24 | Alyssa Campbell     | The Bridge             | The Bridge            |    50 |   5.56 |      |
+|   24 | Audrey Campbell     | The Bridge             | The Bridge            |    50 |   5.56 |      |
+|   25 | Katie Galloway      | Lakeshore Lightning    | Lakeshore Church      |    30 |   3.33 |      |
+|   26 | Sarak Phillips      | Christian Temple       | Christian Temple      |    10 |   1.11 |      |
+|   27 | Trivett Jones       | Lakeshore Lightning    | Lakeshore Church      |       |      0 |      |
+|   27 | Danny Kelton        | Lakeshore Lightning    | Lakeshore Church      |       |      0 |      |
+|   27 | Aiyeem Kelton       | Lakeshore Lightning    | Lakeshore Church      |       |      0 |      |
+|   27 | Genika Nzenwa       | Braeswood A            | Braeswood A/G         |       |      0 |      |
+|   27 | Elizabeth Hammes    | Trinity                | Trinity               |       |      0 |      |
+|   27 | Emily Urbina        | Purple Ducks           | Highpointe            |       |      0 |      |
+|   27 | Kenny Ukoh          | Braeswood A            | Braeswood A/G         |       |      0 |      |
+|   27 | Abigail Cohen       | Spring First Assembly  | Spring First Assembly |       |      0 |      |
+|   28 | Dakota Holland      | GracePointe Bible Quiz | Winfield, KS          |   -10 |  -1.11 |      |
+|   29 | Mason Singer        | GracePointe Bible Quiz | Winfield, KS          |    -5 |  -0.56 |      |
 
 ## MSQ League
 
@@ -73,36 +82,37 @@ menubar_toc_static:
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
-| # | Team                  | Church         | W/L  | Total | Avg    |
-|--:|-----------------------|----------------|------|------:|-------:|
-| 1 | Czech Tech            | Muskogee First | 9/1  | 2055  | 205.50 |
-| 2 | Pure in Heart         | Noble          | 7/3  | 1310  | 131.00 |
-| 3 | Jesus Freaks          | Braeswood A/G  | 7/3  | 1210  | 121.00 |
-| 4 | Bible Olympians       | Braeswood A/G  | 4/6  | 950   | 95.00  |
-| 5 | GENES                 | Owasso First   | 3/7  | 810   | 81.00  |
-| 6 | Family Worship Center | El Dorado      | 0/10 | 65    | 6.50   |
+|    # | Team                  | Church         | W/L  | Total |    Avg |
+| ---: | --------------------- | -------------- | ---- | ----: | -----: |
+|    1 | Czech Tech            | Muskogee First | 9/1  |  2055 | 205.50 |
+|    2 | Pure in Heart         | Noble          | 7/3  |  1310 | 131.00 |
+|    3 | Jesus Freaks          | Braeswood A/G  | 7/3  |  1210 | 121.00 |
+|    4 | Bible Olympians       | Braeswood A/G  | 4/6  |   950 |  95.00 |
+|    5 | GENES                 | Owasso First   | 3/7  |   810 |  81.00 |
+|    6 | Family Worship Center | El Dorado      | 0/10 |    65 |   6.50 |
 
 ### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
-| #  | Quizzer           | Team                  | Church         | Total | Avg    | QO |
-|---:|-------------------|-----------------------|----------------|------:|-------:|---:|
-| 1  | Josiah Schwarz    | Czech Tech            | Muskogee First | 1225  | 122.50 | 9  |
-| 2  | Zach Schwarz      | Czech Tech            | Muskogee First | 660   | 66.00  | 6  |
-| 3  | Talita Kamletz    | GENES                 | Owasso First   | 640   | 64.00  | 5  |
-| 4  | Rachel Mgbeike    | Jesus Freaks          | Braeswood A/G  | 625   | 62.50  | 5  |
-| 5  | Taylor Baker      | Pure in Heart         | Noble          | 560   | 56.00  | 5  |
-| 6  | Britney Pitts     | Pure in Heart         | Noble          | 455   | 45.50  | 5  |
-| 7  | Jeremy Mgbeike    | Bible Olympians       | Braeswood A/G  | 435   | 43.50  | 3  |
-| 8  | Stephanie Oyolu   | Jesus Freaks          | Braeswood A/G  | 395   | 39.50  | 2  |
-| 9  | Osi Nwogu         | Bible Olympians       | Braeswood A/G  | 330   | 33.00  | 2  |
-| 10 | Grace Smith       | Pure in Heart         | Noble          | 305   | 30.50  | 2  |
-| 11 | Taylor Ellis      | Jesus Freaks          | Braeswood A/G  | 190   | 19.00  | 1  |
-| 11 | Jose Lopez Jr.    | Bible Olympians       | Braeswood A/G  | 190   | 19.00  | 1  |
-| 12 | Izzy Lashley-Bobb | Czech Tech            | Muskogee First | 170   | 17.00  | 1  |
-| 13 | Matt Rangle       | GENES                 | Owasso First   | 90    | 9.00   | 1  |
-| 14 | Alexis Glover     | GENES                 | Owasso First   | 80    | 8.00   |    |
-| 15 | Chris Rauth       | Family Worship Center | El Dorado      | 55    | 5.50   |    |
-| 16 | Jeremiah Rauth    | Family Worship Center | El Dorado      | 10    | 1.00   |    |
-| 17 | Zach Thurmon      | Family Worship Center | El Dorado      | 5     | .50    |    |
+|    # | Quizzer            | Team                  | Church         | Total |   Avg |   QO |
+| ---: | ------------------ | --------------------- | -------------- | ----: | ----: | ---: |
+|    1 | Josiah Schwarz     | Czech Tech            | Muskogee First |  1225 | 122.5 |    9 |
+|    2 | Zach Schwarz       | Czech Tech            | Muskogee First |   660 |    66 |    6 |
+|    3 | Talita Kamletz     | GENES                 | Owasso First   |   640 |    64 |    5 |
+|    4 | Rachel Mgbeike     | Jesus Freaks          | Braeswood A/G  |   625 |  62.5 |    5 |
+|    5 | Taylor Baker       | Pure in Heart         | Noble          |   560 |    56 |    5 |
+|    6 | Britney Pitts      | Pure in Heart         | Noble          |   455 |  45.5 |    5 |
+|    7 | Jeremy Mgbeike     | Bible Olympians       | Braeswood A/G  |   435 |  43.5 |    3 |
+|    8 | Stephanie Oyolu    | Jesus Freaks          | Braeswood A/G  |   395 |  39.5 |    2 |
+|    9 | Osi Nwogu          | Bible Olympians       | Braeswood A/G  |   330 |    33 |    2 |
+|   10 | Grace Smith        | Pure in Heart         | Noble          |   305 |  30.5 |    2 |
+|   11 | Taylor Ellis       | Jesus Freaks          | Braeswood A/G  |   190 |    19 |    1 |
+|   11 | Jose Lopez Jr.     | Bible Olympians       | Braeswood A/G  |   190 |    19 |    1 |
+|   12 | Izzy Lashley- Bobb | Czech Tech            | Muskogee First |   170 |    17 |    1 |
+|   13 | Matt Rangle        | GENES                 | Owasso First   |    90 |     9 |    1 |
+|   14 | Alexis Glover      | GENES                 | Owasso First   |    80 |     8 |      |
+|   15 | Chris Rauth        | Family Worship Center | El Dorado      |    55 |   5.5 |      |
+|   16 | Jeremiah Rauth     | Family Worship Center | El Dorado      |    10 |     1 |      |
+|   17 | Zach Thurmon       | Family Worship Center | El Dorado      |     5 |   0.5 |      |
+|   18 | Megan Pitts        | Pure in Heart         | Noble          |   -10 |    -1 |      |

--- a/_pages/history/2013/regionals/southeast.md
+++ b/_pages/history/2013/regionals/southeast.md
@@ -12,61 +12,7 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## A League #1
-
-### Teams
-
-*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
-
-| #  | Team                   | Church                | W/L | Total | Avg    |
-|---:|------------------------|-----------------------|-----|------:|-------:|
-| 1  | The Coming Wrath       | Owasso First          | 9/0 | 2170  | 241.11 |
-| 2  | Spring First Assembly  | Spring First Assembly | 7/2 | 1660  | 184.44 |
-| 3  | Purple Ducks           | Highpointe            | 7/2 | 1840  | 204.44 |
-| 4  | They Don't Wash        | Muskogee First        | 6/3 | 1660  | 184.44 |
-| 5  | Christian Temple       | Christian Temple      | 6/3 | 1050  | 116.67 |
-| 6  | Trinity                | Trinity               | 4/5 | 765   | 85.00  |
-| 7  | Braeswood A            | Braeswood A/G         | 3/6 | 475   | 52.78  |
-| 8  | The Bridge             | The Bridge            | 2/7 | 160   | 17.78  |
-| 9  | Lakeshore Lightning    | Lakeshore Church      | 1/8 | 145   | 16.11  |
-| 10 | GracePointe Bible Quiz | Winfield, KS          | 0/9 | 60    | 6.67   |
-
-### Individuals
-
-*Ties broken by QuizOuts (Scores sorted by TOTAL)*
-
-| #  | Quizzer             | Team                   | Church                | Total | Avg    | QO |
-|---:|---------------------|------------------------|-----------------------|------:|-------:|---:|
-| 1  | Daniel Wagner       | The Coming Wrath       | Owasso First          | 1245  | 138.33 | 9  |
-| 2  | Jacob Wyatt         | Spring First Assembly  | Spring First Assembly | 1045  | 116.11 | 8  |
-| 3  | David Meddaugh      | They Don't Wash        | Muskogee First        | 1030  | 114.44 | 9  |
-| 4  | Micah Samuelson     | Purple Ducks           | Highpointe            | 1025  | 113.89 | 9  |
-| 5  | Luke Wagner         | The Coming Wrath       | Owasso First          | 835   | 92.78  | 8  |
-| 6  | Sabrina Burkhaltder | Trinity                | Trinity               | 715   | 79.44  | 6  |
-| 7  | Tim Pyle            | Christian Temple       | Christian Temple      | 570   | 63.33  | 5  |
-| 8  | Paul Meddaugh       | They Don't Wash        | Muskogee First        | 495   | 55.00  | 5  |
-| 9  | Connor McGraw       | Purple Ducks           | Highpointe            | 480   | 53.33  | 5  |
-| 10 | Andrew Roach        | Christian Temple       | Christian Temple      | 470   | 52.22  | 6  |
-| 11 | Mitt Wyatt          | Spring First Assembly  | Spring First Assembly | 340   | 37.78  | 3  |
-| 12 | John David Sullivan | Spring First Assembly  | Spring First Assembly | 280   | 31.11  | 3  |
-| 13 | Deborah Okoro       | Braeswood A            | Braeswood A/G         | 210   | 23.33  | 1  |
-| 14 | Deborah Odefey      | Purple Ducks           | Highpointe            | 190   | 21.11  | 1  |
-| 15 | Matthew Samuelson   | Purple Ducks           | Highpointe            | 145   | 16.11  |    |
-| 16 | Mary Meddaugh       | They Don't Wash        | Muskogee First        | 140   | 15.56  |    |
-| 17 | Joy Umoekpo         | Braeswood A            | Braeswood A/G         | 135   | 15.00  |    |
-| 18 | Uzondu Okoro        | Braeswood A            | Braeswood A/G         | 130   | 14.44  | 1  |
-| 19 | Matthew Garman      | The Coming Wrath       | Owasso First          | 90    | 10.00  |    |
-| 20 | Daniel Holland      | GracePointe Bible Quiz | Winfield, KS          | 75    | 8.33   |    |
-| 21 | Samuel Galloway     | Lakeshore Lightning    | Lakeshore Church      | 70    | 7.78   |    |
-| 22 | JJ Campbell         | The Bridge             | The Bridge            | 60    | 6.67   |    |
-| 23 | Susanna Ferguson    | Trinity                | Trinity               | 55    | 6.11   |    |
-| 24 | Hannah Moer         | Lakeshore Lightning    | Lakeshore Church      | 50    | 5.56   |    |
-| 24 | Alyssa Campbell     | The Bridge             | The Bridge            | 50    | 5.56   |    |
-| 24 | Audrey Campbell     | The Bridge             | The Bridge            | 50    | 5.56   |    |
-| 25 | Katie Galloway      | Lakeshore Lightning    | Lakeshore Church      | 30    | 3.33   |    |
-| 26 | Sarak Phillips      | Christian Temple       | Christian Temple      | 10    | 1.11   |    |
-
-## A League #2
+## A Division
 
 ### Teams
 
@@ -122,47 +68,7 @@ menubar_toc_static:
 | 28 | Amy Bailey         | GA-2Snellville          | Evangel Community      | 5     | .56    |    |
 | 28 | Marcus Johnson     | GA-Midland              | Solid Rock A/G         | 5     | .56    |    |
 
-## MSQ League
-
-### Teams
-
-*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
-
-| # | Team                  | Church         | W/L  | Total | Avg    |
-|--:|-----------------------|----------------|------|------:|-------:|
-| 1 | Czech Tech            | Muskogee First | 9/1  | 2055  | 205.50 |
-| 2 | Pure in Heart         | Noble          | 7/3  | 1310  | 131.00 |
-| 3 | Jesus Freaks          | Braeswood A/G  | 7/3  | 1210  | 121.00 |
-| 4 | Bible Olympians       | Braeswood A/G  | 4/6  | 950   | 95.00  |
-| 5 | GENES                 | Owasso First   | 3/7  | 810   | 81.00  |
-| 6 | Family Worship Center | El Dorado      | 0/10 | 65    | 6.50   |
-
-### Individuals
-
-*Ties broken by QuizOuts (Scores sorted by TOTAL)*
-
-| #  | Quizzer           | Team                  | Church         | Total | Avg    | QO |
-|---:|-------------------|-----------------------|----------------|------:|-------:|---:|
-| 1  | Josiah Schwarz    | Czech Tech            | Muskogee First | 1225  | 122.50 | 9  |
-| 2  | Zach Schwarz      | Czech Tech            | Muskogee First | 660   | 66.00  | 6  |
-| 3  | Talita Kamletz    | GENES                 | Owasso First   | 640   | 64.00  | 5  |
-| 4  | Rachel Mgbeike    | Jesus Freaks          | Braeswood A/G  | 625   | 62.50  | 5  |
-| 5  | Taylor Baker      | Pure in Heart         | Noble          | 560   | 56.00  | 5  |
-| 6  | Britney Pitts     | Pure in Heart         | Noble          | 455   | 45.50  | 5  |
-| 7  | Jeremy Mgbeike    | Bible Olympians       | Braeswood A/G  | 435   | 43.50  | 3  |
-| 8  | Stephanie Oyolu   | Jesus Freaks          | Braeswood A/G  | 395   | 39.50  | 2  |
-| 9  | Osi Nwogu         | Bible Olympians       | Braeswood A/G  | 330   | 33.00  | 2  |
-| 10 | Grace Smith       | Pure in Heart         | Noble          | 305   | 30.50  | 2  |
-| 11 | Taylor Ellis      | Jesus Freaks          | Braeswood A/G  | 190   | 19.00  | 1  |
-| 11 | Jose Lopez Jr.    | Bible Olympians       | Braeswood A/G  | 190   | 19.00  | 1  |
-| 12 | Izzy Lashley-Bobb | Czech Tech            | Muskogee First | 170   | 17.00  | 1  |
-| 13 | Matt Rangle       | GENES                 | Owasso First   | 90    | 9.00   | 1  |
-| 14 | Alexis Glover     | GENES                 | Owasso First   | 80    | 8.00   |    |
-| 15 | Chris Rauth       | Family Worship Center | El Dorado      | 55    | 5.50   |    |
-| 16 | Jeremiah Rauth    | Family Worship Center | El Dorado      | 10    | 1.00   |    |
-| 17 | Zach Thurmon      | Family Worship Center | El Dorado      | 5     | .50    |    |
-
-## Middle School
+## Middle School Division
 
 ### Teams
 

--- a/_pages/history/2013/regionals/southwest.md
+++ b/_pages/history/2013/regionals/southwest.md
@@ -1,0 +1,27 @@
+---
+layout: page
+title: "2013 Southwest Regionals"
+permalink: /history/2013/regionals/southwest/
+date: "2013-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2013 Season
+    link: /history/2013/
+    icon: fas fa-home
+---
+
+## Teams
+
+| Team                       | W\L  | Total |   Avg |
+| -------------------------- | ---- | ----: | ----: |
+| Living Hope Church*        | 9\1  |  1385 | 138.5 |
+| Irvine Samoan              | 9\1  |  1500 |   150 |
+| Church at Briargate        | 4\6  |   970 |    97 |
+| Newport Mesa               | 3\7  |   685 |  68.5 |
+| North Valley A/G           | 3\7  |   605 |  60.5 |
+| North Scottsdale Christian | 2\8  |   790 |    79 |
+| Anaheim CC                 | 0\12 |    55 |   5.5 |
+
+\* Tie broken by points.

--- a/_pages/history/2014/regionals/great-lakes.md
+++ b/_pages/history/2014/regionals/great-lakes.md
@@ -1,0 +1,98 @@
+---
+layout: page
+title: "2014 Great Lakes Regionals"
+permalink: /history/2014/regionals/great-lakes/
+date: "2014-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2014 Season
+    link: /history/2014/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+|    # | Team                                          |    W |    L | Total |   Avg |
+| ---: | --------------------------------------------- | ---: | ---: | ----: | ----: |
+|    1 | #5 "Without Paying For it", Grant-MI          |   12 |    1 |  1945 | 149.6 |
+|   2* | #1 Lakeview, Indianapolis-IN                  |   10 |    3 |  1785 | 137.3 |
+|   3* | #6 "Chosen", Columbiaville-MI                 |   10 |    3 |  1520 | 116.9 |
+|   4* | #9 "Five Guys", Lexington-KY                  |   10 |    3 |  1320 | 101.5 |
+|   5^ | #7 First A/G Greater Lansing, East Lansing-MI |    9 |    4 |  1345 | 103.5 |
+|   6^ | #8 Trinity Assembly, Georgetown-KY            |    9 |    4 |  1335 | 102.7 |
+|    7 | #11 Radiant Life, Dublin-OH                   |    8 |    5 |  1685 | 129.6 |
+|    8 | #3 Southgate Church, South Bend-IN            |    7 |    6 |  1445 | 111.2 |
+|    9 | #10 Dayspring, Bowling Green-OH               |    5 |    8 |   935 |  71.9 |
+|   10 | #4 "Unchained", Lakeville-IN                  |    4 |    9 |   590 |  45.4 |
+|   11 | #2 First Assembly, Lafayette-IN               |    3 |   10 |   805 |  61.9 |
+|   12 | #12 Painesville A/G, Painesville-OH           |    3 |   10 |   800 |  61.5 |
+|   13 | #14 "Ninja's of the Word", Sugar Grove-IL     |    1 |   12 |   280 |  21.5 |
+|   14 | #13 Stone Church, Orland Park-IL              |    0 |   13 |   165 |  12.7 |
+
+\* No head-to-head winner, tie break determined by point average.\
+^ Tie break determined by head-to-head, #7 defeated #8 by 95 to 45.
+
+### Individuals
+
+|    # | Quizzer            | Church                                     |   Avg | Total | QO Fwd | QO Bk |
+| ---: | ------------------ | ------------------------------------------ | ----: | ----: | -----: | ----: |
+|    1 | James Carey        | Lakeview, Indianapolis-IN                  | 113.1 |  1470 |     13 |     0 |
+|    2 | Keilah Rodgers     | Radiant Life, Dublin-OH                    |  96.2 |  1250 |     11 |     2 |
+|    3 | Kenadee Schrock    | Southgate Church, South Bend-IN            |  78.5 |  1020 |      9 |     1 |
+|    4 | Seth Smith         | "Five Guys", Lexington-KY                  |  76.2 |   990 |      9 |     1 |
+|    5 | Faith Pryer        | "Without Paying For it", Grant-MI          |  74.6 |   970 |      7 |     4 |
+|    6 | Christopher Turner | Trinity Assembly, Georgetown-KY            |    70 |   910 |      7 |     1 |
+|    7 | Joey Huntley Jr    | "Chosen", Columbiaville-MI                 |  58.8 |   765 |      6 |     3 |
+|    8 | Claire Convis      | First A/G Greater Lansing, East Lansing-MI |  57.3 |   745 |      6 |     1 |
+|    9 | Sheila Peters      | "Chosen", Columbiaville-MI                 |  55.8 |   725 |      5 |     3 |
+|   10 | David Kim          | First Assembly, Lafayette-IN               |  53.1 |   690 |      6 |     4 |
+|   11 | Brianna Albrecht   | Dayspring, Bowling Green-OH                |  51.5 |   670 |      5 |     2 |
+|   12 | David Pryer        | "Without Paying For it", Grant-MI          |  49.6 |   645 |      8 |     2 |
+|   13 | Celah Convis       | First A/G Greater Lansing, East Lansing-MI |  42.7 |   555 |      3 |     1 |
+|   14 | Josh Francis       | "Unchained", Lakeville-IN                  |  36.2 |   470 |      1 |     1 |
+|   15 | Caleb Rogenthien   | Painesville A/G, Painesville-OH            |  32.7 |   425 |      1 |     0 |
+|   16 | Kyla Schrock       | Southgate Church, South Bend-IN            |  31.2 |   405 |      5 |     2 |
+|   17 | Zack Chemacki      | Radiant Life, Dublin-OH                    |    30 |   390 |      3 |     0 |
+|   18 | Emily Brown        | Painesville A/G, Painesville-OH            |  28.8 |   375 |      1 |     0 |
+|   19 | John Pryer         | "Without Paying For it", Grant-MI          |  26.5 |   345 |      1 |     0 |
+|   20 | Courtney Turner    | Trinity Assembly, Georgetown-KY            |  23.5 |   305 |      0 |     0 |
+|   21 | Brayden Laakkonen  | "Five Guys", Lexington-KY                  |  21.9 |   285 |      1 |     1 |
+|   22 | Evan Kobylski      | Dayspring, Bowling Green-OH                |  20.4 |   265 |      1 |     0 |
+|   23 | Alisa Hodge        | Lakeview, Indianapolis-IN                  |  18.5 |   240 |      0 |     0 |
+|   24 | Caleb Czaja        | Stone Church, Orland Park-IL               |  13.1 |   170 |      0 |     0 |
+|   25 | Ezequiel Navarro   | "Ninja's of the Word", Sugar Grove-IL      |  12.3 |   160 |      0 |     0 |
+|   26 | Elijah Deaton      | Trinity Assembly, Georgetown-KY            |  11.9 |   155 |      0 |     0 |
+|   27 | Josh McCartney     | "Unchained", Lakeville-IN                  |  11.2 |   145 |      0 |     0 |
+|   28 | Luke Lydecker      | "Ninja's of the Word", Sugar Grove-IL      |   8.8 |   115 |      0 |     1 |
+|   29 | Katie Dowers       | Lakeview, Indianapolis-IN                  |   6.2 |    80 |      0 |     0 |
+|   30 | Jack Bradford      | First Assembly, Lafayette-IN               |   4.6 |    60 |      0 |     0 |
+|   31 | Josiah Netherton   | First Assembly, Lafayette-IN               |   4.2 |    55 |      0 |     0 |
+|   32 | Matthew Walker     | "Five Guys", Lexington-KY                  |   3.5 |    45 |      0 |     0 |
+|   33 | Conner Bjerke      | Radiant Life, Dublin-OH                    |   3.5 |    45 |      0 |     0 |
+|   34 | Chase Buher        | First A/G Greater Lansing, East Lansing-MI |   2.7 |    35 |      0 |     0 |
+|   35 | Camryn Stuart      | Stone Church, Orland Park-IL               |   2.3 |    30 |      0 |     0 |
+|   36 | Luke Hollin        | "Chosen", Columbiaville-MI                 |   2.3 |    30 |      0 |     0 |
+|   37 | Eduenis Navarro    | "Ninja's of the Word", Sugar Grove-IL      |   1.9 |    25 |      0 |     0 |
+|   38 | Ashlynn Schrock    | Southgate Church, South Bend-IN            |   1.5 |    20 |      0 |     0 |
+|   39 | Tyler Bensen       | "Ninja's of the Word", Sugar Grove-IL      |   0.8 |    10 |      0 |     0 |
+|   40 | Austin Haar        | First A/G Greater Lansing, East Lansing-MI |   0.8 |    10 |      0 |     0 |
+|   41 | Alex McCracken     | "Five Guys", Lexington-KY                  |   0.4 |     5 |      0 |     0 |
+|   42 | Abigail Watkins    | Radiant Life, Dublin-OH                    |   0.4 |     5 |      0 |     0 |
+|   43 | Brooke Garcia      | Lakeview, Indianapolis-IN                  |     0 |     0 |      0 |     0 |
+|   44 | Kiley Dowers       | Lakeview, Indianapolis-IN                  |     0 |     0 |      0 |     0 |
+|   45 | Faith Spiteri      | "Unchained", Lakeville-IN                  |     0 |     0 |      0 |     0 |
+|   46 | TJ Craig           | "Unchained", Lakeville-IN                  |     0 |     0 |      0 |     0 |
+|   47 | Megan Dyke         | "Without Paying For it", Grant-MI          |     0 |     0 |      0 |     0 |
+|   48 | Kyler Stephan      | Stone Church, Orland Park-IL               |     0 |     0 |      0 |     0 |
+|   49 | Sopulu Anidobu     | Stone Church, Orland Park-IL               |     0 |     0 |      0 |     0 |
+|   50 | Cheyenne Brown     | "Ninja's of the Word", Sugar Grove-IL      |     0 |     0 |      0 |     0 |
+|   51 | Marray Jenkins     | "Unchained", Lakeville-IN                  |  -0.8 |   -10 |      0 |     0 |
+|   52 | Eean Nelsen        | "Ninja's of the Word", Sugar Grove-IL      |  -0.8 |   -10 |      0 |     0 |
+|   53 | Andrew Miller      | "Unchained", Lakeville-IN                  |  -1.2 |   -15 |      0 |     0 |
+|   54 | Aaron Pryer        | "Without Paying For it", Grant-MI          |  -1.2 |   -15 |      0 |     0 |
+|   55 | Will Turner        | Trinity Assembly, Georgetown-KY            |  -2.3 |   -30 |      0 |     0 |
+|   56 | Sobe Anidobu       | Stone Church, Orland Park-IL               |  -3.1 |   -40 |      0 |     3 |

--- a/_pages/history/2014/regionals/gulf.md
+++ b/_pages/history/2014/regionals/gulf.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: "2014 Gulf Regionals"
+permalink: /history/2014/regionals/gulf/
+date: "2014-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2014 Season
+    link: /history/2014/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team                     |    W |    L | Total |  Avg |
+| ---: | ------------------------ | ---: | ---: | ----: | ---: |
+|    1 | Blazing Fire-Porter      |    6 |    0 |  1125 |  187 |
+|    2 | Awake & Sober-Griffith   |    4 |    2 |  1060 |  176 |
+|    3 | Evangel Temple KC        |    2 |    4 |   375 |   62 |
+|    4 | Labor Pains-Kings Chapel |    0 |    6 |   240 |   40 |
+
+### Individuals
+
+|    # | Quizzer          | Team                     | Total |  Avg |   QO |
+| ---: | ---------------- | ------------------------ | ----: | ---: | ---: |
+|    1 | Daniel Quick     | Blazing Fire-Porter      |   570 |   95 |    5 |
+|    2 | Travis Griessel  | Awake & Sober-Griffith   |   560 |   94 |    4 |
+|    3 | Leisl Jansen     | Awake & Sober-Griffith   |   355 |   60 |    2 |
+|    4 | Hannah Quick     | Blazing Fire-Porter      |   280 |   47 |    2 |
+|    5 | Zack Brookbank   | Evangel Temple KC        |   215 |   36 |    0 |
+|    6 | Kara Peters      | Labor Pains-Kings Chapel |   195 |   33 |    1 |
+|    7 | Jed Brookbank    | Evangel Temple KC        |   180 |   30 |    1 |
+|    8 | Kacie Garrison   | Blazing Fire-Porter      |   175 |   29 |    1 |
+|    9 | Jillian Griffith | Awake & Sober-Griffith   |   145 |   24 |    0 |
+|   10 | Josh Clark       | Blazing Fire-Porter      |   105 |   18 |    0 |
+|   11 | Brock Peters     | Labor Pains-Kings Chapel |    45 |    8 |    0 |
+|   12 | Tirzah Brookbank | Evangel Temple KC        |     0 |    0 |    0 |

--- a/_pages/history/2014/regionals/north-central.md
+++ b/_pages/history/2014/regionals/north-central.md
@@ -1,0 +1,109 @@
+---
+layout: page
+title: "2014 North Central Regionals"
+permalink: /history/2014/regionals/north-central/
+date: "2014-05-18"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2014 Season
+    link: /history/2014/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points. Scores sorted by Average.*
+
+|    # | Team             | Church                         |  W\L | Total |    Avg |
+| ---: | ---------------- | ------------------------------ | ---: | ----: | -----: |
+|    1 | Rapid City, SD   | Bethel Assembly of God         |  9\0 |  1305 |    145 |
+|    2 | Cedar Rapids, IA | First Assembly of God          |  7\2 |  1305 |    145 |
+|    3 | Gering, NE       | Northfield Assembly of God     |  6\3 |  1125 |    125 |
+|    4 | Plymouth, WI     | Christian Life Assembly of God |  6\3 |   965 | 107.22 |
+|    5 | Chariton, IA     | Truth Assembly of God          |  5\4 |   885 |  98.33 |
+|    6 | Racine, WI       | Racine Assembly of God         |  5\4 |   985 | 109.44 |
+|    7 | Bismarck, ND     | Evangel Assembly of God        |  3\6 |   530 |  58.89 |
+|    8 | Moberly, MO      | Moberly First Assembly of God  |  3\6 |   940 | 104.44 |
+|    9 | St. Cloud, MN    | Good News Church               |  1\8 |   345 |  38.33 |
+|   10 | Sioux Falls, SD  | First Assembly of God          |  0\9 |    10 |   1.11 |
+
+### Individuals
+
+*Ties broken by Quiz Outs. Scores sorted by Average.*
+
+|    # | Quizzer               | Team             | Church                         | Total |    Avg |   QO |
+| ---: | --------------------- | ---------------- | ------------------------------ | ----: | -----: | ---: |
+|    1 | Josiah Coder          | Cedar Rapids, IA | First Assembly of God          |  1120 | 124.44 |    9 |
+|    2 | Luke Hamilton         | Gering, NE       | Northfield Assembly of God     |  1070 | 118.89 |    9 |
+|    3 | Spenser Wilhelm       | Rapid City, SD   | Bethel Assembly of God         |   855 |     95 |    7 |
+|    4 | Lucas Hying           | Moberly, MO      | Moberly First Assembly of God  |   820 |  91.11 |    5 |
+|    5 | Matthias Plank        | Chariton, IA     | Truth Assembly of God          |   665 |  73.89 |    6 |
+|    6 | Alexi Turnage         | Plymouth, WI     | Christian Life Assembly of God |   500 |  55.56 |    3 |
+|    7 | Ryan Toeller          | Racine, WI       | Racine Assembly of God         |   475 |  52.78 |    4 |
+|    8 | Zachariah Turnage     | Plymouth, WI     | Christian Life Assembly of God |   465 |  51.67 |    5 |
+|    9 | Charlie Wilhelm       | Rapid City, SD   | Bethel Assembly of God         |   360 |     40 |    1 |
+|   10 | Victoria Anderson     | St. Cloud, MN    | Good News Church               |   330 |  36.67 |    2 |
+|   11 | Christian Jackson     | Racine, WI       | Racine Assembly of God         |   325 |  36.11 |    2 |
+|   12 | Danelle Ragains       | Bismarck, ND     | Evangel Assembly of God        |   285 |  31.67 |    2 |
+|   13 | Lucas Bender          | Bismarck, ND     | Evangel Assembly of God        |   210 |  23.33 |    1 |
+|   14 | Aaron Sullenger       | Chariton, IA     | Truth Assembly of God          |   185 |  20.56 |      |
+|   15 | Reanna Toeller        | Racine, WI       | Racine Assembly of God         |   160 |  17.78 |      |
+|   16 | Matthew Coder         | Cedar Rapids, IA | First Assembly of God          |   135 |     15 |      |
+|   17 | Nick Hying            | Moberly, MO      | Moberly First Assembly of God  |    90 |     10 |      |
+|   18 | Curtis Svenson        | Rapid City, SD   | Bethel Assembly of God         |    80 |   8.89 |      |
+|   19 | Trinity Ternes        | Bismarck, ND     | Evangel Assembly of God        |    55 |   6.11 |      |
+|   20 | Gideon Plank          | Chariton, IA     | Truth Assembly of God          |    50 |   5.56 |      |
+|   20 | Derek Kunkle          | Cedar Rapids, IA | First Assembly of God          |    50 |   5.56 |      |
+|   21 | Bethia Hamilton       | Gering, NE       | Northfield Assembly of God     |    35 |   3.89 |      |
+|   22 | Rebekah Toeller       | Racine, WI       | Racine Assembly of God         |    25 |   2.78 |      |
+|   23 | Quinton Risch         | Moberly, MO      | Moberly First Assembly of God  |    20 |   2.22 |      |
+|   23 | Levi Hamilton         | Gering, NE       | Northfield Assembly of God     |    20 |   2.22 |      |
+|   24 | Matthew McKinley      | Sioux Falls, SD  | First Assembly of God          |    15 |   1.67 |      |
+|   24 | Hadessah Loven        | St. Cloud, MN    | Good News Church               |    15 |   1.67 |      |
+|   25 | Bri McKinley          | Sioux Falls, SD  | First Assembly of God          |    10 |   1.11 |      |
+|   25 | Cyera Young           | Moberly, MO      | Moberly First Assembly of God  |    10 |   1.11 |      |
+|   25 | Micah Pennel          | Rapid City, SD   | Bethel Assembly of God         |    10 |   1.11 |      |
+|   25 | Jonathan Braden       | Sioux Falls, SD  | First Assembly of God          |    10 |   1.11 |      |
+|   26 | CJ Risch              | Moberly, MO      | Moberly First Assembly of God  |       |      0 |      |
+|   26 | Natalie Walnofer      | Sioux Falls, SD  | First Assembly of God          |       |      0 |      |
+|   26 | John Boeckers         | Plymouth, WI     | Christian Life Assembly of God |       |      0 |      |
+|   26 | Brandon Baer          | Racine, WI       | Racine Assembly of God         |       |      0 |      |
+|   26 | Johanna Nick          | Plymouth, WI     | Christian Life Assembly of God |       |      0 |      |
+|   27 | Chad Schwartz         | Sioux Falls, SD  | First Assembly of God          |   -25 |  -2.78 |      |
+|   28 | Leonardo Curzio-Maluy | Bismarck, ND     | Evangel Assembly of God        |   -10 |  -1.11 |      |
+|   28 | Amber Ragains         | Bismarck, ND     | Evangel Assembly of God        |   -10 |  -1.11 |
+
+## Middle School Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points. Scores sorted by Average.*
+
+|    # | Team             | Church                 |  W\L | Total |   Avg |
+| ---: | ---------------- | ---------------------- | ---: | ----: | ----: |
+|    1 | Rapid City, SD   | Bethel Assembly of God |  5\1 |   855 | 142.5 |
+|    2 | Cedar Rapids, IA | First Assembly of God  |  3\3 |   415 | 69.17 |
+|    3 | Hill City, SD    | Little White Church    |  1\5 |   465 |  77.5 |
+
+### Individuals
+
+*Ties broken by Quiz Outs. Scores sorted by Average.*
+
+|    # | Quizzer          | Team             | Church                 | Total |   Avg |   QO |
+| ---: | ---------------- | ---------------- | ---------------------- | ----: | ----: | ---: |
+|    1 | Tori Lind        | Hill City, SD    | Little White Church    |   435 |  72.5 |    4 |
+|    2 | Isabel Wilhelm   | Rapid City, SD   | Bethel Assembly of God |   345 |  57.5 |    2 |
+|    3 | Carson Sehr      | Rapid City, SD   | Bethel Assembly of God |   255 |  42.5 |    3 |
+|    4 | Jonah Boentoro   | Cedar Rapids, IA | First Assembly of God  |   245 | 40.83 |    1 |
+|    5 | Rachel Fenenga   | Rapid City, SD   | Bethel Assembly of God |   225 |  37.5 |      |
+|    6 | Amurie Coder     | Cedar Rapids, IA | First Assembly of God  |   165 |  27.5 |    2 |
+|    7 | Austin Verbeck   | Hill City, SD    | Little White Church    |    30 |     5 |      |
+|    7 | Aspen Kalytka    | Rapid City, SD   | Bethel Assembly of God |    30 |     5 |      |
+|    8 | Jeffrey Coder    | Cedar Rapids, IA | First Assembly of God  |    10 |  1.67 |      |
+|    9 | Elissa Gruzynski | Hill City, SD    | Little White Church    |       |     0 |      |
+|    9 | Samantha Fowler  | Hill City, SD    | Little White Church    |       |     0 |      |
+|    9 | Dakota LaBarr    | Cedar Rapids, IA | First Assembly of God  |       |     0 |      |

--- a/_pages/history/2014/regionals/northeast.md
+++ b/_pages/history/2014/regionals/northeast.md
@@ -12,177 +12,177 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## A League
+## A Division
 
 ### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
-| #  | Team                                             | Church             | W/L  | Total | Avg    |
-|---:|--------------------------------------------------|--------------------|------|------:|-------:|
-| 1  | Maple Lane AG                                    | Deposit NY         | 12/3 | 2680  | 178.67 |
-| 2  | PCC \"Treated Outrageously\"                     | Mt. Pocono PA      | 12/3 | 2665  | 177.67 |
-| 3  | Praise AG \"Ohhimark\"                           | Garfield NJ        | 12/3 | 2210  | 147.33 |
-| 4  | Bethany Church \"Thoroughly Equipped\"           | Wyckoff NJ         | 11/4 | 2715  | 181.00 |
-| 5  | New Day AG \"Final Charge\"                      | Upper St. Clair PA | 11/4 | 2470  | 164.67 |
-| 6  | Living Hope WC \"Worthy Women with Labor Pains\" | Swedesboro NJ      | 11/4 | 1950  | 130.00 |
-| 7  | Mechanicsville CC                                | Mechanicsville VA  | 9/6  | 1630  | 108.67 |
-| 8  | Newport AG \"T.H.E.M\"                           | Newport PA         | 8/7  | 1495  | 99.67  |
-| 9  | Cornerstone AG \"Dalmatia\"                      | Bouie MD           | 8/7  | 1375  | 91.67  |
-| 10 | First AG                                         | Binghamton NY      | 7/8  | 1925  | 128.33 |
-| 11 | Bethlehem Church                                 | Richmond Hill NY   | 6/9  | 1805  | 120.33 |
-| 12 | Word of Life AG                                  | Springfield VA     | 5/10 | 1330  | 88.67  |
-| 13 | Emmanuel AG \"GWWEH\"                            | Allentown PA       | 4/11 | 680   | 45.33  |
-| 14 | Grace AG                                         | Syracuse NY        | 3/12 | 660   | 44.00  |
-| 15 | Evangel Church \"CBTW - The Flash\"              | Scotch Plains NJ   | 1/14 | 425   | 28.33  |
-| 16 | Calvary AG                                       | Ozone Park NY      | 0/15 | 500   | 33.33  |
+|    # | Team                                           | Church             |  W\L | Tiebreaker     | Total |    Avg |
+| ---: | ---------------------------------------------- | ------------------ | ---: | -------------- | ----: | -----: |
+|    1 | PCC "Treated Outrageously"                     | Mt. Pocono PA      | 12\3 | 1st in Playoff |  2665 | 177.67 |
+|    2 | Maple Lane AG                                  | Deposit NY         | 12\3 | 2nd in Playoff |  2680 | 178.67 |
+|    3 | Praise AG "Ohhimark"                           | Garfield NJ        | 12\3 | 3rd in Playoff |  2210 | 147.33 |
+|    4 | Bethany Church "Thoroughly Equipped"           | Wyckoff NJ         | 11\4 | 1st in Playoff |  2715 | 181.00 |
+|    5 | New Day AG "Final Charge"                      | Upper St. Clair PA | 11\4 | 2nd in Playoff |  2470 | 164.67 |
+|    6 | Living Hope WC "Worthy Women with Labor Pains" | Swedesboro NJ      | 11\4 | 3rd in Playoff |  1950 | 130.00 |
+|    7 | Mechanicsville CC                              | Mechanicsville VA  |  9\6 |                |  1630 | 108.67 |
+|    8 | Newport AG "T.H.E.M"                           | Newport PA         |  8\7 | Won Head-Head  |  1495 |  99.67 |
+|    9 | Cornerstone AG "Dalmatia"                      | Bouie MD           |  8\7 |                |  1375 |  91.67 |
+|   10 | First AG                                       | Binghamton NY      |  7\8 |                |  1925 | 128.33 |
+|   11 | Bethlehem Church                               | Richmond Hill NY   |  6\9 |                |  1805 | 120.33 |
+|   12 | Word of Life AG                                | Springfield VA     | 5\10 |                |  1330 |  88.67 |
+|   13 | Emmanuel AG "GWWEH"                            | Allentown PA       | 4\11 |                |   680 |  45.33 |
+|   14 | Grace AG                                       | Syracuse NY        | 3\12 |                |   660 |  44.00 |
+|   15 | Evangel Church "CBTW - The Flash"              | Scotch Plains NJ   | 1\14 |                |   425 |  28.33 |
+|   16 | Calvary AG                                     | Ozone Park NY      | 0\15 |                |   500 |  33.33 |
 
 ### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
-| #  | Quizzer                   | Team                                             | Church             | Total | Avg    | QO |
-|---:|---------------------------|--------------------------------------------------|--------------------|------:|-------:|---:|
-| 1  | Aaron Scarinzi            | First AG                                         | Binghamton NY      | 1595  | 106.33 | 12 |
-| 2  | Julia Rodriguez           | PCC \"Treated Outrageously\"                     | Mt. Pocono PA      | 1525  | 101.67 | 10 |
-| 3  | Jonathan Brown            | New Day AG \"Final Charge\"                      | Upper St. Clair PA | 1405  | 93.67  | 12 |
-| 4  | Gabriel Flores            | Bethany Church \"Thoroughly Equipped\"           | Wyckoff NJ         | 1360  | 90.67  | 13 |
-| 5  | Trey Sederwall            | Praise AG \"Ohhimark\"                           | Garfield NJ        | 1325  | 88.33  | 9  |
-| 6  | Caleb Hoffman             | Maple Lane AG                                    | Deposit NY         | 1230  | 82.00  | 10 |
-| 7  | Rachael Singh             | Bethlehem Church                                 | Richmond Hill NY   | 1015  | 67.67  | 7  |
-| 8  | Chase Hill                | Living Hope WC \"Worthy Women with Labor Pains\" | Swedesboro NJ      | 1010  | 67.33  | 10 |
-| 9  | Halle Reisinger           | Newport AG \"T.H.E.M\"                           | Newport PA         | 980   | 65.33  | 9  |
-| 10 | Solomon Stevens           | Maple Lane AG                                    | Deposit NY         | 975   | 65.00  | 8  |
-| 11 | Joey Lemley               | New Day AG \"Final Charge\"                      | Upper St. Clair PA | 950   | 63.33  | 9  |
-| 12 | Joshua KuKuvka            | Mechanicsville CC                                | Mechanicsville VA  | 930   | 62.00  | 10 |
-| 13 | Katrina Dowdy             | Living Hope WC \"Worthy Women with Labor Pains\" | Swedesboro NJ      | 880   | 58.67  | 5  |
-| 14 | Tyler Adelmann            | Bethany Church \"Thoroughly Equipped\"           | Wyckoff NJ         | 810   | 54.00  | 7  |
-| 15 | Zach Wisz                 | Praise AG \"Ohhimark\"                           | Garfield NJ        | 785   | 52.33  | 8  |
-| 16 | Hava Parker               | PCC \"Treated Outrageously\"                     | Mt. Pocono PA      | 755   | 50.33  | 4  |
-| 17 | Benjamin Beckering        | Grace AG                                         | Syracuse NY        | 645   | 43.00  | 6  |
-| 18 | Nathaniel Stuart          | Emmanuel AG \"GWWEH\"                            | Allentown PA       | 620   | 41.33  | 6  |
-| 19 | Holley Bowen              | Mechanicsville CC                                | Mechanicsville VA  | 580   | 38.67  | 2  |
-| 20 | Joshua Inyangson          | Word of Life AG                                  | Springfield VA     | 575   | 38.33  | 5  |
-| 21 | Hannah Sproull            | Newport AG \"T.H.E.M\"                           | Newport PA         | 525   | 35.00  | 3  |
-| 22 | Rachel Stewart            | Bethany Church \"Thoroughly Equipped\"           | Wyckoff NJ         | 515   | 34.33  | 3  |
-| 23 | Chimaka Ubani             | Calvary AG                                       | Ozone Park NY      | 490   | 32.67  | 1  |
-| 24 | Ethan Hoffman             | Maple Lane AG                                    | Deposit NY         | 475   | 31.67  | 2  |
-| 25 | Marc Smith                | Cornerstone AG \"Dalmatia\"                      | Bouie MD           | 470   | 31.33  | 4  |
-| 26 | Jacob Conerly             | Word of Life AG                                  | Springfield VA     | 470   | 31.33  | 3  |
-| 27 | Joy Okafor                | Bethlehem Church                                 | Richmond Hill NY   | 460   | 30.67  | 2  |
-| 28 | Bethany York              | Cornerstone AG \"Dalmatia\"                      | Bouie MD           | 450   | 30.00  | 1  |
-| 29 | Tobias Garner             | Cornerstone AG \"Dalmatia\"                      | Bouie MD           | 430   | 28.67  | 1  |
-| 29 | Stephen Thomas            | Evangel Church \"CBTW - The Flash\"              | Scotch Plains NJ   | 430   | 28.67  | 1  |
-| 30 | Amanda Persaud            | PCC \"Treated Outrageously\"                     | Mt. Pocono PA      | 390   | 26.00  | 4  |
-| 31 | Rebecca Ford              | Bethlehem Church                                 | Richmond Hill NY   | 315   | 21.00  | 2  |
-| 32 | Nick Congdon              | First AG                                         | Binghamton NY      | 295   | 19.67  | 2  |
-| 33 | David Inyangson           | Word of Life AG                                  | Springfield VA     | 250   | 16.67  | 2  |
-| 34 | Alyssa Walker             | Mechanicsville CC                                | Mechanicsville VA  | 125   | 8.33   |    |
-| 35 | Eve Vargas                | Praise AG \"Ohhimark\"                           | Garfield NJ        | 100   | 6.67   |    |
-| 36 | James Khor                | New Day AG \"Final Charge\"                      | Upper St. Clair PA | 90    | 6.00   |    |
-| 37 | Michael Brunell           | Emmanuel AG \"GWWEH\"                            | Allentown PA       | 70    | 4.67   |    |
-| 38 | Julie Anna Cherednichenko | First AG                                         | Binghamton NY      | 50    | 3.33   |    |
-| 39 | Alex Stewart              | Bethany Church \"Thoroughly Equipped\"           | Wyckoff NJ         | 30    | 2.00   |    |
-| 39 | Sadya Ouedraogo           | Word of Life AG                                  | Springfield VA     | 30    | 2.00   |    |
-| 39 | Jacob Carty               | Living Hope WC \"Worthy Women with Labor Pains\" | Swedesboro NJ      | 30    | 2.00   |    |
-| 40 | Mariah Thompson           | Cornerstone AG \"Dalmatia\"                      | Bouie MD           | 25    | 1.67   |    |
-| 40 | Carrie Rooney             | New Day AG \"Final Charge\"                      | Upper St. Clair PA | 25    | 1.67   |    |
-| 41 | Jordan Ennis              | Grace AG                                         | Syracuse NY        | 20    | 1.33   |    |
-| 41 | Timothy Sumner            | Calvary AG                                       | Ozone Park NY      | 20    | 1.33   |    |
-| 41 | Gabrielle Schell          | Living Hope WC \"Worthy Women with Labor Pains\" | Swedesboro NJ      | 20    | 1.33   |    |
-| 42 | Hannah Hill               | Living Hope WC \"Worthy Women with Labor Pains\" | Swedesboro NJ      | 10    | .67    |    |
-| 42 | Isabella Chittumuri       | Bethlehem Church                                 | Richmond Hill NY   | 10    | .67    |    |
-| 42 | Christina Okafor          | Bethlehem Church                                 | Richmond Hill NY   | 10    | .67    |    |
-| 42 | Nathaniel Walker          | Mechanicsville CC                                | Mechanicsville VA  | 10    | .67    |    |
-| 42 | Daniel Persaud            | Evangel Church \"CBTW - The Flash\"              | Scotch Plains NJ   | 10    | .67    |    |
-| 43 | Martha Gizaw              | Word of Life AG                                  | Springfield VA     | 5     | .33    |    |
-| 43 | Jeffrey Samson            | Evangel Church \"CBTW - The Flash\"              | Scotch Plains NJ   | 5     | .33    |    |
-| 44 | KayLee Heller             | Newport AG \"T.H.E.M\"                           | Newport PA         |       | .00    |    |
-| 44 | Caleb Gerhart             | First AG                                         | Binghamton NY      |       | .00    |    |
-| 44 | Maggie Thompson           | Cornerstone AG \"Dalmatia\"                      | Bouie MD           |       | .00    |    |
-| 45 | Debbie Persaud            | Evangel Church \"CBTW - The Flash\"              | Scotch Plains NJ   | -15   | -1     |    |
-| 46 | Ethan Sproull             | Newport AG \"T.H.E.M\"                           | Newport PA         | -10   | -0.67  |    |
-| 46 | Veronica Cherednichenko   | First AG                                         | Binghamton NY      | -10   | -0.67  |    |
-| 46 | Terril Grant              | Calvary AG                                       | Ozone Park NY      | -10   | -0.67  |    |
-| 47 | Abigail Beckering         | Grace AG                                         | Syracuse NY        | -5    | -0.33  |    |
-| 47 | Ben Fenstermaker          | Emmanuel AG \"GWWEH\"                            | Allentown PA       | -5    | -0.33  |    |
+|    # | Quizzer                   | Team                                           | Church             | Total |    Avg |   QO |
+| ---: | ------------------------- | ---------------------------------------------- | ------------------ | ----: | -----: | ---: |
+|    1 | Aaron Scarinzi            | First AG                                       | Binghamton NY      |  1595 | 106.33 |   12 |
+|    2 | Julia Rodriguez           | PCC "Treated Outrageously"                     | Mt. Pocono PA      |  1525 | 101.67 |   10 |
+|    3 | Jonathan Brown            | New Day AG "Final Charge"                      | Upper St. Clair PA |  1405 |  93.67 |   12 |
+|    4 | Gabriel Flores            | Bethany Church "Thoroughly Equipped"           | Wyckoff NJ         |  1360 |  90.67 |   13 |
+|    5 | Trey Sederwall            | Praise AG "Ohhimark"                           | Garfield NJ        |  1325 |  88.33 |    9 |
+|    6 | Caleb Hoffman             | Maple Lane AG                                  | Deposit NY         |  1230 |  82.00 |   10 |
+|    7 | Rachael Singh             | Bethlehem Church                               | Richmond Hill NY   |  1015 |  67.67 |    7 |
+|    8 | Chase Hill                | Living Hope WC "Worthy Women with Labor Pains" | Swedesboro NJ      |  1010 |  67.33 |   10 |
+|    9 | Halle Reisinger           | Newport AG "T.H.E.M"                           | Newport PA         |   980 |  65.33 |    9 |
+|   10 | Solomon Stevens           | Maple Lane AG                                  | Deposit NY         |   975 |  65.00 |    8 |
+|   11 | Joey Lemley               | New Day AG "Final Charge"                      | Upper St. Clair PA |   950 |  63.33 |    9 |
+|   12 | Joshua KuKuvka            | Mechanicsville CC                              | Mechanicsville VA  |   930 |  62.00 |   10 |
+|   13 | Katrina Dowdy             | Living Hope WC "Worthy Women with Labor Pains" | Swedesboro NJ      |   880 |  58.67 |    5 |
+|   14 | Tyler Adelmann            | Bethany Church "Thoroughly Equipped"           | Wyckoff NJ         |   810 |  54.00 |    7 |
+|   15 | Zach Wisz                 | Praise AG "Ohhimark"                           | Garfield NJ        |   785 |  52.33 |    8 |
+|   16 | Hava Parker               | PCC "Treated Outrageously"                     | Mt. Pocono PA      |   755 |  50.33 |    4 |
+|   17 | Benjamin Beckering        | Grace AG                                       | Syracuse NY        |   645 |  43.00 |    6 |
+|   18 | Nathaniel Stuart          | Emmanuel AG "GWWEH"                            | Allentown PA       |   620 |  41.33 |    6 |
+|   19 | Holley Bowen              | Mechanicsville CC                              | Mechanicsville VA  |   580 |  38.67 |    2 |
+|   20 | Joshua Inyangson          | Word of Life AG                                | Springfield VA     |   575 |  38.33 |    5 |
+|   21 | Hannah Sproull            | Newport AG "T.H.E.M"                           | Newport PA         |   525 |  35.00 |    3 |
+|   22 | Rachel Stewart            | Bethany Church "Thoroughly Equipped"           | Wyckoff NJ         |   515 |  34.33 |    3 |
+|   23 | Chimaka Ubani             | Calvary AG                                     | Ozone Park NY      |   490 |  32.67 |    1 |
+|   24 | Ethan Hoffman             | Maple Lane AG                                  | Deposit NY         |   475 |  31.67 |    2 |
+|   25 | Marc Smith                | Cornerstone AG "Dalmatia"                      | Bouie MD           |   470 |  31.33 |    4 |
+|   26 | Jacob Conerly             | Word of Life AG                                | Springfield VA     |   470 |  31.33 |    3 |
+|   27 | Joy Okafor                | Bethlehem Church                               | Richmond Hill NY   |   460 |  30.67 |    2 |
+|   28 | Bethany York              | Cornerstone AG "Dalmatia"                      | Bouie MD           |   450 |  30.00 |    1 |
+|   29 | Tobias Garner             | Cornerstone AG "Dalmatia"                      | Bouie MD           |   430 |  28.67 |    1 |
+|   29 | Stephen Thomas            | Evangel Church "CBTW - The Flash"              | Scotch Plains NJ   |   430 |  28.67 |    1 |
+|   30 | Amanda Persaud            | PCC "Treated Outrageously"                     | Mt. Pocono PA      |   390 |  26.00 |    4 |
+|   31 | Rebecca Ford              | Bethlehem Church                               | Richmond Hill NY   |   315 |  21.00 |    2 |
+|   32 | Nick Congdon              | First AG                                       | Binghamton NY      |   295 |  19.67 |    2 |
+|   33 | David Inyangson           | Word of Life AG                                | Springfield VA     |   250 |  16.67 |    2 |
+|   34 | Alyssa Walker             | Mechanicsville CC                              | Mechanicsville VA  |   125 |   8.33 |      |
+|   35 | Eve Vargas                | Praise AG "Ohhimark"                           | Garfield NJ        |   100 |   6.67 |      |
+|   36 | James Khor                | New Day AG "Final Charge"                      | Upper St. Clair PA |    90 |   6.00 |      |
+|   37 | Michael Brunell           | Emmanuel AG "GWWEH"                            | Allentown PA       |    70 |   4.67 |      |
+|   38 | Julie Anna Cherednichenko | First AG                                       | Binghamton NY      |    50 |   3.33 |      |
+|   39 | Alex Stewart              | Bethany Church "Thoroughly Equipped"           | Wyckoff NJ         |    30 |   2.00 |      |
+|   39 | Sadya Ouedraogo           | Word of Life AG                                | Springfield VA     |    30 |   2.00 |      |
+|   39 | Jacob Carty               | Living Hope WC "Worthy Women with Labor Pains" | Swedesboro NJ      |    30 |   2.00 |      |
+|   40 | Mariah Thompson           | Cornerstone AG "Dalmatia"                      | Bouie MD           |    25 |   1.67 |      |
+|   40 | Carrie Rooney             | New Day AG "Final Charge"                      | Upper St. Clair PA |    25 |   1.67 |      |
+|   41 | Jordan Ennis              | Grace AG                                       | Syracuse NY        |    20 |   1.33 |      |
+|   41 | Timothy Sumner            | Calvary AG                                     | Ozone Park NY      |    20 |   1.33 |      |
+|   41 | Gabrielle Schell          | Living Hope WC "Worthy Women with Labor Pains" | Swedesboro NJ      |    20 |   1.33 |      |
+|   41 | Isabella Chittumuri       | Bethlehem Church                               | Richmond Hill NY   |    20 |   1.33 |      |
+|   42 | Hannah Hill               | Living Hope WC "Worthy Women with Labor Pains" | Swedesboro NJ      |    10 |   0.67 |      |
+|   42 | Christina Okafor          | Bethlehem Church                               | Richmond Hill NY   |    10 |   0.67 |      |
+|   42 | Nathaniel Walker          | Mechanicsville CC                              | Mechanicsville VA  |    10 |   0.67 |      |
+|   42 | Daniel Persaud            | Evangel Church "CBTW - The Flash"              | Scotch Plains NJ   |    10 |   0.67 |      |
+|   43 | Martha Gizaw              | Word of Life AG                                | Springfield VA     |     5 |   0.33 |      |
+|   43 | Jeffrey Samson            | Evangel Church "CBTW - The Flash"              | Scotch Plains NJ   |     5 |   0.33 |      |
+|   44 | KayLee Heller             | Newport AG "T.H.E.M"                           | Newport PA         |       |   0.00 |      |
+|   44 | Caleb Gerhart             | First AG                                       | Binghamton NY      |       |   0.00 |      |
+|   44 | Maggie Thompson           | Cornerstone AG "Dalmatia"                      | Bouie MD           |       |   0.00 |      |
+|   45 | Debbie Persaud            | Evangel Church "CBTW - The Flash"              | Scotch Plains NJ   |   -15 |  -1.00 |      |
+|   46 | Ethan Sproull             | Newport AG "T.H.E.M"                           | Newport PA         |   -10 |  -0.67 |      |
+|   46 | Veronica Cherednichenko   | First AG                                       | Binghamton NY      |   -10 |  -0.67 |      |
+|   46 | Terril Grant              | Calvary AG                                     | Ozone Park NY      |   -10 |  -0.67 |      |
+|   47 | Abigail Beckering         | Grace AG                                       | Syracuse NY        |    -5 |  -0.33 |      |
+|   47 | Ben Fenstermaker          | Emmanuel AG "GWWEH"                            | Allentown PA       |    -5 |  -0.33 |      |
 
-## Middle School League
+## Middle School Division
 
 ### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
-| #  | Team                                               | Church             | W/L  | Total | Avg    |
-|---:|----------------------------------------------------|--------------------|------|------:|-------:|
-| 1  | Evangel Heights AG \"Blazing Encouragement\"       | Sarver PA          | 13/0 | 2400  | 184.62 |
-| 2  | Vailsburg AG \"Fahrenheit\"                        | Newark NJ          | 12/1 | 2390  | 183.85 |
-| 3  | New Day AG \"Sons of Blazing Fire\"                | Upper St. Clair PA | 9/4  | 2270  | 174.62 |
-| 4  | Kennebec Valley AG \"L2PG\"                        | Chelsea ME         | 9/4  | 2190  | 168.46 |
-| 5  | Evangel Church \"Superman\"                        | Scotch Plains NJ   | 8/5  | 1560  | 120.00 |
-| 6  | Word of Life AG MS                                 | Springfield VA     | 8/5  | 1560  | 120.00 |
-| 7  | First AG \"Duty Calls\"                            | Waynesburg PA      | 6/7  | 1860  | 143.08 |
-| 8  | South Hills AG \"Flaming Swords of the Archangel\" | Bethel Park PA     | 6/7  | 1765  | 135.77 |
-| 9  | South Hills AG \"Addicted to Jesus\"               | Bethel Park PA     | 6/7  | 1385  | 106.54 |
-| 10 | Church of the Risen King                           | Gloucester City NJ | 4/9  | 1350  | 103.85 |
-| 11 | Evangel Chapel                                     | Bridgewater NJ     | 4/9  | 1465  | 112.69 |
-| 12 | Mechanicsville CC MS                               | Mechanicsville VA  | 3/10 | 1585  | 121.92 |
-| 13 | Bethany Church \"Herald, Apostle and Teacher\"     | Wyckoff NJ         | 2/11 | 1215  | 93.46  |
-| 14 | Fountain of Life Center                            | Burlington NJ      | 1/12 | 945   | 72.69  |
+|    # | Team                                             | Church             |  W\L | Tiebreaker    | Total |    Avg |
+| ---: | ------------------------------------------------ | ------------------ | ---: | ------------- | ----: | -----: |
+|    1 | Evangel Heights AG "Blazing Encouragement"       | Sarver PA          | 13\0 |               |  2400 | 184.62 |
+|    2 | Vailsburg AG "Fahrenheit"                        | Newark NJ          | 12\1 |               |  2390 | 183.85 |
+|    3 | New Day AG "Sons of Blazing Fire"                | Upper St. Clair PA |  9\4 | Won Head-Head |  2270 | 174.62 |
+|    4 | Kennebec Valley AG "L2PG"                        | Chelsea ME         |  9\4 |               |  2190 | 168.46 |
+|    5 | Evangel Church "Superman"                        | Scotch Plains NJ   |  8\5 | Won Head-Head |  1560 | 120.00 |
+|    6 | Word of Life AG MS                               | Springfield VA     |  8\5 |               |  1560 | 120.00 |
+|    7 | South Hills AG "Addicted to Jesus"               | Bethel Park PA     |  6\7 | 2-0 in Group  |  1385 | 106.54 |
+|    8 | South Hills AG "Flaming Swords of the Archangel" | Bethel Park PA     |  6\7 | 1-1 in Group  |  1765 | 135.77 |
+|    9 | First AG "Duty Calls"                            | Waynesburg PA      |  6\7 | 0-2 in Group  |  1860 | 143.08 |
+|   10 | Church of the Risen King                         | Gloucester City NJ |  4\9 | Won Head-Head |  1350 | 103.85 |
+|   11 | Evangel Chapel                                   | Bridgewater NJ     |  4\9 |               |  1465 | 112.69 |
+|   12 | Mechanicsville CC MS                             | Mechanicsville VA  | 3\10 |               |  1585 | 121.92 |
+|   13 | Bethany Church "Herald, Apostle and Teacher"     | Wyckoff NJ         | 2\11 |               |  1215 |  93.46 |
+|   14 | Fountain of Life Center                          | Burlington NJ      | 1\12 |               |   945 |  72.69 |
 
 ### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
-| #  | Quizzer             | Team                                               | Church             | Total | Avg    | QO |
-|---:|---------------------|----------------------------------------------------|--------------------|------:|-------:|---:|
-| 1  | Jonathan Baily      | First AG \"Duty Calls\"                            | Waynesburg PA      | 1480  | 113.85 | 11 |
-| 2  | Brooklyne Sederwall | Vailsburg AG \"Fahrenheit\"                        | Newark NJ          | 1345  | 103.46 | 8  |
-| 3  | Ally Waller         | Kennebec Valley AG \"L2PG\"                        | Chelsea ME         | 1295  | 99.62  | 8  |
-| 4  | Madison Holcomb     | Evangel Heights AG \"Blazing Encouragement\"       | Sarver PA          | 1185  | 91.15  | 9  |
-| 5  | Rachel Adelmann     | Bethany Church \"Herald, Apostle and Teacher\"     | Wyckoff NJ         | 1140  | 87.69  | 7  |
-| 6  | Divya Matthews      | Word of Life AG MS                                 | Springfield VA     | 1135  | 87.31  | 6  |
-| 7  | Benshel Bright      | Evangel Church \"Superman\"                        | Scotch Plains NJ   | 1030  | 79.23  | 5  |
-| 8  | Chad Sederwall      | Vailsburg AG \"Fahrenheit\"                        | Newark NJ          | 955   | 73.46  | 8  |
-| 9  | Elijah Abad         | Church of the Risen King                           | Gloucester City NJ | 955   | 73.46  | 5  |
-| 10 | Phoebe Hoffman      | Mechanicsville CC MS                               | Mechanicsville VA  | 945   | 72.69  | 9  |
-| 11 | Carissa Gullino     | Evangel Chapel                                     | Bridgewater NJ     | 930   | 71.54  | 7  |
-| 12 | Shayaan Meyer       | South Hills AG \"Addicted to Jesus\"               | Bethel Park PA     | 815   | 62.69  | 7  |
-| 13 | Liam Rooney         | New Day AG \"Sons of Blazing Fire\"                | Upper St. Clair PA | 785   | 60.38  | 6  |
-| 14 | David Sikes         | South Hills AG \"Flaming Swords of the Archangel\" | Bethel Park PA     | 760   | 58.46  | 6  |
-| 15 | Alex Bradley        | New Day AG \"Sons of Blazing Fire\"                | Upper St. Clair PA | 760   | 58.46  | 4  |
-| 16 | Justin Reid         | New Day AG \"Sons of Blazing Fire\"                | Upper St. Clair PA | 725   | 55.77  | 6  |
-| 17 | Aidan McIntire      | Evangel Heights AG \"Blazing Encouragement\"       | Sarver PA          | 700   | 53.85  | 5  |
-| 18 | Mikkalah Patterson  | Fountain of Life Center                            | Burlington NJ      | 635   | 48.85  | 4  |
-| 19 | Seth Misak          | South Hills AG \"Flaming Swords of the Archangel\" | Bethel Park PA     | 625   | 48.08  | 4  |
-| 20 | Sydney Avery        | Kennebec Valley AG \"L2PG\"                        | Chelsea ME         | 565   | 43.46  | 5  |
-| 21 | Alex Thornton       | South Hills AG \"Addicted to Jesus\"               | Bethel Park PA     | 550   | 42.31  | 2  |
-| 22 | Joy Ladignon        | Evangel Chapel                                     | Bridgewater NJ     | 540   | 41.54  | 2  |
-| 23 | Thomas Winslow      | Evangel Church \"Superman\"                        | Scotch Plains NJ   | 530   | 40.77  | 6  |
-| 24 | Kristiana Ramos     | Church of the Risen King                           | Gloucester City NJ | 395   | 30.38  |    |
-| 25 | Josh Fuller         | South Hills AG \"Flaming Swords of the Archangel\" | Bethel Park PA     | 380   | 29.23  | 1  |
-| 26 | Nikki Rittenhouse   | Mechanicsville CC MS                               | Mechanicsville VA  | 370   | 28.46  | 1  |
-| 27 | Tanner Hoscheid     | Evangel Heights AG \"Blazing Encouragement\"       | Sarver PA          | 345   | 26.54  | 2  |
-| 28 | Josiah Bartlett     | Kennebec Valley AG \"L2PG\"                        | Chelsea ME         | 335   | 25.77  | 5  |
-| 29 | Sophia Whitfield    | Mechanicsville CC MS                               | Mechanicsville VA  | 270   | 20.77  | 1  |
-| 30 | Elijah Earnest      | First AG \"Duty Calls\"                            | Waynesburg PA      | 255   | 19.62  | 1  |
-| 31 | Debi Tura           | Word of Life AG MS                                 | Springfield VA     | 250   | 19.23  |    |
-| 32 | Savannah Cosme      | Fountain of Life Center                            | Burlington NJ      | 190   | 14.62  |    |
-| 33 | Renee Thiele        | Evangel Heights AG \"Blazing Encouragement\"       | Sarver PA          | 170   | 13.08  | 1  |
-| 34 | Blessing Inyangson  | Word of Life AG MS                                 | Springfield VA     | 130   | 10.00  |    |
-| 35 | Scott Benco         | First AG \"Duty Calls\"                            | Waynesburg PA      | 125   | 9.62   |    |
-| 36 | Imah Umoh           | Fountain of Life Center                            | Burlington NJ      | 120   | 9.23   |    |
-| 37 | Brian McClendon     | Vailsburg AG \"Fahrenheit\"                        | Newark NJ          | 110   | 8.46   |    |
-| 38 | Daniel Flores       | Bethany Church \"Herald, Apostle and Teacher\"     | Wyckoff NJ         | 75    | 5.77   |    |
-| 39 | Lydia Dawit         | Word of Life AG MS                                 | Springfield VA     | 45    | 3.46   |    |
-| 40 | Abby Powers         | South Hills AG \"Addicted to Jesus\"               | Bethel Park PA     | 20    | 1.54   |    |
-| 41 | Matthew Wright      | Fountain of Life Center                            | Burlington NJ      |       | .00    |    |
-| 41 | Rebekah Anischenko  | South Hills AG \"Addicted to Jesus\"               | Bethel Park PA     |       | .00    |    |
-| 41 | David Batchelder    | New Day AG \"Sons of Blazing Fire\"                | Upper St. Clair PA |       | .00    |    |
-| 41 | Alena Ambers        | Kennebec Valley AG \"L2PG\"                        | Chelsea ME         |       | .00    |    |
-| 41 | Alison Stanly       | Mechanicsville CC MS                               | Mechanicsville VA  |       | .00    |    |
-| 41 | Charlotte Burt      | Word of Life AG MS                                 | Springfield VA     |       | .00    |    |
-| 41 | Gabrielle Burgos    | Bethany Church \"Herald, Apostle and Teacher\"     | Wyckoff NJ         |       | .00    |    |
-| 41 | Isabella Burt       | Word of Life AG MS                                 | Springfield VA     |       | .00    |    |
-| 41 | Andreanna Rivera    | Evangel Church \"Superman\"                        | Scotch Plains NJ   |       | .00    |    |
-| 42 | Kelvin Ubaechu      | Vailsburg AG \"Fahrenheit\"                        | Newark NJ          | -15   | -1.15  |    |
+|    # | Quizzer               | Team                                               | Church               |   Total |      Avg |   QO |
+| ---: | --------------------- | -------------------------------------------------- | -------------------- | ------: | -------: | ---: |
+|    1 | Jonathan Baily        | First AG "Duty Calls"                              | Waynesburg PA        |    1480 |   113.85 |   11 |
+|    2 | Brooklyne Sederwall   | Vailsburg AG "Fahrenheit"                          | Newark NJ            |    1345 |   103.46 |    8 |
+|    3 | Ally Waller           | Kennebec Valley AG "L2PG"                          | Chelsea ME           |    1295 |    99.62 |    8 |
+|    4 | Madison Holcomb       | Evangel Heights AG "Blazing Encouragement"         | Sarver PA            |    1185 |    91.15 |    9 |
+|    5 | Rachel Adelmann       | Bethany Church "Herald, Apostle and Teacher"       | Wyckoff NJ           |    1140 |    87.69 |    7 |
+|    6 | Divya Matthews        | Word of Life AG MS                                 | Springfield VA       |    1135 |    87.31 |    6 |
+|    7 | Benshel Bright        | Evangel Church "Superman"                          | Scotch Plains NJ     |    1030 |    79.23 |    5 |
+|    8 | Chad Sederwall        | Vailsburg AG "Fahrenheit"                          | Newark NJ            |     955 |    73.46 |    8 |
+|    9 | Elijah Abad           | Church of the Risen King                           | Gloucester City NJ   |     955 |    73.46 |    5 |
+|   10 | Phoebe Hoffman        | Mechanicsville CC MS                               | Mechanicsville VA    |     945 |    72.69 |    9 |
+|   11 | Carissa Gullino       | Evangel Chapel                                     | Bridgewater NJ       |     930 |    71.54 |    7 |
+|   12 | Shayaan Meyer         | South Hills AG "Addicted to Jesus"                 | Bethel Park PA       |     815 |    62.69 |    7 |
+|   13 | Liam Rooney           | New Day AG "Sons of Blazing Fire"                  | Upper St. Clair PA   |     785 |    60.38 |    6 |
+|   14 | David Sikes           | South Hills AG "Flaming Swords of the Archangel"   | Bethel Park PA       |     760 |    58.46 |    6 |
+|   15 | Alex Bradley          | New Day AG "Sons of Blazing Fire"                  | Upper St. Clair PA   |     760 |    58.46 |    4 |
+|   16 | Justin Reid           | New Day AG "Sons of Blazing Fire"                  | Upper St. Clair PA   |     725 |    55.77 |    6 |
+|   17 | Aidan McIntire        | Evangel Heights AG "Blazing Encouragement"         | Sarver PA            |     700 |    53.85 |    5 |
+|   18 | Mikkalah Patterson    | Fountain of Life Center                            | Burlington NJ        |     635 |    48.85 |    4 |
+|   19 | Seth Misak            | South Hills AG "Flaming Swords of the Archangel"   | Bethel Park PA       |     625 |    48.08 |    4 |
+|   20 | Sydney Avery          | Kennebec Valley AG "L2PG"                          | Chelsea ME           |     565 |    43.46 |    5 |
+|   21 | Alex Thornton         | South Hills AG "Addicted to Jesus"                 | Bethel Park PA       |     550 |    42.31 |    2 |
+|   22 | Joy Ladignon          | Evangel Chapel                                     | Bridgewater NJ       |     540 |    41.54 |    2 |
+|   23 | Thomas Winslow        | Evangel Church "Superman"                          | Scotch Plains NJ     |     530 |    40.77 |    6 |
+|   24 | Kristiana Ramos       | Church of the Risen King                           | Gloucester City NJ   |     395 |    30.38 |      |
+|   25 | Josh Fuller           | South Hills AG "Flaming Swords of the Archangel"   | Bethel Park PA       |     380 |    29.23 |    1 |
+|   26 | Nikki Rittenhouse     | Mechanicsville CC MS                               | Mechanicsville VA    |     370 |    28.46 |    1 |
+|   27 | Tanner Hoscheid       | Evangel Heights AG "Blazing Encouragement"         | Sarver PA            |     345 |    26.54 |    2 |
+|   28 | Josiah Bartlett       | Kennebec Valley AG "L2PG"                          | Chelsea ME           |     335 |    25.77 |    5 |
+|   29 | Sophia Whitfield      | Mechanicsville CC MS                               | Mechanicsville VA    |     270 |    20.77 |    1 |
+|   30 | Elijah Earnest        | First AG "Duty Calls"                              | Waynesburg PA        |     255 |    19.62 |    1 |
+|   31 | Debi Tura             | Word of Life AG MS                                 | Springfield VA       |     250 |    19.23 |      |
+|   32 | Savannah Cosme        | Fountain of Life Center                            | Burlington NJ        |     190 |    14.62 |      |
+|   33 | Renee Thiele          | Evangel Heights AG "Blazing Encouragement"         | Sarver PA            |     170 |    13.08 |    1 |
+|   34 | Blessing Inyangson    | Word of Life AG MS                                 | Springfield VA       |     130 |    10.00 |      |
+|   35 | Scott Benco           | First AG "Duty Calls"                              | Waynesburg PA        |     125 |     9.62 |      |
+|   36 | Imah Umoh             | Fountain of Life Center                            | Burlington NJ        |     120 |     9.23 |      |
+|   37 | Brian McClendon       | Vailsburg AG "Fahrenheit"                          | Newark NJ            |     110 |     8.46 |      |
+|   38 | Daniel Flores         | Bethany Church "Herald, Apostle and Teacher"       | Wyckoff NJ           |      75 |     5.77 |      |
+|   39 | Lydia Dawit           | Word of Life AG MS                                 | Springfield VA       |      45 |     3.46 |      |
+|   40 | Abby Powers           | South Hills AG "Addicted to Jesus"                 | Bethel Park PA       |      20 |     1.54 |      |
+|   41 | Matthew Wright        | Fountain of Life Center                            | Burlington NJ        |         |     0.00 |      |
+|   41 | Rebekah Anischenko    | South Hills AG "Addicted to Jesus"                 | Bethel Park PA       |         |     0.00 |      |
+|   41 | David Batchelder      | New Day AG "Sons of Blazing Fire"                  | Upper St. Clair PA   |         |     0.00 |      |
+|   41 | Alena Ambers          | Kennebec Valley AG "L2PG"                          | Chelsea ME           |         |     0.00 |      |
+|   41 | Alison Stanly         | Mechanicsville CC MS                               | Mechanicsville VA    |         |     0.00 |      |
+|   41 | Charlotte Burt        | Word of Life AG MS                                 | Springfield VA       |         |     0.00 |      |
+|   41 | Gabrielle Burgos      | Bethany Church "Herald, Apostle and Teacher"       | Wyckoff NJ           |         |     0.00 |      |
+|   41 | Isabella Burt         | Word of Life AG MS                                 | Springfield VA       |         |     0.00 |      |
+|   41 | Andreanna Rivera      | Evangel Church "Superman"                          | Scotch Plains NJ     |         |     0.00 |      |
+|   42 | Kelvin Ubaechu        | Vailsburg AG "Fahrenheit"                          | Newark NJ            |     -15 |    -1.15 |      |

--- a/_pages/history/2014/regionals/northwest.md
+++ b/_pages/history/2014/regionals/northwest.md
@@ -1,0 +1,101 @@
+---
+layout: page
+title: "2014 Northwest Regionals"
+permalink: /history/2014/regionals/northwest/
+date: "2014-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2014 Season
+    link: /history/2014/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team                       | City         |    W |    L | Total |  Avg |
+| ---: | -------------------------- | ------------ | ---: | ---: | ----: | ---: |
+|    1 | CPC-The A Team             | Bothell, WA  |    7 |    - | 1,985 |  284 |
+|    2 | BNC-Dear Obedient Children | Bellevue, WA |    6 |    1 | 1,535 |  219 |
+|    3 | CPC-Keep Your Head         | Bothell, WA  |    5 |    2 | 1,345 |  192 |
+|    4 | TLC-Watch Out              | Tacoma, WA   |    4 |    3 |   700 |  100 |
+|    5 | CPC-Blazing Fire           | Bothell, WA  |    3 |    4 |   490 |   70 |
+|    6 | KLC-Lazy Gluttons          | Kuna, ID     |    2 |    5 |   185 |   26 |
+|    7 | MAG-Blazing Fire           | Meridian, ID |    1 |    6 |    95 |   14 |
+|    8 | Montana All-Star A Team    | Montana      |    - |    7 |    65 |    9 |
+
+### Individuals
+
+|    # | Quizzer           | Team                       | Total |  Avg |
+| ---: | ----------------- | -------------------------- | ----: | ---: |
+|    1 | Abby Rogers       | CPC-The A Team             |   955 |  136 |
+|    2 | Damon Comfort     | BNC-Dear Obedient Children |   810 |  116 |
+|    3 | Jacob Schumacher  | CPC-Keep Your Head         |   660 |   94 |
+|    4 | Abigail Peterson  | TLC-Watch Out              |   575 |   82 |
+|    5 | Kara Gallo        | BNC-Dear Obedient Children |   565 |   81 |
+|    6 | Ani Purohith      | CPC-The A Team             |   540 |   77 |
+|    7 | Adi Purohith      | CPC-The A Team             |   455 |   65 |
+|    8 | E J Olsen         | CPC-Keep Your Head         |   435 |   62 |
+|    9 | Joshua Roberts    | CPC-Blazing Fire           |   305 |   44 |
+|   10 | Samuel Schumacher | CPC-Keep Your Head         |   250 |   36 |
+|   11 | Brayden Olson     | KLC-Lazy Gluttons          |   165 |   24 |
+|   12 | Paloma Betrisey   | BNC-Dear Obedient Children |   150 |   21 |
+|   13 | Johan West        | CPC-Blazing Fire           |    95 |   14 |
+|   14 | Jonathan Roberts  | CPC-Blazing Fire           |    90 |   13 |
+|   15 | Samuel Dawson     | TLC-Watch Out              |    65 |    9 |
+|   16 | Jessica Kreiner   | MAG-Blazing Fire           |    65 |    9 |
+|   17 | Annalise Guy      | Montana All-Star A Team    |    65 |    9 |
+|   18 | Kristina Hisel    | KLC-Lazy Gluttons          |    55 |    8 |
+|   19 | Seth Dawson       | TLC-Watch Out              |    40 |    6 |
+|   20 | Jackson Houser    | CPC-The A Team             |    35 |    5 |
+|   21 | Chris Kreiner     | MAG-Blazing Fire           |    30 |    4 |
+|   22 | Jacob Yanez       | TLC-Watch Out              |    20 |    3 |
+|   23 | Hannah Wehrman    | Montana All-Star A Team    |    20 |    3 |
+|   24 | Daniel Gallo      | BNC-Dear Obedient Children |    10 |    1 |
+|   25 | Nicole Kreiner    | MAG-Blazing Fire           |     5 |    1 |
+|   26 | Andre' Nicolov    | CPC-Keep Your Head         |     - |    - |
+|   27 | Doug Correa       | BNC-Dear Obedient Children |     - |    - |
+|   28 | Becca Brander     | Montana All-Star A Team    |     - |    - |
+|   29 | Macy Olson        | KLC-Lazy Gluttons          |   -15 |  -2) |
+|   30 | Jake Wright       | KLC-Lazy Gluttons          |   -20 |  -3) |
+|   31 | Rachel Ledgerwood | Montana All-Star A Team    |   -20 |  -3) |
+
+## Middle School Division
+
+### Teams
+
+|    # | Team                         |    W |    L | Total |  Avg |
+| ---: | ---------------------------- | ---: | ---: | ----: | ---: |
+|    1 | CPC-Addicted to Seriousness  |    9 |    1 | 1,610 |  161 |
+|    2 | CPC-Meaningless Talk         |    7 |    3 | 1,570 |  157 |
+|    3 | BNC-sparTANs                 |    6 |    4 | 1,180 |  118 |
+|    4 | KLC-Quarrels About Words     |    6 |    4 | 1,120 |  112 |
+|    5 | Montana All Star Novice Too  |    1 |    9 |   685 |   69 |
+|    6 | Montana All Star Novice Team |    1 |    9 |   370 |   37 |
+
+### Individuals
+
+|    # | Quizzer             | Team                         | Total |  Avg |
+| ---: | ------------------- | ---------------------------- | ----: | ---: |
+|    1 | Reid Jarrell        | CPC-Addicted to Seriousness  | 1,235 |  124 |
+|    2 | Delaney Gillihan    | KLC-Quarrels About Words     |   785 |   79 |
+|    3 | Raychael Bertrand   | CPC-Meaningless Talk         |   725 |   73 |
+|    4 | Kiley Frank         | CPC-Meaningless Talk         |   720 |   72 |
+|    5 | Elisabeth Buckner   | Montana All Star Novice Too  |   595 |   60 |
+|    6 | Teddy Arasavelli    | BNC-sparTANs                 |   575 |   58 |
+|    7 | Adrien Jefferson    | BNC-sparTANs                 |   465 |   47 |
+|    8 | Nicholas Schumacher | CPC-Addicted to Seriousness  |   375 |   38 |
+|    9 | Daniel Guy          | Montana All Star Novice Team |   235 |   24 |
+|   10 | Miguel Lopez        | KLC-Quarrels About Words     |   175 |   18 |
+|   11 | Coralina Elhart     | KLC-Quarrels About Words     |   160 |   16 |
+|   12 | Mindy Brower        | Montana All Star Novice Team |   160 |   16 |
+|   13 | Noah Gallo          | BNC-sparTANs                 |   140 |   14 |
+|   14 | Jenna Roberts       | CPC-Meaningless Talk         |   125 |   13 |
+|   15 | Ben Pilskalns       | Montana All Star Novice Too  |    90 |    9 |
+|   16 | Trystan Stremel     | Montana All Star Novice Too  |    15 |    2 |
+|   17 | Tairin Wright       | KLC-Quarrels About Words     |     - |    - |
+|   18 | Lydia Pilskalns     | Montana All Star Novice Too  |   -15 |   -2 |
+|   19 | Hannah Feliciano    | Montana All Star Novice Team |   -25 |   -3 |

--- a/_pages/history/2014/regionals/south-central.md
+++ b/_pages/history/2014/regionals/south-central.md
@@ -1,0 +1,104 @@
+---
+layout: page
+title: "2014 South Central Regionals"
+permalink: /history/2014/regionals/south-central/
+date: "2022-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2014 Season
+    link: /history/2014/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+| Team             |    W |    L | Total |   Avg |
+| ---------------- | ---: | ---: | ----: | ----: |
+| Muskogee First   |   10 |    0 |  2560 |   256 |
+| Spring First     |    9 |    1 |  1290 |   129 |
+| Braeswood #1 *   |    7 |    3 |  1205 | 120.5 |
+| Harvest AG       |    7 |    3 |  1025 | 102.5 |
+| Noble AG **      |    6 |    4 |  1190 |   119 |
+| CT Church        |    6 |    4 |  1245 | 124.5 |
+| The Oaks         |    4 |    6 |   800 |    80 |
+| Christian Chapel |    3 |    7 |   315 |  31.5 |
+| Memorial AG      |    2 |    8 |   475 |  47.5 |
+| Braeswood #2     |    1 |    9 |   315 |  31.5 |
+| Owasso First     |    0 |   10 |    65 |   6.5 |
+
+\* Braeswood #1 won play-­‐off for 3rd place.\
+\*\* Noble won play-­‐off for 5th place.
+
+### Individuals
+
+| Quizzer          | Team             | Total |  Avg |   QO |
+| ---------------- | ---------------- | ----: | ---: | ---: |
+| Luke Wagner      | Muskogee First   |  1140 |  114 |    8 |
+| Andrew Roach     | CT Church        |   980 |   98 |    8 |
+| Jacob Wyatt      | Spring First     |   860 |   86 |    7 |
+| Andrew VanHorn   | Harvest AG       |   725 | 72.5 |    5 |
+| Cameron Berta    | The Oaks         |   700 |   70 |    5 |
+| David Meddaugh   | Muskogee First   |   685 | 68.5 |    3 |
+| Caleb Cain       | Noble AG         |   605 | 60.5 |    4 |
+| Paul Meddaugh    | Muskogee First   |   595 | 59.5 |    8 |
+| Connor McGraw    | Noble AG         |   560 |   56 |    4 |
+| Deborah Okoro    | Braeswood #1     |   470 |   47 |    4 |
+| Chime Nwogu      | Braeswood #1     |   360 |   40 |    3 |
+| Faith King       | Memorial AG      |   360 |   36 |    3 |
+| Cherokee Hill    | Christian Chapel |   325 | 32.5 |    2 |
+| Taylor Ellis     | Braeswood #1     |   310 |   31 |    1 |
+| JB VanHorn       | Harvest AG       |   305 | 30.5 |    2 |
+| Jeremy Mgbeike   | Braeswood #2     |   290 |   29 |    1 |
+| Mitt Wyatt       | Spring First     |   265 | 26.5 |    1 |
+| Sydny Bettis     | CT Church        |   210 |   21 |    1 |
+| John Sullivan    | Spring First     |   170 |   17 |    0 |
+| Josiah Schwarz   | Muskogee First   |   145 | 16.1 |    1 |
+| Andrew Garcia    | The Oaks         |   105 | 10.5 |    0 |
+| Joy Umoekpo      | Braeswood #1     |    90 |    9 |    0 |
+| Jose Lopez       | Braeswood #2     |    65 |  6.5 |    0 |
+| Daniel Kirby     | CT Church        |    25 |  6.3 |    0 |
+| Beth Pyle        | CT Church        |    30 |    6 |    0 |
+| Matthew Garman   | Owasso First     |    60 |    6 |    0 |
+| Karlee Snow      | Memorial AG      |    60 |    6 |    0 |
+| Kylee Snow       | Memorial AG      |    60 |    6 |    0 |
+| Britney Pitts    | Noble AG         |    25 |  2.5 |    0 |
+| Matthew Rangel   | Owasso First     |     5 |  0.5 |    0 |
+| Mary Meddaugh    | Muskogee First   |     0 |    0 |    0 |
+| Megan Pitts      | Noble AG         |     0 |    0 |    0 |
+| Grace Smith      | Noble AG         |     0 |    0 |    0 |
+| Kayla Roettgers  | CT Church        |     0 |    0 |    0 |
+| Chandler Kellett | Harvest AG       |    -5 | -0.5 |    0 |
+| David Obitade    | Braeswood #2     |   -40 |   -4 |    0 |
+
+## MSQ Division
+
+### Teams
+
+| Team           |    W |    L | Total |    Avg |
+| -------------- | ---: | ---: | ----: | -----: |
+| Muskogee First |    5 |    1 |   930 |    155 |
+| Braeswood #1   |    4 |    2 |   620 | 103.33 |
+| Braeswood #2   |    3 |    3 |   535 |   89.2 |
+| CT Church      |    0 |    6 |    60 |     10 |
+
+### Individuals
+
+| Quizzer           | Team           | Total |  Avg |   QO |
+| ----------------- | -------------- | ----: | ---: | ---: |
+| Zachary Schwarz   | Muskogee First |   750 |  125 |    5 |
+| Daniel Obitade    | Braeswood #1   |   430 | 71.7 |    2 |
+| Rachel Mgbeike    | Braeswood #2   |   315 | 52.5 |    3 |
+| Wayne Ellis       | Braeswood #2   |   220 | 36.7 |    1 |
+| Elizabeth Kirby   | CT Church      |   130 | 21.7 |    0 |
+| Izzy Lashley-Bobb | Muskogee First |   120 |   20 |    1 |
+| Tega Umukoro      | Braeswood #1   |   100 | 16.7 |    0 |
+| Jeremiah Ubak     | Braeswood #1   |    90 |   15 |    0 |
+| Sam Carter        | Muskogee First |    40 |  6.7 |    0 |
+| Bri Riley         | Muskogee First |    20 |  3.3 |    0 |
+| Abbe Branson      | CT Church      |     0 |    0 |    0 |
+| Jasmine Gonzalez  | CT Church      |   -30 |   -5 |    0 |
+| Reginald Connor   | CT Church      |   -40 |   -8 |    0 |

--- a/_pages/history/2014/regionals/southeast.md
+++ b/_pages/history/2014/regionals/southeast.md
@@ -12,63 +12,104 @@ menubar_toc_static:
     icon: fas fa-home
 ---
 
-## A League
+## A Division
 
 ### Teams
 
 *2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
 
-| # | Team              | Church            | W/L | Total | Avg    |
-|--:|-------------------|-------------------|-----|------:|-------:|
-| 1 | Montgomery, AL    | 1st A/G           | 8/0 | 1220  | 152.50 |
-| 2 | Toccoa, GA        | Toccoa A/G        | 7/1 | 1150  | 143.75 |
-| 3 | Wesley Chapel, FL | Victorious Life   | 6/2 | 940   | 117.50 |
-| 4 | Warner Robins, GA | The Assembly      | 5/3 | 1000  | 125.00 |
-| 5 | Ft Lauderdale, FL | Christian Life    | 4/4 | 680   | 85.00  |
-| 6 | Clermont, FL      | Gateway Church    | 3/5 | 465   | 58.13  |
-| 7 | Snellville, GA    | Evangel Community | 1/7 | 355   | 44.38  |
-| 8 | Lexington, NC     | 1st A/G           | 1/7 | 205   | 25.63  |
-| 9 | Jacksonville, FL  | Freedom Christian | 1/7 | 50    | 6.25   |
+|    # | Team              | Church            | W/L | Total |    Avg |
+| ---: | ----------------- | ----------------- | --- | ----: | -----: |
+|    1 | Montgomery, AL    | 1st A/G           | 8/0 |  1220 | 152.50 |
+|    2 | Toccoa, GA        | Toccoa A/G        | 7/1 |  1150 | 143.75 |
+|    3 | Wesley Chapel, FL | Victorious Life   | 6/2 |   940 | 117.50 |
+|    4 | Warner Robins, GA | The Assembly      | 5/3 |  1000 | 125.00 |
+|    5 | Ft Lauderdale, FL | Christian Life    | 4/4 |   680 |  85.00 |
+|    6 | Clermont, FL      | Gateway Church    | 3/5 |   465 |  58.13 |
+|    7 | Snellville, GA    | Evangel Community | 1/7 |   355 |  44.38 |
+|    8 | Lexington, NC     | 1st A/G           | 1/7 |   205 |  25.63 |
+|    9 | Jacksonville, FL  | Freedom Christian | 1/7 |    50 |   6.25 |
 
 ### Individuals
 
 *Ties broken by QuizOuts (Scores sorted by TOTAL)*
 
-| #  | Quizzer            | Team              | Church            | Total | Avg   | QO |
-|---:|--------------------|-------------------|-------------------|------:|------:|---:|
-| 1  | Lindsay Cowan      | Toccoa, GA        | Toccoa A/G        | 730   | 91.25 | 6  |
-| 2  | Paul Willis        | Montgomery, AL    | 1st A/G           | 685   | 85.63 | 8  |
-| 3  | Teddy Willis       | Montgomery, AL    | 1st A/G           | 535   | 66.88 | 5  |
-| 4  | Oore Morakinyo     | Ft Lauderdale, FL | Christian Life    | 500   | 62.50 | 4  |
-| 5  | Emily Herron       | Warner Robins, GA | The Assembly      | 495   | 61.88 | 2  |
-| 6  | Veronica Johnson   | Warner Robins, GA | The Assembly      | 490   | 61.25 | 6  |
-| 7  | Brielle Smith      | Clermont, FL      | Gateway Church    | 445   | 55.63 | 4  |
-| 8  | Shannon Wolf       | Wesley Chapel, FL | Victorious Life   | 375   | 46.88 |    |
-| 9  | Lacey Cowan        | Toccoa, GA        | Toccoa A/G        | 340   | 42.50 | 2  |
-| 10 | Erinn Wolf         | Wesley Chapel, FL | Victorious Life   | 305   | 38.13 | 2  |
-| 11 | Elizabeth Olatunji | Wesley Chapel, FL | Victorious Life   | 270   | 33.75 | 1  |
-| 12 | Jose Solano        | Lexington, NC     | 1st A/G           | 195   | 24.38 | 1  |
-| 13 | Rowojo Okala       | Snellville, GA    | Evangel Community | 175   | 21.88 |    |
-| 14 | Rhashaan Omar      | Snellville, GA    | Evangel Community | 170   | 21.25 | 1  |
-| 15 | Anthony Sangermano | Ft Lauderdale, FL | Christian Life    | 130   | 16.25 | 1  |
-| 16 | Allison Johnson    | Toccoa, GA        | Toccoa A/G        | 80    | 10.00 |    |
-| 17 | Layne Perkins      | Jacksonville, FL  | Freedom Christian | 55    | 6.88  |    |
-| 18 | Ope Morakinyo      | Ft Lauderdale, FL | Christian Life    | 50    | 6.25  |    |
-| 19 | Angela Magditch    | Warner Robins, GA | The Assembly      | 15    | 1.88  |    |
-| 20 | Logan Bennett      | Clermont, FL      | Gateway Church    | 10    | 1.25  |    |
-| 20 | Michael Davis      | Clermont, FL      | Gateway Church    | 10    | 1.25  |    |
-| 20 | Juan Velasco       | Lexington, NC     | 1st A/G           | 10    | 1.25  |    |
-| 20 | Casey Bailey       | Snellville, GA    | Evangel Community | 10    | 1.25  |    |
-| 21 | Timi Fagbamiye     | Warner Robins, GA | The Assembly      | 5     | .63   |    |
-| 22 | Silas Mims         | Montgomery, AL    | 1st A/G           |       | .00   |    |
-| 22 | Ashlyn Strahan     | Montgomery, AL    | 1st A/G           |       | .00   |    |
-| 22 | Savannah Mims      | Montgomery, AL    | 1st A/G           |       | .00   |    |
-| 22 | Greg Anderson      | Ft Lauderdale, FL | Christian Life    |       | .00   |    |
-| 22 | Lorena Lee         | Jacksonville, FL  | Freedom Christian |       | .00   |    |
-| 22 | Lexi Perkins       | Jacksonville, FL  | Freedom Christian |       | .00   |    |
-| 22 | Josue Benjamin     | Ft Lauderdale, FL | Christian Life    |       | .00   |    |
-| 22 | Amy Bailey         | Snellville, GA    | Evangel Community |       | .00   |    |
-| 22 | Mary Olowofela     | Ft Lauderdale, FL | Christian Life    |       | .00   |    |
-| 23 | Helyn Dunn         | Wesley Chapel, FL | Victorious Life   | -5    | -0.63 |    |
-| 23 | Daniel Olantunji   | Wesley Chapel, FL | Victorious Life   | -5    | -0.63 |    |
-| 23 | Beau Perkins       | Jacksonville, FL  | Freedom Christian | -5    | -0.63 |    |
+|    # | Quizzer            | Team              | Church            | Total |   Avg |   QO |
+| ---: | ------------------ | ----------------- | ----------------- | ----: | ----: | ---: |
+|    1 | Lindsay Cowan      | Toccoa, GA        | Toccoa A/G        |   730 | 91.25 |    6 |
+|    2 | Paul Willis        | Montgomery, AL    | 1st A/G           |   685 | 85.63 |    8 |
+|    3 | Teddy Willis       | Montgomery, AL    | 1st A/G           |   535 | 66.88 |    5 |
+|    4 | Oore Morakinyo     | Ft Lauderdale, FL | Christian Life    |   500 | 62.50 |    4 |
+|    5 | Emily Herron       | Warner Robins, GA | The Assembly      |   495 | 61.88 |    2 |
+|    6 | Veronica Johnson   | Warner Robins, GA | The Assembly      |   490 | 61.25 |    6 |
+|    7 | Brielle Smith      | Clermont, FL      | Gateway Church    |   445 | 55.63 |    4 |
+|    8 | Shannon Wolf       | Wesley Chapel, FL | Victorious Life   |   375 | 46.88 |      |
+|    9 | Lacey Cowan        | Toccoa, GA        | Toccoa A/G        |   340 | 42.50 |    2 |
+|   10 | Erinn Wolf         | Wesley Chapel, FL | Victorious Life   |   305 | 38.13 |    2 |
+|   11 | Elizabeth Olatunji | Wesley Chapel, FL | Victorious Life   |   270 | 33.75 |    1 |
+|   12 | Jose Solano        | Lexington, NC     | 1st A/G           |   195 | 24.38 |    1 |
+|   13 | Rowojo Okala       | Snellville, GA    | Evangel Community |   175 | 21.88 |      |
+|   14 | Rhashaan Omar      | Snellville, GA    | Evangel Community |   170 | 21.25 |    1 |
+|   15 | Anthony Sangermano | Ft Lauderdale, FL | Christian Life    |   130 | 16.25 |    1 |
+|   16 | Allison Johnson    | Toccoa, GA        | Toccoa A/G        |    80 | 10.00 |      |
+|   17 | Layne Perkins      | Jacksonville, FL  | Freedom Christian |    55 |  6.88 |      |
+|   18 | Ope Morakinyo      | Ft Lauderdale, FL | Christian Life    |    50 |  6.25 |      |
+|   19 | Angela Magditch    | Warner Robins, GA | The Assembly      |    15 |  1.88 |      |
+|   20 | Logan Bennett      | Clermont, FL      | Gateway Church    |    10 |  1.25 |      |
+|   20 | Michael Davis      | Clermont, FL      | Gateway Church    |    10 |  1.25 |      |
+|   20 | Juan Velasco       | Lexington, NC     | 1st A/G           |    10 |  1.25 |      |
+|   20 | Casey Bailey       | Snellville, GA    | Evangel Community |    10 |  1.25 |      |
+|   21 | Timi Fagbamiye     | Warner Robins, GA | The Assembly      |     5 |   .63 |      |
+|   22 | Silas Mims         | Montgomery, AL    | 1st A/G           |       |   .00 |      |
+|   22 | Ashlyn Strahan     | Montgomery, AL    | 1st A/G           |       |   .00 |      |
+|   22 | Savannah Mims      | Montgomery, AL    | 1st A/G           |       |   .00 |      |
+|   22 | Greg Anderson      | Ft Lauderdale, FL | Christian Life    |       |   .00 |      |
+|   22 | Lorena Lee         | Jacksonville, FL  | Freedom Christian |       |   .00 |      |
+|   22 | Lexi Perkins       | Jacksonville, FL  | Freedom Christian |       |   .00 |      |
+|   22 | Josue Benjamin     | Ft Lauderdale, FL | Christian Life    |       |   .00 |      |
+|   22 | Amy Bailey         | Snellville, GA    | Evangel Community |       |   .00 |      |
+|   22 | Mary Olowofela     | Ft Lauderdale, FL | Christian Life    |       |   .00 |      |
+|   23 | Helyn Dunn         | Wesley Chapel, FL | Victorious Life   |    -5 | -0.63 |      |
+|   23 | Daniel Olantunji   | Wesley Chapel, FL | Victorious Life   |    -5 | -0.63 |      |
+|   23 | Beau Perkins       | Jacksonville, FL  | Freedom Christian |    -5 | -0.63 |      |
+
+## Middle School Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+|    # | Team           | Church            | W/L | Total |    Avg |
+| ---: | -------------- | ----------------- | --- | ----: | -----: |
+|    1 | Middleburg, FL | Evangel Temple    | 8/0 |  1935 | 241.88 |
+|    2 | Norcross, GA   | Atlanta Tamil     | 5/3 |   550 |  68.75 |
+|    3 | Belleview, FL  | Sacred Fire       | 5/3 |   650 |  81.25 |
+|    4 | Clermont, FL   | Gateway Church    | 1/7 |    85 |  10.63 |
+|    5 | Snellville, GA | Evangel Community | 1/7 |   200 |     25 |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+|    # | Quizzer              | Team           | Church            | Total |    Avg |   QO |
+| ---: | -------------------- | -------------- | ----------------- | ----: | -----: | ---: |
+|    1 | James Joyce          | Middleburg, FL | Evangel Temple    |   845 | 105.63 |    7 |
+|    2 | Alexandria Eddy      | Middleburg, FL | Evangel Temple    |   675 |  84.38 |    8 |
+|    3 | Bryant Arias         | Belleview, FL  | Sacred Fire       |   485 |  60.63 |    3 |
+|    4 | Emmanuel Joshua      | Norcross, GA   | Atlanta Tamil     |   410 |  51.25 |    2 |
+|    5 | Samantha Eddy        | Middleburg, FL | Evangel Temple    |   385 |  48.13 |    3 |
+|    6 | Limi Okala           | Snellville, GA | Evangel Community |    95 |  11.88 |      |
+|    7 | Dalton Walker        | Belleview, FL  | Sacred Fire       |    90 |  11.25 |      |
+|    8 | Paul Igali           | Snellville, GA | Evangel Community |    80 |     10 |      |
+|    9 | Matthew Leppi        | Belleview, FL  | Sacred Fire       |    75 |   9.38 |      |
+|   10 | Kevin Samraj         | Norcross, GA   | Atlanta Tamil     |    70 |   8.75 |      |
+|   10 | Roshan Muthugomu     | Norcross, GA   | Atlanta Tamil     |    70 |   8.75 |      |
+|   11 | Joseph Davis         | Clermont, FL   | Gateway Church    |    60 |    7.5 |      |
+|   12 | Daniel Dave          | Middleburg, FL | Evangel Temple    |    35 |   4.38 |      |
+|   13 | Sam Lindsey          | Snellville, GA | Evangel Community |    30 |   3.75 |      |
+|   14 | Jonathan Daniel-Hegg | Clermont, FL   | Gateway Church    |    25 |   3.13 |      |
+|   15 | Abigail Bailey       | Snellville, GA | Evangel Community |       |      0 |      |
+|   15 | Toni Smith           | Clermont, FL   | Gateway Church    |       |      0 |      |
+|   15 | Megan Harris         | Snellville, GA | Evangel Community |       |      0 |      |
+|   15 | Trent Bennett        | Clermont, FL   | Gateway Church    |       |      0 |      |
+|   16 | Elijah Berry         | Snellville, GA | Evangel Community |    -5 |  -0.63 |      |

--- a/_pages/history/2014/regionals/southwest.md
+++ b/_pages/history/2014/regionals/southwest.md
@@ -1,0 +1,81 @@
+---
+layout: page
+title: "2014 Southwest Regionals"
+permalink: /history/2014/regionals/southwest/
+date: "2014-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2014 Season
+    link: /history/2014/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points. Scores sorted by Total.*
+
+|    # | Team                             | Church                     | W\L  | Total |    Avg |
+| ---: | -------------------------------- | -------------------------- | ---- | ----: | -----: |
+|    1 | God's Girlz A1                   | North Scottsdale Christian | 13\2 |  2485 | 165.67 |
+|    2 | North Valley A1                  | North Valley A/G           | 11\4 |  2540 | 169.33 |
+|    3 | Adelphoi A1                      | North Scottsdale Christian | 11\4 |  2455 | 163.67 |
+|    4 | Chosen-A1                        | Newport Mesa               | 6\9  |  1150 |  76.67 |
+|    5 | We have Fought the Good Fight A1 | Two Rivers Fellowship      | 3\12 |   945 |     63 |
+|    6 | Irvine A1                        | Irvine Samoan              | 1\14 |   685 |  45.67 |
+
+### Individuals
+
+*Ties broken by Quiz Outs. Scores sorted by Total.*
+
+|    # | Quizzer           | Team                             | Church                     | Total |   Avg |   QO |
+| ---: | ----------------- | -------------------------------- | -------------------------- | ----: | ----: | ---: |
+|    1 | Chad Stogner      | North Valley A1                  | North Valley A/G           |  1270 | 84.67 |   12 |
+|    2 | Stephen Moses     | Adelphoi A1                      | North Scottsdale Christian |  1230 |    82 |   10 |
+|    3 | Kenzie Brown      | God's Girlz A1                   | North Scottsdale Christian |   995 | 66.33 |    6 |
+|    4 | Hannah Smith      | God's Girlz A1                   | North Scottsdale Christian |   815 | 54.33 |    5 |
+|    5 | Kristina Van Gorp | We have Fought the Good Fight A1 | Two Rivers Fellowship      |   810 |    54 |    5 |
+|    6 | Zachary Kellock   | North Valley A1                  | North Valley A/G           |   760 | 50.67 |    4 |
+|    7 | David Moses       | Adelphoi A1                      | North Scottsdale Christian |   715 | 47.67 |    6 |
+|    8 | Kelsey Cruz       | Chosen-A1                        | Newport Mesa               |   705 |    47 |    5 |
+|    9 | Faith Brown       | God's Girlz A1                   | North Scottsdale Christian |   685 | 45.67 |    4 |
+|   10 | Ashley Kellock    | North Valley A1                  | North Valley A/G           |   515 | 34.33 |    2 |
+|   11 | Grace Xu          | Irvine A1                        | Irvine Samoan              |   510 |    34 |    3 |
+|   12 | Joanna Moses      | Adelphoi A1                      | North Scottsdale Christian |   470 | 31.33 |    4 |
+|   13 | Pearl Smith       | Chosen-A1                        | Newport Mesa               |   240 |    16 |      |
+|   14 | Josh Dupree       | Chosen-A1                        | Newport Mesa               |   210 |    14 |      |
+|   15 | Joy Van Gorp      | We have Fought the Good Fight A1 | Two Rivers Fellowship      |   135 |     9 |      |
+|   16 | Jeremy Wu         | Irvine A1                        | Irvine Samoan              |   100 |  6.67 |      |
+|   17 | Luke Ruan         | Irvine A1                        | Irvine Samoan              |    75 |     5 |      |
+|   18 | Peter Moses       | Adelphoi A1                      | North Scottsdale Christian |    50 |  3.33 |      |
+|   19 | Sophia Ouyang     | Irvine A1                        | Irvine Samoan              |       |     0 |      |
+|   19 | Jessica Baskette  | Chosen-A1                        | Newport Mesa               |       |     0 |      |
+|   19 | Kegn Venegas      | Chosen-A1                        | Newport Mesa               |       |     0 |      |
+|   19 | Samantha Oriza    | Adelphoi A1                      | North Scottsdale Christian |       |     0 |
+
+## Middle School Division
+
+### Teams
+
+|    # | Team                | Church            | W\L | Total |    Avg |
+| ---: | ------------------- | ----------------- | --- | ----: | -----: |
+|    1 | Kingdom Seekers MS1 | Beth Yachad       | 7\1 |  1560 |    195 |
+|    2 | Bible Warriors MS1  | Bethel Church     | 3\5 |  1175 | 146.88 |
+|    3 | Timberline MS1      | Timberline Church | 2\6 |  1025 | 128.13 |
+
+### Individuals
+
+|    # | Quizzer           | Team                | Church            | Total |    Avg |   QO |
+| ---: | ----------------- | ------------------- | ----------------- | ----: | -----: | ---: |
+|    1 | Erika Gozar       | Kingdom Seekers MS1 | Beth Yachad       |  1090 | 136.25 |    8 |
+|    2 | David Hill        | Timberline MS1      | Timberline Church |   785 |  98.13 |    5 |
+|    3 | Gabriel Roberts   | Bible Warriors MS1  | Bethel Church     |   710 |  88.75 |    6 |
+|    4 | Alexa Gozar       | Kingdom Seekers MS1 | Beth Yachad       |   475 |  59.38 |    5 |
+|    5 | Timothy Nirmal    | Bible Warriors MS1  | Bethel Church     |   465 |  58.13 |    4 |
+|    6 | Hudson Scandrett  | Timberline MS1      | Timberline Church |   240 |     30 |      |
+|    7 | Noah Kirbey       | Kingdom Seekers MS1 | Beth Yachad       |       |      0 |      |
+|    7 | Giovanni Panzetta | Kingdom Seekers MS1 | Beth Yachad       |       |      0 |      |
+|    8 | Ben Horowitz      | Kingdom Seekers MS1 | Beth Yachad       |    -5 |  -0.63 |      |

--- a/_pages/history/2015/regionals/gulf.md
+++ b/_pages/history/2015/regionals/gulf.md
@@ -1,0 +1,43 @@
+---
+layout: page
+title: "2015 Gulf Regionals"
+permalink: /history/2015/regionals/gulf/
+date: "2015-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2015 Season
+    link: /history/2015/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team                         |    W |    L | Total |  Avg |
+| ---: | ---------------------------- | ---: | ---: | ----: | ---: |
+|    1 | JRC - On Fire                |    3 |    0 |   435 |  145 |
+|    2 | JRC - Zeal                   |    2 |    1 |   345 |  115 |
+|    3 | Evangel Church               |    1 |    2 |   300 |  100 |
+|    4 | KC- Double Minded & Unstable |    0 |    3 |   300 |  100 |
+
+### Individuals
+
+|    # | Quizzer          | Team                         | Total |  Avg |   QO |
+| ---: | ---------------- | ---------------------------- | ----: | ---: | ---: |
+|    1 | Luna Cooper      | KC- Double Minded & Unstable |   215 |   72 |    1 |
+|    2 | Travis Griessel  | JRC - Zeal                   |   160 |   54 |    1 |
+|    3 | Daniel Quick     | JRC - On Fire                |   150 |   50 |    1 |
+|    4 | Leisl Jansen     | JRC - Zeal                   |   145 |   48 |    1 |
+|    5 | Hannah Quick     | JRC - On Fire                |   140 |   47 |    1 |
+|    6 | Tirzah Brookbank | Evangel Church               |   125 |   42 |    1 |
+|    6 | Zach Brookbank   | Evangel Church               |   125 |   42 |    1 |
+|    8 | Josh Clark       | JRC - On Fire                |    85 |   29 |    0 |
+|    8 | Kara Peters      | KC- Double Minded & Unstable |    85 |   29 |    1 |
+|   10 | Kacie Garrison   | JRC - On Fire                |    60 |   20 |    0 |
+|   11 | Jed Brookbank    | Evangel Church               |    55 |   19 |    0 |
+|   12 | Linsey Garrison  | JRC - Zeal                   |    30 |   10 |    0 |
+|   13 | Reagan Griessel  | JRC - Zeal                   |    10 |    4 |    0 |
+|   14 | Brock Peters     | KC- Double Minded & Unstable |     0 |    0 |    0 |

--- a/_pages/history/2015/regionals/north-central.md
+++ b/_pages/history/2015/regionals/north-central.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: "2015 North Central Regionals"
+permalink: /history/2015/regionals/north-central/
+date: "2015-05-18"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2015 Season
+    link: /history/2015/
+    icon: fas fa-home
+---
+
+## Teams
+
+|    # | Team             | Church             |    W |    L |   Avg |
+| ---: | ---------------- | ------------------ | ---: | ---: | ----: |
+|    1 | Racine, WI       | Racine AG          |    9 |    0 | 179.4 |
+|    2 | Rapid City, SD   | Bethel AG          |    8 |    1 | 201.1 |
+|    3 | Bismarck, ND     | Evangel AG         |    7 |    2 | 108.3 |
+|    4 | Sioux Falls, SD  | First AG           |    6 |    3 | 175.0 |
+|    5 | Cedar Rapids, IA | First AG           |    5 |    4 |  79.4 |
+|    6 | Brookfield, WI   | Victory Int. Fell. |    4 |    5 |  65.6 |
+|    7 | St Cloud, MN     | Relevant Life      |    3 |    6 |  51.7 |
+|    8 | Gering, NE       | Northfield AG      |    2 |    7 |  81.7 |
+|    9 | New Richmond, WI | Cornerstone AG     |    1 |    8 |  20.0 |
+|   10 | Valentine, NE    | Crossroads AG      |    0 |    9 |  17.8 |
+
+## Individuals
+
+|    # | Quizzer           | Team             | Total |   Avg |   QO |
+| ---: | ----------------- | ---------------- | ----: | ----: | ---: |
+|    1 | Selena Rodriguez  | Sioux Falls, SD  |  1150 | 127.8 |    8 |
+|    2 | Spenser Wilhelmn  | Rapid City, SD   |   945 | 105.0 |    6 |
+|    3 | Christian Jackson | Racine, WI       |   810 |  90.0 |    6 |
+|    4 | Abby Swanson      | Gering, NE       |   650 |  72.2 |    4 |
+|    5 | Jessica Weller    | Rapid City, SD   |   595 |  66.1 |    6 |
+|    6 | Lillian Mione     | Cedar Rapids, IA |   540 |  60.0 |    3 |
+|    7 | Victoria Anderson | St. Cloud, MN    |   480 |  53.3 |    3 |
+|    8 | Danelle Ragains   | Bismarck, ND     |   415 |  46.1 |    3 |
+|    9 | Rebekah Toeller   | Racine, WI       |   410 |  45.6 |    3 |
+|   10 | Lucas Bender      | Bismarck, ND     |   400 |  44.4 |    3 |
+|   11 | Reanna Toeller    | Racine, WI       |   395 |  43.9 |    4 |
+|   12 | Caleb Bloomberg   | Brookfield, WI   |   335 |  37.2 |    3 |
+|   13 | Brianna McKinley  | Sioux Falls, SD  |   335 |  37.2 |    2 |
+|   14 | Samuel Dimmock    | Brookfield, WI   |   255 |  28.3 |    1 |
+|   15 | Joelle Rapp       | New Richmond, WI |   230 |  25.6 |    1 |
+|   16 | Carson Sehr       | Rapid City, SD   |   180 |  20.0 |    2 |
+|   17 | Trinity Ternes    | Bismarck, ND     |   170 |  18.9 |    1 |
+|   18 | Bethia Hamilton   | Gering, NE       |    90 |  10.0 |      |
+|   19 | Matthew Coder     | Cedar Rapids, IA |    80 |   8.9 |      |
+|   20 | Chad Schwartz     | Sioux Falls, SD  |    80 |   8.9 |      |
+|   21 | Derek Kunkle      | Cedar Rapids, IA |    75 |   8.3 |      |
+|   22 | Carson Buer       | Valentine, NE    |    75 |   8.3 |      |
+|   23 | Curtis Svenson    | Rapid City, SD   |    50 |   5.6 |      |
+|   24 | Isable Wilhelm    | Rapid City, SD   |    40 |   4.4 |      |
+|   25 | Bradi Larabee     | Valentine, NE    |    35 |   3.9 |      |
+|   26 | Daniel Mione      | Cedar Rapids, IA |    25 |   2.8 |      |
+|   27 | Erik Carlson      | Racine, WI       |    20 |   2.2 |      |
+|   28 | Maegan Crawford   | New Richmond, WI |    10 |   1.1 |      |
+|   29 | Merisa Rodriguez  | Sioux Falls, SD  |    10 |   1.1 |      |
+|   30 | Gabriel Dunkel    | Valentine, NE    |    10 |   1.1 |      |
+|   31 | Levi Hamilton     | Gering, NE       |    -5 |  -0.6 |      |
+|   32 | Dahlia Rzeszutek  | St. Cloud, MN    |   -10 |  -1.1 |      |
+|   33 | Janae Rapp        | New Richmond, WI |   -60 |  -6.7 |      |

--- a/_pages/history/2015/regionals/northeast.md
+++ b/_pages/history/2015/regionals/northeast.md
@@ -1,0 +1,106 @@
+---
+layout: page
+title: "2015 Northeast Regionals"
+permalink: /history/2015/regionals/northeast/
+date: "2022-05-11"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2015 Season
+    link: /history/2015/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+|    # | Team                               | Church                   |                W\L | Total |    Avg |
+| ---: | ---------------------------------- | ------------------------ | -----------------: | ----- | -----: |
+|    1 | Upper St Clair - Fear the Sword    | New Day AG - PA          |               13\0 | 2750  | 211.54 |
+|    2 | Deposit                            | Maple Lane AG - NY       |               11\2 | 2595  | 199.62 |
+|    3 | Wyckoff - Bethany 1                | Bethany AG - NJ          |               11\2 | 2505  | 192.69 |
+|    4 | Newport - Wild by Nature           | Newport AG - PA          |  9\4 - Won Playoff | 1720  | 132.31 |
+|    5 | Mechanicsville                     | Mechanicsville CC - VA   | 9\4 - Lost Playoff | 1510  | 116.15 |
+|    6 | Sarver - What Shall We Say Then    | Evangel Heights AG - PA  |                8\5 | 1690  | 130.00 |
+|    7 | Swedesboro - #Synomical            | Living Hope WC - NJ      |  6\7 - Won Playoff | 2090  | 160.77 |
+|    8 | Binghamton                         | First AG - NY            | 6\7 - Lost Playoff | 1180  |  90.77 |
+|    9 | Bowie - Set on Fire                | Cornerstone Church - MD  |                5\8 | 1260  |  96.92 |
+|   10 | Newark - Sanctified                | Vailsburg AG - NJ        |  4\9 - Won Playoff | 1435  | 110.38 |
+|   11 | Springfield                        | Word of Life - VA        | 4\9 - Lost Playoff | 1155  |  88.85 |
+|   12 | Waynesburg - Devoted Conquerors    | First AG - PA            |          4\9 - DNP | 1310  | 100.77 |
+|   13 | Bethel Park - More Than Conquerors | South Hills AG - PA      |               1\12 | 520   |  40.00 |
+|   14 | Allison Park - The Untitled        | Allison Park Church - PA |               0\13 | 555   |  42.69 |
+
+### Individuals (Top 15)
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+|    # | Quizzer         | Team                            | Church                  | Total |    Avg |   QO |
+| ---: | --------------- | ------------------------------- | ----------------------- | ----: | -----: | ---: |
+|    1 | Jonathan Brown  | Upper St Clair - Fear the Sword | New Day AG - PA         |  1480 | 113.85 |   13 |
+|    2 | Halle Reisinger | Newport - Wild by Nature        | Newport AG - PA         |  1220 |  93.85 |    9 |
+|    3 | Tyler Adelmann  | Wyckoff - Bethany 1             | Bethany AG - NJ         |  1220 |  93.85 |    9 |
+|    4 | Sophie Benco    | Waynesburg - Devoted Conquerors | First AG - PA           |  1195 |  91.92 |    9 |
+|    5 | Chase Hill      | Swedesboro - #Synomical         | Living Hope WC - NJ     |  1145 |  88.08 |   10 |
+|    6 | Joseph Lemley   | Upper St Clair - Fear the Sword | New Day AG - PA         |  1130 |  86.92 |   11 |
+|    7 | Gabriel Flores  | Wyckoff - Bethany 1             | Bethany AG - NJ         |  1085 |  83.46 |    9 |
+|    8 | Solomon Stevens | Deposit                         | Maple Lane AG - NY      |  1020 |  78.46 |    8 |
+|    9 | Madison Holcomb | Sarver - What Shall We Say Then | Evangel Heights AG - PA |   980 |  75.38 |    7 |
+|   10 | Joshua Kukuvka  | Mechanicsville                  | Mechanicsville CC - VA  |   960 |  73.85 |    8 |
+|   11 | Caleb Hoffmann  | Deposit                         | Maple Lane AG - NY      |   950 |  73.08 |    8 |
+|   12 | Chad Sederwall  | Newark - Sanctified             | Vailsburg AG - NJ       |   760 |  58.46 |    4 |
+|   13 | Katrina Dowdy   | Swedesboro - #Synomical         | Living Hope WC - NJ     |   740 |  56.92 |    5 |
+|   14 | Nick Congdon    | Binghamton                      | First AG - NY           |   720 |  55.38 |    5 |
+|   15 | Divya Mathews   | Springfield                     | Word of Life - VA       |   630 |  48.46 |    3 |
+
+## Middle School Division
+
+### Teams
+
+*2 way ties broken by head to head, 3+ way ties broken by points (Scores sorted by TOTAL)*
+
+|    # | Team                                 | Church                  |                      W\L | Total |    Avg |
+| ---: | ------------------------------------ | ----------------------- | -----------------------: | ----- | -----: |
+|    1 | Chelsea - Alive in Christ            | Kennebec Valley AG - ME |                     14\2 | 2910  | 181.88 |
+|    2 | Springfield                          | Word of Life - VA       |  12\4 - Won Head to Head | 2605  | 162.81 |
+|    3 | Upper St Clair - Not Worth Comparing | New Day AG - PA         | 12\4 - Lost Head to Head | 3060  | 191.25 |
+|    4 | Burlington - More Than Quizzers      | Fountain of Life - NJ   |                     11\5 | 2265  | 141.56 |
+|    5 | Wyckoff - 1                          | Bethany Church - NJ     |  10\6 - Won Head to Head | 2105  | 131.56 |
+|    6 | Binghamton                           | First AG - NY           | 10\6 - Lost Head to Head | 3160  |  197.5 |
+|    7 | Smithtown                            | Smithtown GT - NY       |                      9\7 | 2290  | 143.13 |
+|    8 | Charleston - Justified               | Charleston PC - ME      |             8\8 - Points | 2495  | 155.94 |
+|    9 | Waynesburg - Unashamed               | First AG - PA           |             8\8 - Points | 1995  | 124.69 |
+|   10 | Bowie - For the Sake of Food         | Cornerstone Church - MD |             8\8 - Points | 1865  | 116.56 |
+|   11 | Houston - Merciful Triumphs          | Central AG - PA         |             8\8 - Points | 1700  | 106.25 |
+|   12 | Blackwood                            | Bethel CC - NJ          |                      7\9 | 1560  |   97.5 |
+|   13 | Wyckoff - 2                          | Bethany Church - NJ     |  6\10 - Won Head to Head | 1665  | 104.06 |
+|   14 | Scotch Plains - God is Our Avenger   | Evangel AG - NJ         | 6\10 - Lost Head to Head | 1720  |  107.5 |
+|   15 | Mechanicsville                       | Mechanicsville CC - VA  |                     5\11 | 1690  | 105.63 |
+|   16 | Bethel Park - Mere Human Beings      | South Hills AG - PA     |  1\15 - Won Head to Head | 980   |  61.25 |
+|   17 | Ephrata - Future Glory               | Evangel AG - PA         | 1\15 - Lost Head to Head | 810   |  50.63 |
+
+### Individuals
+
+*Ties broken by QuizOuts (Scores sorted by TOTAL)*
+
+|    # | Quizzer                   | Team                                 | Church                  | Total |    Avg |   QO |
+| ---: | ------------------------- | ------------------------------------ | ----------------------- | ----: | -----: | ---: |
+|    1 | Allyson Waller            | Chelsea - Alive in Christ            | Kennebec Valley AG - ME |  2060 | 128.75 |   15 |
+|    2 | Julie-Anna Cherednichenko | Binghamton                           | First AG - NY           |  1875 | 117.19 |   14 |
+|    3 | Nigus Dawit               | Springfield                          | Word of Life - VA       |  1820 | 113.75 |   14 |
+|    4 | Jonathan Baily            | Waynesburg - Unashamed               | First AG - PA           |  1665 | 104.06 |   12 |
+|    5 | Zach Budday               | Upper St Clair - Not Worth Comparing | New Day AG - PA         |  1520 |     95 |   12 |
+|    6 | Savannah Cosme            | Burlington - More Than Quizzers      | Fountain of Life - NJ   |  1350 |  84.38 |   10 |
+|    7 | Samuel Thrift             | Charleston - Justified               | Charleston PC - ME      |  1295 |  80.94 |   10 |
+|    8 | Seth Robertson            | Houston - Merciful Triumphs          | Central AG - PA         |  1250 |  78.13 |    8 |
+|    9 | Ronald Barr               | Blackwood                            | Bethel CC - NJ          |  1210 |  75.63 |   12 |
+|   10 | Garrett Adelmann          | Wyckoff - 2                          | Bethany Church - NJ     |  1105 |  69.06 |    8 |
+|   11 | Andrew Scarinzi           | Binghamton                           | First AG - NY           |  1100 |  68.75 |    9 |
+|   12 | Benshel Bright            | Scotch Plains - God is Our Avenger   | Evangel AG - NJ         |   995 |  62.19 |    5 |
+|   13 | Hannah Erdvig             | Smithtown                            | Smithtown GT - NY       |   945 |  59.06 |    7 |
+|   14 | Joel Thompson             | Bowie - For the Sake of Food         | Cornerstone Church - MD |   875 |  54.69 |    6 |
+|   15 | Leo Hsu                   | Smithtown                            | Smithtown GT - NY       |   865 |  54.06 |    3 |

--- a/_pages/history/2015/regionals/northwest.md
+++ b/_pages/history/2015/regionals/northwest.md
@@ -1,0 +1,98 @@
+---
+layout: page
+title: "2015 Northwest Regionals"
+permalink: /history/2015/regionals/northwest/
+date: "2015-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2015 Season
+    link: /history/2015/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team                      |    W |    L | Total |  Avg |
+| ---: | ------------------------- | ---: | ---: | ----: | ---: |
+|    1 | CPC-Smooth With Something |    7 |    - | 2,110 |  301 |
+|    2 | TLC-Hold No Terror*       |    5 |    2 |   900 |  129 |
+|    3 | BNC-Quick To Listen*      |    5 |    2 | 1,120 |  160 |
+|    4 | KLC-Wild By Nature*       |    4 |    3 |   520 |   74 |
+|    5 | CPC-Zeal Based On*        |    4 |    3 | 1,205 |  172 |
+|    6 | NLC-Trip Trap             |    2 |    5 |   455 |   65 |
+|    7 | MAG-Shifting Shadows      |    1 |    6 |   300 |   43 |
+|    8 | MT-All-Star Team          |    - |    7 |   355 |   51 |
+
+\* TLC beat BNC head-to-head, and KLC beat CPC2 head-to-head
+
+### Individuals
+
+|    # | Quizzer             | Team                      | Total |  Avg |
+| ---: | ------------------- | ------------------------- | ----: | ---: |
+|    1 | Abby Rogers         | CPC-Smooth With Something | 1,020 |  146 |
+|    2 | Abigail Peterson    | TLC-Hold No Terror        |   790 |  113 |
+|    3 | Damon Comfort       | BNC-Quick To Listen       |   695 |   99 |
+|    4 | Reid Jarrell        | CPC-Zeal Based On         |   545 |   78 |
+|    5 | EJ Olsen            | CPC-Smooth With Something |   525 |   75 |
+|    6 | Joshua Roberts      | CPC-Zeal Based On         |   420 |   60 |
+|    7 | Jacob Schumacher    | CPC-Smooth With Something |   400 |   57 |
+|    8 | Brayden Olson       | KLC-Wild By Nature        |   395 |   56 |
+|    9 | Iva Papini          | NLC-Trip Trap             |   350 |   50 |
+|   10 | Kaelyn Comfort      | BNC-Quick To Listen       |   245 |   35 |
+|   11 | Shayliana Mills     | CPC-Zeal Based On         |   190 |   27 |
+|   12 | Jackson Houser      | CPC-Smooth With Something |   165 |   24 |
+|   13 | Teddy Arasavelli    | BNC-Quick To Listen       |   165 |   24 |
+|   14 | Abby Boyce          | MT-All-Star Team          |   160 |   23 |
+|   15 | Nicole Kreiner      | MAG-Shifting Shadows      |   155 |   22 |
+|   16 | Annalise Guy        | MT-All-Star Team          |   140 |   20 |
+|   17 | Jessica Kreiner     | MAG-Shifting Shadows      |   135 |   19 |
+|   18 | Sofia Papini        | NLC-Trip Trap             |   105 |   15 |
+|   19 | Samuel Dawson       | TLC-Hold No Terror        |    80 |   11 |
+|   20 | Kristina Hisel      | KLC-Wild By Nature        |    80 |   11 |
+|   21 | Jonathan Roberts    | CPC-Zeal Based On         |    70 |   10 |
+|   22 | Daniel Guy          | MT-All-Star Team          |    60 |    9 |
+|   23 | Jake Wright         | KLC-Wild By Nature        |    45 |    6 |
+|   24 | Alyssa Staub        | TLC-Hold No Terror        |    30 |    4 |
+|   25 | Noah Gallo          | BNC-Quick To Listen       |    15 |    2 |
+|   26 | Cameron Hale        | MAG-Shifting Shadows      |    10 |    1 |
+|   27 | Andre' Nicolov      | CPC-Smooth With Something |     - |    - |
+|   28 | Nicholas Schumacher | CPC-Zeal Based On         |     - |    - |
+|   29 | Izhanna Erickson    | MT-All-Star Team          |     - |    - |
+|   30 | Korbyn Rague        | MT-All-Star Team          |     - |    - |
+|   31 | Seth Donaldson      | TLC-Hold No Terror        |     - |    - |
+|   32 | Louis Hwang         | TLC-Hold No Terror        |     - |    - |
+|   33 | Christopher Kreiner | MAG-Shifting Shadows      |     - |    - |
+|   34 | Ellen Jacobs        | NLC-Trip Trap             |     - |    - |
+|   35 | Giulia Papini       | NLC-Trip Trap             |     - |    - |
+|   36 | Nathan Jacobs       | NLC-Trip Trap             |     - |    - |
+|   37 | Johan West          | CPC-Zeal Based On         |   -10 |   -1 |
+
+## Middle School Division
+
+### Teams
+
+|    # | Team               |    W |    L | Total |  Avg |
+| ---: | ------------------ | ---: | ---: | ----: | ---: |
+|    1 | CPC-J.A.C.K.       |    5 |    1 | 1,510 |  252 |
+|    2 | KLC-Dough          |    4 |    2 |   795 |  133 |
+|    3 | NCF-Those Gentiles |    - |    6 |    95 |   16 |
+
+### Individuals
+
+|    # | Quizzer               | Team               | Total |  Avg |
+| ---: | --------------------- | ------------------ | ----: | ---: |
+|    1 | Anastasia Yentushenko | CPC-J.A.C.K.       |   445 |   74 |
+|    2 | Cecily Houser         | CPC-J.A.C.K.       |   400 |   67 |
+|    3 | Jenna Roberts         | CPC-J.A.C.K.       |   355 |   59 |
+|    4 | Delaney Gillihan      | KLC-Dough          |   325 |   54 |
+|    5 | Kiley Frank           | CPC-J.A.C.K.       |   310 |   52 |
+|    6 | Miguel Lopez          | KLC-Dough          |   250 |   42 |
+|    7 | Coralina Elhart       | KLC-Dough          |   220 |   37 |
+|    8 | Jessie Hamilton       | NCF-Those Gentiles |    45 |    8 |
+|    9 | McKenzie Sorrell      | NCF-Those Gentiles |    45 |    8 |
+|   10 | Ryan Simpson          | NCF-Those Gentiles |     5 |    1 |
+|   11 | Tairin Wright         | KLC-Dough          |     - |    - |

--- a/_pages/history/2015/regionals/south-central.md
+++ b/_pages/history/2015/regionals/south-central.md
@@ -1,0 +1,64 @@
+---
+layout: page
+title: "2015 South Central Regionals"
+permalink: /history/2015/regionals/south-central/
+date: "2022-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2015 Season
+    link: /history/2015/
+    icon: fas fa-home
+---
+
+## A League
+
+### Teams
+
+|    # | Church              | City           |    W |    L | Total |    Avg |
+| ---: | ------------------- | -------------- | ---: | ---: | ----: | -----: |
+|    1 | Braeswood A/G       | Houston, TX    |    5 |    1 |   620 | 103.33 |
+|    2 | Muskogee First #1   | Muskogee, OK   |    4 |    2 |   820 | 136.67 |
+|    3 | Muskogee First #2   | Muskogee, OK   |    4 |    2 |   665 | 110.83 |
+|    4 | CT Church           | Houston, TX    |    2 |    4 |   705 |  117.5 |
+|    5 | Trinity Church      | Cedar Hill, TX |    2 |    4 |   750 |    125 |
+|    6 | The Oaks Fellowship | Red Oak, TX    |    2 |    4 |   525 |   87.5 |
+|    7 | Memorial A/G        | Purcell, OK    |    2 |    4 |   605 | 100.83 |
+
+### Individuals (Top 10)
+
+|    # | Name                | Church                           | Total |   Avg |   QO |
+| ---: | ------------------- | -------------------------------- | ----: | ----: | ---: |
+|    1 | Faith King          | Memorial A/G, Purcell, OK        |   565 | 94.17 |    4 |
+|    2 | David Meddaugh      | Muskogee First #1, Muskogee, OK  |   470 | 78.33 |    3 |
+|    3 | John David Sullivan | Trinity Church, Cedar Hill, TX   |   460 | 76.67 |    3 |
+|    4 | Andrew Roach        | CT Church, Houston, TX           |   390 |    65 |    3 |
+|    5 | Mary Meddaugh       | Muskogee First #2, Muskogee, OK  |   385 | 64.17 |    4 |
+|    6 | Sydny Bettis        | CT Church, Houston, TX           |   325 | 54.17 |    3 |
+|    7 | Cameron Berta       | The Oaks Fellowship, Red Oak, TX |   310 | 51.67 |    2 |
+|    8 | Michael Williams    | Muskogee First #2, Muskogee, OK  |   285 |  47.5 |    1 |
+|    9 | Chime Nwogu         | Braeswood A/G, Houston, TX       |   265 | 44.17 |    1 |
+|   10 | Taylor Ellis        | Braeswood A/G, Houston, TX       |   225 |  37.5 |    2 |
+
+## MSQ League
+
+### Teams
+
+|    # | Church         | City         |    W |    L | Total |    Avg |
+| ---: | -------------- | ------------ | ---: | ---: | ----: | -----: |
+|    1 | CT Church      | Houston, TX  |    5 |    1 |   820 | 136.67 |
+|    2 | Spring First   | Spring, TX   |    4 |    2 |   820 | 136.67 |
+|    3 | Noble A/G      | Noble, OK    |    3 |    4 |   615 |  102.5 |
+|    4 | Muskogee First | Muskogee, OK |    2 |    5 |   310 |  51.67 |
+
+### Individuals (Top 6)
+
+|    # | Name              | Church                       | Total |   Avg |   QO |
+| ---: | ----------------- | ---------------------------- | ----: | ----: | ---: |
+|    1 | Jason Royer       | Spring First, Spring, OK     |   560 | 93.33 |    5 |
+|    2 | Reggie Conner     | CT Church, Houston, TX       |   505 | 84.17 |    5 |
+|    3 | Britney Pitts     | Noble A/G, Noble, OK         |   350 | 58.33 |    3 |
+|    4 | Lizzie Kirby      | CT Church, Houston, TX       |   315 |  52.5 |      |
+|    5 | Izzy Lashley-Bobb | Muskogee First, Muskogee, OK |   295 | 49.17 |    1 |
+|    6 | Gabrielle Bell    | Noble A/G, Noble, OK         |   225 |  37.5 |    1 |

--- a/_pages/history/2016/regionals/great-lakes.md
+++ b/_pages/history/2016/regionals/great-lakes.md
@@ -1,0 +1,123 @@
+---
+layout: page
+title: "2016 Great Lakes Regionals"
+permalink: /history/2016/regionals/great-lakes/
+date: "2016-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2016 Season
+    link: /history/2016/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team                             | Total |   Avg |    W |    L |
+| ---: | -------------------------------- | ----: | ----: | ---: | ---: |
+|    1 | Calvary Church - Naperville, IL  |  1900 | 190.0 |    9 |    1 |
+|   2* | First A/G - Lexington, KY        |  1720 | 172.0 |    8 |    2 |
+|   3* | 1st A/G of Greater Lansing, MI   |  1455 | 145.5 |    8 |    2 |
+|  4** | Grant A/G - Grant, MI            |  1195 | 119.5 |    7 |    3 |
+|  5** | Stone Church - Orland Park, IL   |  1145 | 114.5 |    7 |    3 |
+|    6 | Trinity - Georgetown, KY         |   985 |  98.5 |    6 |    4 |
+|    7 | Calvary Church - Sugar Grove, IL |   480 |  48.0 |    4 |    6 |
+|    8 | 1st A/G - Louisville, OH #2      |   140 |  14.0 |    3 |    7 |
+|    9 | Calvary-/ Elkhart, IN            |   230 |  23.0 |    2 |    8 |
+|   10 | Radiant Life Church - Dublin, OH |   135 |  13.5 |    1 |    9 |
+|   11 | 1st A/G - Louisville, OH #1      |    10 |   1.0 |    0 |   10 |
+
+\* Tie for 2nd place broken by head to head.\
+\*\* Tie for 4th place broken by playoff.
+
+### Individuals
+
+|    # | Quizzer            | Total |   Avg | QO Fwd | QO Bk |
+| ---: | ------------------ | ----: | ----: | -----: | ----: |
+|    1 | Josiah Smith       |  1015 | 101.5 |      8 |     2 |
+|    2 | Caleb Czaja        |   930 |  93.0 |      9 |     0 |
+|    3 | Shreanna Powell    |   905 |  90.5 |      8 |     0 |
+|    4 | Sheldon Powell     |   710 |  71.0 |      7 |     2 |
+|    5 | Celah Convis       |   625 |  62.5 |      5 |     0 |
+|    6 | Noah Barnes        |   625 |  62.5 |      5 |     2 |
+|    7 | Faith Pryer        |   610 |  61.0 |      4 |     3 |
+|    8 | Darcie Harr        |   585 |  58.5 |      5 |     1 |
+|    9 | Aaron Pryer        |   555 |  55.5 |      5 |     4 |
+|   10 | Seth Smith         |   485 |  48.5 |      5 |     3 |
+|   11 | Chris Turner       |   340 |  34.0 |      2 |     0 |
+|   12 | Ezequiel Navarro   |   325 |  32.5 |      1 |     0 |
+|   13 | Harrison Stevens   |   285 |  28.5 |      1 |     0 |
+|   14 | Kyla Schrock       |   230 |  23.0 |      1 |     3 |
+|   15 | Anna Kelly         |   180 |  18.0 |      0 |     1 |
+|   16 | Luke Lydecker      |   155 |  15.5 |      0 |     0 |
+|   17 | Jonathan Mafe      |   155 |  15.5 |      0 |     0 |
+|   18 | Camryn Stuart      |   135 |  13.5 |      0 |     0 |
+|   19 | Darren Hester      |   115 |  11.5 |      0 |     1 |
+|   20 | Claire Convis      |    70 |   7.0 |      0 |     0 |
+|   21 | Willow Chemacki    |    55 |   5.5 |      0 |     1 |
+|   22 | Naomi Czaja        |    45 |   4.5 |      0 |     0 |
+|   23 | Mike Galliers      |    40 |   4.0 |      0 |     0 |
+|   24 | Tayo Omoniyi       |    35 |   3.5 |      0 |     0 |
+|   25 | Logan Weist        |    30 |   3.0 |      0 |     0 |
+|   26 | David Cherry       |    30 |   3.0 |      0 |     0 |
+|   27 | Hope Fuller        |    25 |   2.5 |      0 |     0 |
+|   28 | Issac Chemacki     |    25 |   2.5 |      0 |     0 |
+|   29 | Zachary Chemacki   |    25 |   2.5 |      0 |     1 |
+|   30 | Shannon Tinney     |    20 |   2.0 |      0 |     0 |
+|   31 | Zoie Mafe          |    20 |   2.0 |      0 |     0 |
+|   32 | Connor Norquest    |    15 |   1.5 |      0 |     0 |
+|   33 | Lauren Randolph    |     0 |   0.0 |      0 |     0 |
+|   34 | Jonathon Cherry    |     0 |   0.0 |      0 |     0 |
+|   35 | Hannah Robeck      |     0 |   0.0 |      0 |     0 |
+|   36 | Austin Harr        |     0 |   0.0 |      0 |     0 |
+|   37 | Cody Weist         |     0 |   0.0 |      0 |     0 |
+|   38 | Jeremiah Watene    |     0 |   0.0 |      0 |     0 |
+|   39 | Gwendalynn Costlow |     0 |   0.0 |      0 |     0 |
+|   40 | Allison Norquest   |     0 |   0.0 |      0 |     0 |
+|   41 | Victoria Vaught    |     0 |   0.0 |      0 |     0 |
+|   42 | Cameron Norquest   |     0 |   0.0 |      0 |     0 |
+|   43 | Emmanuel Navarro   |     0 |   0.0 |      0 |     0 |
+|   44 | Anna Somerlot      |     0 |   0.0 |      0 |     0 |
+|   45 | Autumn Deaton      |     0 |   0.0 |      0 |     0 |
+|   46 | Sarah Carrico      |    -5 |  -0.5 |      0 |     0 |
+
+## Middle School Division
+
+### Teams
+
+|    # | Team                            | Total |   Avg |    W |    L |
+| ---: | ------------------------------- | ----: | ----: | ---: | ---: |
+|   1* | Trinity - Georgetown, KY        |  1135 | 113.5 |    5 |    3 |
+|   2* | Calvary Church - Naperville, IL |   935 |  93.5 |    5 |    3 |
+|   3* | Lighthouse - Cuyahoga Falls, OH |   875 |  87.5 |    5 |    3 |
+|    4 | Stone Church - Orland Park, IL  |   970 |  97.0 |    4 |    4 |
+|    5 | Lakeview - Indianapolis, IN     |   800 |  80.0 |    1 |    7 |
+
+\* Three way tie for 1st place broken by playoff.
+
+### Individuals
+
+|    # | Quizzer        | Total |  Avg | QO Fwd | QO Bk |
+| ---: | -------------- | ----: | ---: | -----: | ----: |
+|    1 | Caleb Cullins  |   780 | 78.0 |      6 |     0 |
+|    2 | Gideon Thomas  |   720 | 72.0 |      6 |     0 |
+|    3 | Hannah Tinney  |   615 | 61.5 |      5 |     0 |
+|    4 | Carol Paleti   |   500 | 50.0 |      3 |     0 |
+|    5 | Kemi Omoniyi   |   500 | 50.0 |      3 |     0 |
+|    6 | Ethan Satish   |   425 | 42.5 |      2 |     1 |
+|    7 | Steven Satish  |   350 | 35.0 |      2 |     0 |
+|    8 | Miriam Czaja   |   260 | 26.0 |      0 |     0 |
+|    9 | Collin Bougher |   210 | 21.0 |      0 |     0 |
+|   10 | Nicola Betz    |   170 | 17.0 |      0 |     0 |
+|   11 | Emily Buess    |    55 |  5.5 |      0 |     2 |
+|   12 | Nathan Brown   |    50 |  5.0 |      0 |     0 |
+|   13 | Noah Neal      |    45 |  4.5 |      0 |     0 |
+|   14 | Tabby Brooks   |    30 |  3.0 |      0 |     0 |
+|   15 | Raja Jones     |    20 |  2.0 |      0 |     0 |
+|   16 | Alexa Chung    |     0 |  0.0 |      0 |     0 |
+|   17 | Lizzie Chung   |     0 |  0.0 |      0 |     0 |
+|   18 | Anna Kirsch    |     0 |  0.0 |      0 |     0 |
+|   19 | Andrew Berens  |     0 |  0.0 |      0 |     0 |

--- a/_pages/history/2016/regionals/gulf.md
+++ b/_pages/history/2016/regionals/gulf.md
@@ -1,0 +1,24 @@
+---
+layout: page
+title: "2016 Gulf Regionals"
+permalink: /history/2016/regionals/gulf/
+date: "2016-05-07"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2016 Season
+    link: /history/2016/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team                        |    W |    L | Total |  Avg |
+| ---: | --------------------------- | ---: | ---: | ----: | ---: |
+|    1 | JRC - Driving Your Insane   |    3 |    0 |   525 |  175 |
+|    2 | JRC - One in Heart and Mind |    2 |    1 |   190 |   63 |
+|    3 | Evangel Temple              |    1 |    2 |   245 |   81 |
+|    4 | Lee's Summit                |    0 |    3 |   180 |   60 |

--- a/_pages/history/2016/regionals/north-central.md
+++ b/_pages/history/2016/regionals/north-central.md
@@ -1,0 +1,60 @@
+---
+layout: page
+title: "2016 North Central Regionals"
+permalink: /history/2016/regionals/north-central/
+date: "2016-05-18"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2016 Season
+    link: /history/2016/
+    icon: fas fa-home
+---
+
+## Teams
+
+|    # | Team              | Church             |    W |    L |   Avg |
+| ---: | ----------------- | ------------------ | ---: | ---: | ----: |
+|    1 | Rapid City, SD #1 | Bethel AG          |    7 |    0 | 177.9 |
+|    2 | Sioux Falls, SD   | First AG           |    5 |    2 |  78.6 |
+|    3 | Brookfield, WI    | Victory Int. Fell. |    5 |    2 |  59.3 |
+|    4 | Valentine, NE #1  | Crossroads AG      |    4 |    3 |  62.1 |
+|    5 | Cedar Rapids, IA  | First AG           |    3 |    4 |  50.0 |
+|    6 | Rapid City, SD #2 | Bethel AG          |    3 |    4 |  22.1 |
+|    7 | Valentine, NE #2  | Crossroads AG      |    1 |    6 |   5.7 |
+|    8 | Richfield, MN     | Bethel's Rock      |    0 |    7 |  -0.7 |
+
+### Individuals
+
+|    # | Quizzer              | Team              | Total |   Avg |   QO |
+| ---: | -------------------- | ----------------- | ----: | ----: | ---: |
+|    1 | Spenser Wilhelm      | Rapid City, SD #1 |   890 | 127.1 |    7 |
+|    2 | Abigail Swanson      | Valentine, NE #1  |   365 |  52.1 |    3 |
+|    3 | David Blomberg       | Brookfield, WI    |   315 |  45.0 |    2 |
+|    4 | Cammi Kjetland       | Sioux Falls, SD   |   315 |  45.0 |    3 |
+|    5 | Lillian Mione        | Cedar Rapids, IA  |   295 |  42.1 |    1 |
+|    6 | Danelle Ragains      | Rapid City, SD #1 |   245 |  35.0 |    2 |
+|    7 | Brianna McKinley     | Sioux Falls, SD   |   160 |  22.9 |      |
+|    8 | Kodi Ladd            | Rapid City, SD #2 |   105 |  15.0 |      |
+|    9 | Caleb Blomberg       | Brookfield, WI    |    85 |  12.1 |      |
+|   10 | Noble Spire          | Rapid City, SD #1 |    75 |  10.7 |      |
+|   11 | Carson Buer          | Valentine, NE #1  |    75 |  10.7 |      |
+|   12 | Isabel Wilhelm       | Rapid City, SD #1 |    65 |   9.3 |      |
+|   13 | Merisa Rodriguez     | Sioux Falls, SD   |    40 |   5.7 |      |
+|   14 | Daniel Mione         | Cedar Rapids, IA  |    35 |   5.0 |      |
+|   15 | Matthew McKinley     | Sioux Falls, SD   |    35 |   5.0 |      |
+|   16 | Matthew Coder        | Cedar Rapids, IA  |    30 |   4.3 |      |
+|   17 | Amber Ragains        | Rapid City, SD #2 |    25 |   3.6 |      |
+|   18 | Hadli Langstaff      | Rapid City, SD #2 |    20 |   2.9 |      |
+|   19 | Faith Buer           | Valentine, NE #2  |    20 |   2.9 |      |
+|   20 | Logan Cate           | Valentine, NE #2  |    20 |   2.9 |      |
+|   21 | Samuel Dimmock       | Brookfield, WI    |    15 |   2.1 |      |
+|   22 | Derek Kunkle         | Cedar Rapids, IA  |     0 |   0.0 |      |
+|   23 | Rachel Fenenga       | Rapid City, SD #1 |     0 |   0.0 |      |
+|   24 | Bianca Biffert       | Richfield, MN     |     0 |   0.0 |      |
+|   25 | Lauren Freitag       | Richfield, MN     |     0 |   0.0 |      |
+|   26 | Mercy Maune          | Valentine, NE #1  |     0 |   0.0 |      |
+|   27 | Ashton Dehart        | Valentine, NE #2  |     0 |   0.0 |      |
+|   28 | Tabor Van Dusseldorp | Rapid City, SD #2 |    -5 |  -0.7 |      |
+|   29 | Bailey Biffert       | Richfield, MN     |    -5 |  -0.7 |      |

--- a/_pages/history/2016/regionals/northwest.md
+++ b/_pages/history/2016/regionals/northwest.md
@@ -1,0 +1,88 @@
+---
+layout: page
+title: "2016 Northwest Regionals"
+permalink: /history/2016/regionals/northwest/
+date: "2016-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2016 Season
+    link: /history/2016/
+    icon: fas fa-home
+---
+
+## A Division
+
+### Teams
+
+|    # | Team                   |    W |    L | Total |  Avg |
+| ---: | ---------------------- | ---: | ---: | ----: | ---: |
+|    1 | CPC-Savage NW Sirs     |   11 |    1 | 1,900 |  158 |
+|    2 | TLC-Without Hinderance |   10 |    2 | 1,465 |  122 |
+|    3 | CPC-Porcius Pines      |    7 |    5 |   945 |   79 |
+|    4 | BNC-Sour Patch Kids    |    7 |    5 |   895 |   75 |
+|    5 | KLC-Eaten by Worms     |    3 |    9 |   460 |   38 |
+|    6 | HAG-Spilled Intestines |    2 |   10 |   570 |   48 |
+|    7 | FV-Undeniable Facts    |    2 |   10 |   355 |   30 |
+
+### Individuals
+
+|    # | Quizzer               | Team                   | Total |  Avg |
+| ---: | --------------------- | ---------------------- | ----: | ---: |
+|    1 | Abigail Peterson      | TLC-Without Hinderance | 1,265 |  105 |
+|    2 | Jacob Schumacher      | CPC-Savage NW Sirs     | 1,000 |   83 |
+|    3 | Teddy Arasavelli      | BNC-Sour Patch Kids    |   730 |   61 |
+|    4 | Jackson Houser        | CPC-Savage NW Sirs     |   655 |   55 |
+|    5 | Alaynee Hawley        | HAG-Spilled Intestines |   460 |   38 |
+|    6 | Brayden Olson         | KLC-Eaten by Worms     |   455 |   38 |
+|    7 | Jonathan Zhu          | CPC-Porcius Pines      |   435 |   36 |
+|    8 | Reid Jarrell          | CPC-Savage NW Sirs     |   255 |   21 |
+|    9 | Daniel Guy            | FV-Undeniable Facts    |   205 |   17 |
+|   10 | Isaiah Hahn           | CPC-Porcius Pines      |   200 |   17 |
+|   11 | Annalise Guy          | FV-Undeniable Facts    |   170 |   14 |
+|   12 | Kaelyn Comfort        | CPC-Porcius Pines      |   150 |   13 |
+|   13 | Noah Gallo            | BNC-Sour Patch Kids    |   145 |   12 |
+|   14 | Anastasia Yevtushenko | CPC-Porcius Pines      |   140 |   12 |
+|   15 | Zach Ponraj           | TLC-Without Hinderance |   140 |   12 |
+|   16 | Abby Boyce            | HAG-Spilled Intestines |   110 |    9 |
+|   17 | Wyatt Peterson        | TLC-Without Hinderance |    60 |    5 |
+|   18 | Delaney Gillihan      | KLC-Eaten by Worms     |    60 |    5 |
+|   19 | Padmini Abothu        | BNC-Sour Patch Kids    |    40 |    3 |
+|   20 | Miguel Lopez          | KLC-Eaten by Worms     |    40 |    3 |
+|   21 | Johan West            | CPC-Porcius Pines      |    35 |    3 |
+|   22 | Jonathan Roberts      | CPC-Savage NW Sirs     |     - |    - |
+|   23 | Anna Gallo            | BNC-Sour Patch Kids    |     - |    - |
+|   24 | Seth Donaldson        | TLC-Without Hinderance |     - |    - |
+|   25 | Samuel Dawson         | TLC-Without Hinderance |     - |    - |
+|   26 | Tairin Wright         | KLC-Eaten by Worms     |     - |    - |
+|   27 | Izhanna Erickson      | HAG-Spilled Intestines |     - |    - |
+|   28 | Jeremiah Boe          | HAG-Spilled Intestines |     - |    - |
+|   29 | Joshua Roberts        | CPC-Savage NW Sirs     |    -5 |    0 |
+|   30 | Sharon Godavarthi     | BNC-Sour Patch Kids    |    -5 |    0 |
+|   31 | Josiah Boe            | FV-Undeniable Facts    |   -10 |   -1 |
+|   32 | Coralina Elhart       | KLC-Eaten by Worms     |   -75 |   -6 |
+
+## Middle School Division
+
+### Teams
+
+| #   | Team                   | W   | L   | Total | Avg |
+| --- | ---------------------- | --- | --- | ----- | --- |
+| 1   | BNC-Broom Hockey Mafia | 5   | 1   | 620   | 103 |
+| 2   | CPC-Isn't Human        | 3   | 3   | 545   | 91  |
+| 3   | BNC-All We Do…         | 1   | 5   | 85    | 14  |
+
+### Individuals
+
+|    # | Quizzer          | Team                   | Total |  Avg |
+| ---: | ---------------- | ---------------------- | ----: | ---: |
+|    1 | Samuel Clinston  | BNC-Broom Hockey Mafia |   475 |   79 |
+|    2 | Alex Jarrell     | CPC-Isn't Human        |   380 |   63 |
+|    3 | Christiaan West  | CPC-Isn't Human        |   130 |   22 |
+|    4 | Avinash Poguluri | BNC-Broom Hockey Mafia |    75 |   13 |
+|    5 | Ethan Kolakaluri | BNC-Broom Hockey Mafia |    70 |   12 |
+|    6 | Ryan Matta       | BNC-All We Do…         |    60 |   10 |
+|    7 | Erik Klimenko    | CPC-Isn't Human        |    35 |    6 |
+|    8 | Smily Avula      | BNC-All We Do…         |    20 |    3 |
+|    9 | Madie Lickey     | BNC-All We Do…         |     5 |    1 |

--- a/_pages/history/2017/regionals/southwest.md
+++ b/_pages/history/2017/regionals/southwest.md
@@ -1,0 +1,50 @@
+---
+layout: page
+title: "2017 Southwest Regionals"
+permalink: /history/2017/regionals/southwest/
+date: "2017-05-03"
+toc_title: Results
+menubar_toc: true
+menubar_toc_static:
+- items:
+  - name: 2017 Season
+    link: /history/2017/
+    icon: fas fa-home
+---
+
+## Teams
+
+|    # | Team                    |    W |    L | Total |  Avg |
+| ---: | ----------------------- | ---: | ---: | ----: | ---: |
+|    1 | Made the Two Groups One |   10 |    0 |  2380 |  238 |
+|    2 | God's Chosen People     |    8 |    2 |  1635 |  164 |
+|    3 | New Creation            |    6 |    4 |   840 |   84 |
+|    4 | Foolish Galatian        |    3 |    7 |   470 |   47 |
+|    5 | Newport Mesa            |    3 |    7 |   340 |   34 |
+|    6 | God's Holy People       |    0 |   10 |   130 |   13 |
+
+## Individuals
+
+|    # | Quizzer            | Team                    | Total |   QO |  Avg |
+| ---: | ------------------ | ----------------------- | ----: | ---: | ---: |
+|    1 | Zak Kellock        | Made the Two Groups One |  1150 |    9 |  115 |
+|    2 | Kelsey Cruz        | God's Chosen People     |  1085 |    9 |  109 |
+|    3 | Stephen Moses      | Made the Two Groups One |   800 |    8 |   80 |
+|    4 | Amelia Gephart     | New Creation            |   655 |    4 |   66 |
+|    5 | Elena Ramirez      | Foolish Galatian        |   480 |    4 |   48 |
+|    6 | Joanna Moses       | Made the Two Groups One |   425 |    4 |   43 |
+|    7 | Charles Obinma     | God's Chosen People     |   415 |    3 |   42 |
+|    8 | Pearl Smith        | Newport Mesa            |   370 |    3 |   37 |
+|    9 | Kevin Ju           | God's Chosen People     |   140 |    1 |   14 |
+|   10 | Anthony Diaz       | New Creation            |   125 |    0 |   13 |
+|   11 | Maxwell Obinma     | God's Holy People       |   115 |    0 |   12 |
+|   12 | Grace Gephart      | New Creation            |    60 |    0 |    6 |
+|   13 | Jasmine Sirvent    | Newport Mesa            |    20 |    0 |    2 |
+|   14 | Neyssia White      | God's Holy People       |    15 |    0 |    2 |
+|   15 | David Moses        | Made the Two Groups One |    10 |    0 |    1 |
+|   16 | Katie Miller       | Foolish Galatian        |     0 |    0 |    0 |
+|   17 | Sterling Howard    | New Creation            |     0 |    0 |    0 |
+|   18 | Lillien White      | God's Holy People       |     0 |    0 |    0 |
+|   19 | Mikayla Steiger    | Foolish Galatian        |     0 |    0 |    0 |
+|   20 | Johnathan Baskette | Newport Mesa            |   -10 |    0 |   -1 |
+|   21 | Gabriel Sirvent    | Newport Mesa            |   -40 |    0 |   -4 |


### PR DESCRIPTION
Completing another round of importing regional scores, including all the archived `*.pdf`, `*.docx`, and `*.xlsx` files for regionals from the old sites.