### PR TITLE
Update source of live event scoring data

### DIFF
--- a/_pages/live-events.md
+++ b/_pages/live-events.md
@@ -2,9 +2,7 @@
 layout: page
 permalink: /live-events/
 title: Live TBQ Events
-
+menubar: menu_current_season
 ---
-
-<a href="{% link _pages/national-finals.md %}" class="button is-primary">Nationals 2023 Home Page</a>
 
 {% include event-live-scores.html %}

--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -124,7 +124,7 @@ function ensureMainTableIsLoaded(eventId, urlParts, callback) {
     // Retrieve the latest information for the table.
     mainTablePane.style.display = "none";
 
-    fetch("https://registration.biblequiz.com/api/Events/" + eventId + "/Reports")
+    fetch("https://scores.biblequiz.com/api/Events/" + eventId + "/Reports")
         .then(response => response.json())
         .then(data => {
             const eventTitle = document.getElementById("eventTitle");
@@ -198,7 +198,7 @@ function renderHtmlReport(eventId, databaseId, teamFragment, includeQrCode, url,
 
     resultsPane.style.display = "none";
 
-    fetch("https://registration.biblequiz.com/api/Events" + url)
+    fetch("https://scores.biblequiz.com/api/Events" + url)
         .then(response => response.json())
         .then(data => {
 

--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -130,52 +130,61 @@ function ensureMainTableIsLoaded(eventId, urlParts, callback) {
             const eventTitle = document.getElementById("eventTitle");
             const mainTable = document.getElementById("mainTable");
 
-            eventTitle.innerText = data.EventName;
+            const eventName = data.EventName;
+            if (!eventName && !data.Meets) {
+                errorPane.innerText = "Looks like there aren't any meets uploaded for this event yet. Check back later.";
+                errorPane.style.display = "";
+                loadingPane.style.display = "none";
+                mainTablePane.style.display = "none";
+            }
+            else {
+                eventTitle.innerText = eventName;
 
-            if (data.Meets) {
-                const urlBase = "#/" + eventId;
+                if (data.Meets) {
+                    const urlBase = "#/" + eventId;
 
-                for (let i = 0; i < data.Meets.length; i++) {
+                    for (let i = 0; i < data.Meets.length; i++) {
 
-                    const meet = data.Meets[i];
-                    const row = mainTable.tBodies[0].insertRow(i);
+                        const meet = data.Meets[i];
+                        const row = mainTable.tBodies[0].insertRow(i);
 
-                    // Add the name cell
-                    row.insertCell(0).innerText = meet.Label;
+                        // Add the name cell
+                        row.insertCell(0).innerText = meet.Label;
 
-                    // Build the schedule cell.
-                    const scheduleCell = row.insertCell(1);
-                    scheduleCell.className = "has-text-centered";
-                    if (meet.HasSchedule) {
-                        const linkUrl = urlBase + "/" + meet.DatabaseId + "/Schedule/" + meet.MeetId;
-                        scheduleCell.innerHTML = "<a href=\"" + linkUrl + "\" class=\"button is-primary\"><i class=\"far fa-calendar-alt\"></i>&nbsp;Schedule</a>";
-                    }
-                    else {
-                        scheduleCell.innerHTML = "&nbsp;";
-                    }
+                        // Build the schedule cell.
+                        const scheduleCell = row.insertCell(1);
+                        scheduleCell.className = "has-text-centered";
+                        if (meet.HasSchedule) {
+                            const linkUrl = urlBase + "/" + meet.DatabaseId + "/Schedule/" + meet.MeetId;
+                            scheduleCell.innerHTML = "<a href=\"" + linkUrl + "\" class=\"button is-primary\"><i class=\"far fa-calendar-alt\"></i>&nbsp;Schedule</a>";
+                        }
+                        else {
+                            scheduleCell.innerHTML = "&nbsp;";
+                        }
 
-                    // Build the Scores cell.
-                    const scoreSummaryCell = row.insertCell(2);
-                    scoreSummaryCell.className = "has-text-centered";
+                        // Build the Scores cell.
+                        const scoreSummaryCell = row.insertCell(2);
+                        scoreSummaryCell.className = "has-text-centered";
 
-                    const scoreDetailsCell = row.insertCell(3);
-                    scoreDetailsCell.className = "has-text-centered";
+                        const scoreDetailsCell = row.insertCell(3);
+                        scoreDetailsCell.className = "has-text-centered";
 
-                    if (meet.HasScores) {
-                        const summaryLinkUrl = urlBase + "/" + meet.DatabaseId + "/Scores/" + meet.MeetId;
-                        scoreSummaryCell.innerHTML = "<a href=\"" + summaryLinkUrl + "\" class=\"button is-primary\"><i class=\"fas fa-stopwatch\"></i>&nbsp;Score Summary</a>";
+                        if (meet.HasScores) {
+                            const summaryLinkUrl = urlBase + "/" + meet.DatabaseId + "/Scores/" + meet.MeetId;
+                            scoreSummaryCell.innerHTML = "<a href=\"" + summaryLinkUrl + "\" class=\"button is-primary\"><i class=\"fas fa-stopwatch\"></i>&nbsp;Score Summary</a>";
 
-                        const detailsLinkUrl = urlBase + "/" + meet.DatabaseId + "/Dashboard/" + meet.MeetId;
-                        scoreDetailsCell.innerHTML = "<a href=\"" + detailsLinkUrl + "\" class=\"button is-primary\"><i class=\"fas fa-stopwatch\"></i>&nbsp;Score Details</a>";
-                    }
-                    else {
-                        scoreSummaryCell.innerHTML = "&nbsp;";
-                        scoreDetailsCell.innerHTML = "&nbsp;";
+                            const detailsLinkUrl = urlBase + "/" + meet.DatabaseId + "/Dashboard/" + meet.MeetId;
+                            scoreDetailsCell.innerHTML = "<a href=\"" + detailsLinkUrl + "\" class=\"button is-primary\"><i class=\"fas fa-stopwatch\"></i>&nbsp;Score Details</a>";
+                        }
+                        else {
+                            scoreSummaryCell.innerHTML = "&nbsp;";
+                            scoreDetailsCell.innerHTML = "&nbsp;";
+                        }
                     }
                 }
-            }
 
-            mainTablePane.style.display = "";
+                mainTablePane.style.display = "";
+            }
 
             callback(urlParts);
 
@@ -183,7 +192,7 @@ function ensureMainTableIsLoaded(eventId, urlParts, callback) {
 
             console.log('Failed to retrieve the meets table.', err);
 
-            errorPane.style.display = "Failed to retrieve the Event Details.";
+            errorPane.innerText = "Failed to retrieve the Event Details.";
             errorPane.style.display = "";
             loadingPane.style.display = "none";
             mainTablePane.style.display = "none";


### PR DESCRIPTION
* **Moved Source of Live Event Data**
The back-end has been updated to use a different source (scores.biblequiz.com) to allow for better caching and performance. Additional changes are coming related to this.

* **Update TBQ Live Events**
The TBQ Live Events has a link to the 2023 Nationals rather than the menu bar used in JBQ Live Events and the TBQ Current Season. This change fixes the issue.

* **Handle Missing Meets**
If there's a link to an unknown database, it will now get a better error message.