### PR TITLE
Update the current season in BibleQuiz.com

### DIFF
--- a/_pages/contesting-changes.md
+++ b/_pages/contesting-changes.md
@@ -5,8 +5,7 @@ title: "Contesting Changes for National Finals"
 date: "2023-04-10"
 ---
 
-<a href="{% link _pages/national-finals.md %}" class="button is-primary">Nationals 2023 Home Page</a>
-
+<a href="{% link _pages/history/2023/nationals.md %}" class="button is-primary">Nationals 2023 Home Page</a>
 
 As many of you know, starting last July at the National BQ Finals in Palm Springs, CA the Rules Committee met to discuss updating the Contesting Rules after receiving suggestions from Coaches, Officials, and Quizzers. Starting with Tournaments last October, we started incorporating the new suggestions. The Contesting Rules were “tweaked” throughout the year after each tournament. 
 
@@ -35,4 +34,4 @@ Teams may present validity as part of a multi-issue contest. If validity is pres
 1. All other conferring and contesting rules are in effect.
 2. Contact Bernie Elliot ([pastorbernie@biblequiz.com](mailto:pastorbernie@biblequiz.com)) with any questions.
 
-<a href="{% link _pages/national-finals.md %}" class="button is-primary">Nationals 2023 Home Page</a>
+<a href="{% link _pages/history/2023/nationals.md %}" class="button is-primary">Nationals 2024 Home Page</a>

--- a/_pages/current-season.md
+++ b/_pages/current-season.md
@@ -17,6 +17,6 @@ The rules for the 2023-2024 season are now available. You can see [the summary o
 
 ## National Finals
 
-[![Hyatt Regency Dallas]({% link assets/2024/dal-hotel-v1.jpg %})]({% link _pages/national-finals.md %})
+[![Hyatt Regency Dallas]({% link assets/2024/dal-hotel-v1.jpg %})]({% link _pages/history/2024/nationals/index.md %})
 
-<a href="{% link _pages/national-finals.md %}" class="button is-primary">National Finals Info</a>
+<a href="{% link _pages/history/2024/nationals/index.md %}" class="button is-primary">National Finals Info</a>

--- a/_pages/history/2024/index.md
+++ b/_pages/history/2024/index.md
@@ -1,0 +1,29 @@
+---
+layout: page
+permalink: /history/2024/
+title: "2024 Season - Romans and James"
+date: "2023-11-09"
+menubar: menu_history
+---
+
+<img src="{% link assets/2024/Banner Empty.jpg %}" alt="Cover Art" style="max-height:400px" />
+
+## Nationals
+
+<a href="{% link _pages/history/2024/nationals/index.md %}" class="button is-primary">National Finals</a>
+
+## Tournaments
+
+{% include events-season.html type="tbq" year="2024" scope="tournament" %}
+
+## Regional Finals
+
+{% include events-season.html type="tbq" year="2024" scope="regionFinals" %}
+
+## District Finals
+
+{% include events-season.html type="tbq" year="2024" scope="districtFinals" %}
+
+## Other Competitions
+
+{% include events-season.html type="tbq" year="2024" scope="other" %}

--- a/_pages/history/2024/nationals/index.md
+++ b/_pages/history/2024/nationals/index.md
@@ -1,10 +1,9 @@
 ---
 layout: page
-permalink: /national-finals/
+permalink: /history/2024/nationals/
 title: "2024 National Finals"
-date: "2022-04-14"
+date: "2023-11-09"
 menubar: menu_current_season
-
 ---
 
 ![]({% link assets/2024/dal-hotel-v1.jpg %})

--- a/_pages/history/2024/nationals/schedule.md
+++ b/_pages/history/2024/nationals/schedule.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-permalink: /national-finals-schedule/
-title: "2023 National Finals Schedule"
+permalink: /history/2024/nationals/schedule
+title: "2024 National Finals Schedule"
 date: "2023-05-29"
 ---
 
-<a href="{% link _pages/national-finals.md %}" class="button is-primary">Nationals 2023 Home Page</a>
+<a href="{% link _pages/history/2024/nationals/index.md %}" class="button is-primary">Nationals 2024 Home Page</a>
 
 ## Tuesday, July 4
 
@@ -66,7 +66,7 @@ date: "2023-05-29"
 
 *Note: Any additional evening meetings will be announced during the morning services.*
 
-<a href="{% link _pages/national-finals.md %}" class="button is-primary">Nationals 2023 Home Page</a>
+<a href="{% link _pages/history/2024/nationals/index.md %}" class="button is-primary">Nationals 2024 Home Page</a>
 
 ---
 

--- a/_pages/history/index.md
+++ b/_pages/history/index.md
@@ -9,6 +9,7 @@ toc_title: Decades
 ---
 
 ## 2020s
+* [2024: Romans and James]({% link _pages/history/2024/index.md %})
 * [2023: 1 & 2 Thessalonians, 1 & 2 Timothy, Titus, 1, 2, & 3 John]({% link _pages/history/2023/index.md %})
 * [2022: Gospel of Matthew]({% link _pages/history/2022/index.md %})
 * [2021: Hebrews, I & II Peter, Jude]({% link _pages/history/2021/index.md %})

--- a/_pages/jbq/2024/index.md
+++ b/_pages/jbq/2024/index.md
@@ -1,0 +1,26 @@
+---
+layout: page
+title: "2024 JBQ Season"
+permalink: /jbq/2023/
+date: "2023-11-09"
+menubar: menu_jbq
+---
+
+## Nationals
+*Details will be available closer to the National Festival.*
+
+## Tournaments
+
+{% include events-season.html type="jbq" year="2024" scope="tournament" %}
+
+## Regional Finals
+
+{% include events-season.html type="jbq" year="2024" scope="regionFinals" %}
+
+## District Finals
+
+{% include events-season.html type="jbq" year="2024" scope="districtFinals" %}
+
+## Other Competitions
+
+{% include events-season.html type="jbq" year="2024" scope="other" %}

--- a/_pages/jbq/index.md
+++ b/_pages/jbq/index.md
@@ -9,6 +9,7 @@ toc_title: Decades
 ---
 
 ## 2020s
+* [2024]({% link _pages/jbq/2024/index.md %})
 * [2023]({% link _pages/jbq/2023/index.md %})
 * [2022]({% link _pages/jbq/2022/index.md %})
 * [2021]({% link _pages/jbq/2021/index.md %})

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ hide_hero: true
         </p>
         <p>
             <a
-                href="{% link _pages/national-finals.md %}"
+                href="{% link _pages/history/2024/nationals/index.md %}"
                 class="button is-primary"
                 >Go Now&nbsp;<i class="far fa-arrow-alt-circle-right"></i
             ></a>


### PR DESCRIPTION
* **Move National Finals**
Migrate the `/national-finals` to `/history/2024/nationals/` to ensure there's a new page for each year.

* **Add 2024 Season to History**
Introduced the 2024 season to the history of both JBQ and TBQ so that the current events are available.