### PR TITLE
Team with Index 0 is treated as missing

### DIFF
--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -270,7 +270,7 @@ function initializeLiveEvents() {
                     otherTeamContainer = otherTeamCell;
                 }
 
-                otherTeamContainer.text(match.OtherTeam ? meet.Teams[match.OtherTeam].Name : "BYE");
+                otherTeamContainer.text(match.OtherTeam || 0 == match.OtherTeam ? meet.Teams[match.OtherTeam].Name : "BYE");
             }
             else {
                 otherTeamCell.text("--");
@@ -286,7 +286,7 @@ function initializeLiveEvents() {
                 matchRow
                     .append($("<td />")
                         .addClass("has-text-right")
-                        .text(match && match.OtherTeam ? meet.Teams[match.OtherTeam].Matches[matchIndex].Score : "--"));
+                        .text(match && (match.OtherTeam || 0 == match.OtherTeam) ? meet.Teams[match.OtherTeam].Matches[matchIndex].Score : "--"));
             }
 
             matchIndex++;


### PR DESCRIPTION
## Issue
A team with index 0 in the `Teams` array is treated as missing entirely when showing the teams dialog.

## Fix
Explicitly check for `0` for the field to avoid accidentally excluding it.