### PR TITLE
Add Room and Grid Schedule View to Live Scores

### DIFF
--- a/_includes/event-live-scores.html
+++ b/_includes/event-live-scores.html
@@ -24,7 +24,7 @@
     </ul>
   </div>
 
-  <div class="field has-addons hide-on-print">
+  <div class="field has-addons hide-on-print mb-0" id="searchRow">
     <div class="dropdown" id="searchDropdown">
       <div class="dropdown-menu" style="top: 75%">
         <div class="dropdown-content">
@@ -65,6 +65,26 @@
         Search
       </a>
     </div>
+  </div>
+
+  <div class="tabs is-toggle is-small mb-0 hide-on-print">
+    <ul class="ml-0 mt-0">
+      <li id="scheduleViewTab_Team">
+        <a>
+          <i class="fas fa-users"></i>&nbsp;Team Schedules
+        </a>
+      </li>
+      <li id="scheduleViewTab_Room">
+        <a>
+          <i class="fas fa-door-open"></i>&nbsp;Room Schedules
+        </a>
+      </li>
+      <li id="scheduleViewTab_Grid">
+        <a>
+          <i class="fas fa-border-all"></i>&nbsp;Schedule Grid
+        </a>
+      </li>
+    </ul>
   </div>
 </div>
 

--- a/_includes/event-live-scores.html
+++ b/_includes/event-live-scores.html
@@ -6,6 +6,15 @@
 <script src="{{ site.baseurl }}/assets/js/live-event-scores.js" type="module"></script>
 <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/live-event-scores.css">
 
+<div class="has-text-centered" id="loadingPane" style="margin-top:30px">
+  <p><b>Retrieving Latest Information for Event ...</b></p>
+  <progress class="progress is-medium is-primary" max="100">30%</progress>
+</div>
+
+<div class="notification is-danger" id="errorPane" style="margin-top:30px;display:none">
+  Failed to retrieve the latest information. Please try again ...
+</div>
+
 <div style="display:none" id="resultsPane">
   <div class="tabs is-boxed hide-on-print">
     <ul class="mt-0 ml-0">
@@ -67,7 +76,7 @@
     </div>
   </div>
 
-  <div class="tabs is-toggle is-small mb-0 hide-on-print">
+  <div class="tabs is-toggle is-small mb-0 hide-on-print" id="scheduleViewTabs">
     <ul class="ml-0 mt-0">
       <li id="scheduleViewTab_Team">
         <a>
@@ -86,196 +95,228 @@
       </li>
     </ul>
   </div>
-</div>
-
-<div class="has-text-centered" id="loadingPane" style="margin-top:30px">
-  <p><b>Retrieving Latest Information for Event ...</b></p>
-  <progress class="progress is-medium is-primary" max="100">30%</progress>
-</div>
-
-<div class="notification is-danger" id="errorPane" style="margin-top:30px;display:none">
-  Failed to retrieve the latest information. Please try again ...
-</div>
-
-<div class="modal hide-on-print" id="teamModal">
-  <div class="modal-background hide-on-print"></div>
-  <div class="modal-card" style="width:95%">
-    <header class="modal-card-head">
-      <p class="modal-card-title" id="teamModalTitle" style="margin-bottom:0px">Title</p>
-      <button class="delete hide-on-print" id="teamModalClose" />
-    </header>
-    <section class="modal-card-body" id="teamModalBody">Body</section>
-  </div>
-</div>
-
-<template id="statsTemplate">
-  <div class="columns is-mobile mt-2">
-    <div class="column is-four-fifths">
-      <p class="title is-3" id="meetName" />
-      <p class="subtitle is-7"><i>Last Updated: <span id="lastUpdated" /></i></p>
+  
+  <div class="modal hide-on-print" id="teamModal">
+    <div class="modal-background hide-on-print"></div>
+    <div class="modal-card" style="width:95%">
+      <header class="modal-card-head">
+        <p class="modal-card-title" id="teamModalTitle" style="margin-bottom:0px">Title</p>
+        <button class="delete hide-on-print" id="teamModalClose" />
+      </header>
+      <section class="modal-card-body" id="teamModalBody">Body</section>
     </div>
-    <div class="column is-one-fifth has-text-right hide-on-print">
-      <div class="dropdown is-right">
-        <div class="dropdown-trigger">
-          <button class="button is-primary"><i class="fas fa-print"></i></button>
-          <div class="dropdown-menu">
-            <div class="dropdown-content">
-              <a class="dropdown-item" id="print_TeamsAndQuizzers">Teams &amp; Quizzers</a>
-              <a class="dropdown-item" id="print_TeamsOnly">Teams Only</a>
-              <a class="dropdown-item" id="print_QuizzersOnly">Quizzers Only</a>
+  </div>
+
+  <template id="statsTemplate">
+    <div class="columns is-mobile mt-2">
+      <div class="column is-four-fifths">
+        <p class="title is-3" id="meetName" />
+        <p class="subtitle is-7"><i>Last Updated: <span id="lastUpdated" /></i></p>
+      </div>
+      <div class="column is-one-fifth has-text-right hide-on-print" id="statsPrintButton">
+        <div class="dropdown is-right">
+          <div class="dropdown-trigger">
+            <button class="button is-primary"><i class="fas fa-print"></i></button>
+            <div class="dropdown-menu">
+              <div class="dropdown-content">
+                <a class="dropdown-item" id="print_TeamsAndQuizzers">Teams &amp; Quizzers</a>
+                <a class="dropdown-item" id="print_TeamsOnly">Teams Only</a>
+                <a class="dropdown-item" id="print_QuizzersOnly">Quizzers Only</a>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-  <div class="notification is-success" id="meetProgress_IsCompleted">
-    <strong>COMPLETE: <span id="meetProgressLabel" /></strong>
-  </div>
-  <div class="notification is-warning" id="meetProgress_IsMismatched">
-    <strong>IN PROGRESS: <span id="meetProgressLabel" /></strong>
-  </div>
-  <div id="teamsSection">
-    <p class="title is-4" style="margin-top: 0px;">Teams</p>
-    <div class="is-size-6" id="teamRankingRow">
-      <i><strong>Team Report:</strong> <span id="teamRankingLabel" /></i>
+    <div class="notification is-info" id="noScoresWarning">
+      <strong>Either the event coordinator hasn't enabled scores for this event yet or scoring hasn't started yet.</strong>
     </div>
-    <table class="table is-striped is-fullwidth is-bordered is-narrow">
-      <thead>
-        <tr>
-          <th class="has-text-right" width="30">#</th>
-          <th width="33%">Team (Church)</th>
-          <th class="has-text-right" width="30">W</th>
-          <th class="has-text-right" width="30">L</th>
-          <th class="has-text-right" width="65">W%</th>
-          <th class="has-text-right" width="65">Total</th>
-          <th class="has-text-right" width="65">Avg</th>
-          <th class="has-text-right" width="45">QO</th>
-          <th class="has-text-right" width="45">Q%</th>
-          <th class="has-text-right" width="45">30s</th>
-          <th class="has-text-right" width="45">20s</th>
-          <th class="has-text-right" width="45">10s</th>
-        </tr>
-      </thead>
-      <tbody id="teamsTableBody">
-        <tr id="tableRow">
-          <td class="has-text-right" id="rankColumn" />
-          <td id="nameColumn" />
-          <td class="has-text-right" id="winColumn" />
-          <td class="has-text-right" id="lossColumn" />
-          <td class="has-text-right" id="winPercentageColumn" />
-          <td class="has-text-right" id="totalColumn" />
-          <td class="has-text-right" id="averageColumn" />
-          <td class="has-text-right" id="quizOutColumn" />
-          <td class="has-text-right" id="quizOutPercentageColumn" />
-          <td class="has-text-right" id="question30sColumn" />
-          <td class="has-text-right" id="question20sColumn" />
-          <td class="has-text-right" id="question10sColumn" />
-        </tr>
-      </tbody>
-    </table>
-    <div id="teamTieBreakingRow">
-      <font size="2"><i>* Tie couldn't be broken by tie breaking rules.</i></font>
+    <div class="notification is-success" id="meetProgress_IsCompleted">
+      <strong>COMPLETE: <span id="meetProgressLabel" /></strong>
     </div>
-  </div>
-  <div id="quizzersSection" class="mt-4">
-    <p class="title is-4">Quizzers</p>
-    <div class="is-size-6" id="quizzersRankingRow">
-      <i><strong>Individual Report:</strong> <span id="quizzerRankingLabel" /></i>
+    <div class="notification is-warning" id="meetProgress_IsMismatched">
+      <strong>IN PROGRESS: <span id="meetProgressLabel" /></strong>
     </div>
-    <table class="table is-striped is-fullwidth is-bordered is-narrow">
-      <thead>
-        <tr>
-          <th class="has-text-right" width="30">#</th>
-          <th>Quizzer</th>
-          <th>Team (Church)</th>
-          <th class="has-text-right" width="65">Total</th>
-          <th class="has-text-right" width="65">Avg</th>
-          <th class="has-text-right" width="45">QO</th>
-          <th class="has-text-right" width="45">Q%</th>
-          <th class="has-text-right" width="45">30s</th>
-          <th class="has-text-right" width="45">20s</th>
-          <th class="has-text-right" width="45">10s</th>
-        </tr>
-      </thead>
-      <tbody id="quizzersTableBody">
-        <tr id="tableRow">
-          <td class="has-text-right" id="rankColumn" />
-          <td id="nameColumn" />
-          <td id="teamNameColumn" />
-          <td class="has-text-right" id="totalColumn" />
-          <td class="has-text-right" id="averageColumn" />
-          <td class="has-text-right" id="quizOutColumn" />
-          <td class="has-text-right" id="quizOutPercentageColumn" />
-          <td class="has-text-right" id="question30sColumn" />
-          <td class="has-text-right" id="question20sColumn" />
-          <td class="has-text-right" id="question10sColumn" />
-        </tr>
-      </tbody>
-    </table>
-    <div id="quizzerTieBreakingRow">
-      <font size="2"><i>* Tie couldn't be broken by tie breaking rules.</i></font>
+    <div id="teamsSection">
+      <p class="title is-4" style="margin-top: 0px;">Teams</p>
+      <div class="is-size-6" id="teamRankingRow">
+        <i><strong>Team Report:</strong> <span id="teamRankingLabel" /></i>
+      </div>
+      <table class="table is-striped is-fullwidth is-bordered is-narrow">
+        <thead>
+          <tr>
+            <th class="has-text-right" width="30">#</th>
+            <th width="33%">Team (Church)</th>
+            <th class="has-text-right" width="30">W</th>
+            <th class="has-text-right" width="30">L</th>
+            <th class="has-text-right" width="65">W%</th>
+            <th class="has-text-right" width="65">Total</th>
+            <th class="has-text-right" width="65">Avg</th>
+            <th class="has-text-right" width="45">QO</th>
+            <th class="has-text-right" width="45">Q%</th>
+            <th class="has-text-right" width="45">30s</th>
+            <th class="has-text-right" width="45">20s</th>
+            <th class="has-text-right" width="45">10s</th>
+          </tr>
+        </thead>
+        <tbody id="teamsTableBody">
+          <tr id="tableRow">
+            <td class="has-text-right" id="rankColumn" />
+            <td id="nameColumn" />
+            <td class="has-text-right" id="winColumn" />
+            <td class="has-text-right" id="lossColumn" />
+            <td class="has-text-right" id="winPercentageColumn" />
+            <td class="has-text-right" id="totalColumn" />
+            <td class="has-text-right" id="averageColumn" />
+            <td class="has-text-right" id="quizOutColumn" />
+            <td class="has-text-right" id="quizOutPercentageColumn" />
+            <td class="has-text-right" id="question30sColumn" />
+            <td class="has-text-right" id="question20sColumn" />
+            <td class="has-text-right" id="question10sColumn" />
+          </tr>
+        </tbody>
+      </table>
+      <div id="teamTieBreakingRow">
+        <font size="2"><i>* Tie couldn't be broken by tie breaking rules.</i></font>
+      </div>
     </div>
-  </div>
-</template>
+    <div id="quizzersSection" class="mt-4">
+      <p class="title is-4">Quizzers</p>
+      <div class="is-size-6" id="quizzersRankingRow">
+        <i><strong>Individual Report:</strong> <span id="quizzerRankingLabel" /></i>
+      </div>
+      <table class="table is-striped is-fullwidth is-bordered is-narrow">
+        <thead>
+          <tr>
+            <th class="has-text-right" width="30">#</th>
+            <th>Quizzer</th>
+            <th>Team (Church)</th>
+            <th class="has-text-right" width="65">Total</th>
+            <th class="has-text-right" width="65">Avg</th>
+            <th class="has-text-right" width="45">QO</th>
+            <th class="has-text-right" width="45">Q%</th>
+            <th class="has-text-right" width="45">30s</th>
+            <th class="has-text-right" width="45">20s</th>
+            <th class="has-text-right" width="45">10s</th>
+          </tr>
+        </thead>
+        <tbody id="quizzersTableBody">
+          <tr id="tableRow">
+            <td class="has-text-right" id="rankColumn" />
+            <td id="nameColumn" />
+            <td id="teamNameColumn" />
+            <td class="has-text-right" id="totalColumn" />
+            <td class="has-text-right" id="averageColumn" />
+            <td class="has-text-right" id="quizOutColumn" />
+            <td class="has-text-right" id="quizOutPercentageColumn" />
+            <td class="has-text-right" id="question30sColumn" />
+            <td class="has-text-right" id="question20sColumn" />
+            <td class="has-text-right" id="question10sColumn" />
+          </tr>
+        </tbody>
+      </table>
+      <div id="quizzerTieBreakingRow">
+        <font size="2"><i>* Tie couldn't be broken by tie breaking rules.</i></font>
+      </div>
+    </div>
+  </template>
 
-<template id="schedulesTemplate">
-  <div class="columns is-mobile mt-2">
-    <div class="column is-four-fifths">
-      <p class="title is-3" id="meetName" />
-      <p class="subtitle is-7"><i>Last Updated: <span id="lastUpdated" /></i></p>
-    </div>
-    <div class="column is-one-fifth has-text-right hide-on-print">
-      <div class="dropdown is-right">
-        <div class="dropdown-trigger">
-          <button class="button is-primary"><i class="fas fa-print"></i></button>
-          <div class="dropdown-menu">
-            <div class="dropdown-content">
-              <a class="dropdown-item" id="print_ScheduleAndScores">Schedule and Scores</a>
-              <a class="dropdown-item" id="print_ScheduleOnly">Schedule Only</a>
+  <template id="schedulesTemplate">
+    <div class="columns is-mobile mt-2">
+      <div class="column is-four-fifths">
+        <p class="title is-3" id="meetName" />
+        <p class="subtitle is-7"><i>Last Updated: <span id="lastUpdated" /></i></p>
+      </div>
+      <div class="column is-one-fifth has-text-right hide-on-print">
+        <div class="dropdown is-right">
+          <div class="dropdown-trigger">
+            <button class="button is-primary"><i class="fas fa-print"></i></button>
+            <div class="dropdown-menu">
+              <div class="dropdown-content">
+                <a class="dropdown-item" id="print_ScheduleAndScores">Schedule and Scores</a>
+                <a class="dropdown-item" id="print_ScheduleOnly">Schedule Only</a>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-  <div class="columns is-multiline" id="teamCards">
-    <div class="column is-half team-card p-3" id="cardTemplate">
-      <p class="title is-5" id="teamName" />
-      <p class="subtitle is-7" id="churchName" />
-      <div class="columns is-mobile is-centered mt-2 hide-if-schedule" id="statsRow">
-        <div class="column is-3 has-text-centered team-card-right-border">
-          <span class="title is-5" id="rankLabel"></span><br />
-          <i class="subtitle is-6">PLACE</i>
+    <div class="columns is-multiline" id="teamCards">
+      <div class="column is-half team-card p-3" id="cardTemplate">
+        <p class="title is-5" id="teamName" />
+        <p class="subtitle is-7" id="churchName" />
+        <div class="columns is-mobile is-centered mt-2 hide-if-schedule" id="statsRow">
+          <div class="column is-3 has-text-centered team-card-right-border">
+            <span class="title is-5" id="rankLabel"></span><br />
+            <i class="subtitle is-6">PLACE</i>
+          </div>
+          <div class="column is-one-fifth has-text-centered team-card-right-border">
+            <span class="title is-5" id="recordLabel"></span><br />
+            <i class="subtitle is-6">W-L</i>
+          </div>
+          <div class="column is-one-fifth has-text-centered team-card-right-border">
+            <span class="title is-5" id="pointsLabel"></span><br>
+            <i class="subtitle is-6">PTS</i>
+          </div>
+          <div class="column is-one-fifth has-text-centered">
+            <span class="title is-5" id="averageLabel"></span><br />
+            <i class="subtitle is-6">AVG</i>
+          </div>
         </div>
-        <div class="column is-one-fifth has-text-centered team-card-right-border">
-          <span class="title is-5" id="recordLabel"></span><br />
-          <i class="subtitle is-6">W-L</i>
-        </div>
-        <div class="column is-one-fifth has-text-centered team-card-right-border">
-          <span class="title is-5" id="pointsLabel"></span><br>
-          <i class="subtitle is-6">PTS</i>
-        </div>
-        <div class="column is-one-fifth has-text-centered">
-          <span class="title is-5" id="averageLabel"></span><br />
-          <i class="subtitle is-6">AVG</i>
-        </div>
-      </div>
-      <ol class="is-size-7" id="matchList">
-        <li id="matchItem">
-          <div class="show-if-schedule hide-on-print" id="scheduleLabel"></div>
-          <div class="hide-if-schedule" id="statsLabel">
-            <a id="statsLink"></a>
-            <i id="liveEventLabel">
-              <br />
-              <i>
-                <i class="fas fa-broadcast-tower"></i>&nbsp;Question #<span id="questionNumber" />
+        <ol class="is-size-7" id="matchList">
+          <li id="matchItem">
+            <div class="show-if-schedule hide-on-print" id="scheduleLabel"></div>
+            <div class="hide-if-schedule" id="statsLabel">
+              <a id="statsLink"></a>
+              <i id="liveEventLabel">
+                <br />
+                <i>
+                  <i class="fas fa-broadcast-tower"></i>&nbsp;Question #<span id="questionNumber" />
+                </i>
               </i>
-            </i>
-          </div>
-        </li>
-      </ol>
-      <p class="is-size-7" id="quizzersContainer"><b>Quizzers: </b> <span id="quizzersLabel" /></p>
+            </div>
+          </li>
+        </ol>
+        <p class="is-size-7" id="quizzersContainer"><b>Quizzers: </b> <span id="quizzersLabel" /></p>
+      </div>
     </div>
-  </div>
-</template>
+    <div id="scheduleGrid">
+      <table class="table is-striped is-fullwidth is-bordered is-narrow">
+        <thead>
+          <tr id="scheduleTableHeaderRow">
+            <th class="has-text-right" width="30" class="hide-if-schedule">#</th>
+            <th width="33%">Team (Church)</th>
+            <th class="has-text-right" width="30" class="hide-if-schedule">W</th>
+            <th class="has-text-right" width="30" class="hide-if-schedule">L</th>
+            <th class="has-text-right" width="65" class="hide-if-schedule">Total</th>
+            <th class="has-text-right" width="65" class="hide-if-schedule">Avg</th>
+            <th class="has-text-centered" id="matchItem" />
+          </tr>
+        </thead>
+        <tbody id="scheduleTableBody">
+          <tr id="cardTemplate">
+            <td class="has-text-right" id="rankColumn" class="hide-if-schedule" />
+            <td id="nameColumn" />
+            <td class="has-text-right" id="winColumn" class="hide-if-schedule" />
+            <td class="has-text-right" id="lossColumn" class="hide-if-schedule" />
+            <td class="has-text-right" id="totalColumn" class="hide-if-schedule" />
+            <td class="has-text-right" id="averageColumn" class="hide-if-schedule" />
+            <td class="has-text-centered" id="matchItem">
+              <div class="show-if-schedule hide-on-print" id="scheduleLabel"></div>
+              <div class="hide-if-schedule" id="statsLabel">
+                <a id="statsLink"></a><br />
+                <i id="liveEventLabel">#<span id="questionNumber"></span></i>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+        <tfoot id="scheduleTableFooter">
+          <tr id="tableRow">
+            <th class="show-if-schedule">Planned Start Time for Match</th>
+            <th colspan="6" class="hide-if-schedule">Planned Start Time for Match</th>
+            <th class="has-text-centered" id="matchItem" />
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </template>

--- a/assets/Test_ScoringReport.json
+++ b/assets/Test_ScoringReport.json
@@ -1,0 +1,4416 @@
+{
+    "EventName": "Test Event kgallo",
+    "DatabaseNames": {
+        "f0f62f82-19d6-422a-a09f-f8b3cb46b481": "NWD_JBQ_-_2024_League_1"
+    },
+    "Report": {
+        "Meets": [
+            {
+                "DatabaseId": "f0f62f82-19d6-422a-a09f-f8b3cb46b481",
+                "MeetId": 5,
+                "Name": "Bronze (B3)",
+                "LastUpdated": "12/4/23 4:24 PM",
+                "Teams": [
+                    {
+                        "Name": "Bellevue Neighborhood Church (Bellevue) #8",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "CoachName": "Deepthi Konda",
+                        "Quizzers": [
+                            0,
+                            2,
+                            6,
+                            8
+                        ],
+                        "Matches": [
+                            {
+                                "Result": "W",
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": 10,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": 2,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": false,
+                            "Wins": 1,
+                            "Losses": 0,
+                            "WinPercentage": 100,
+                            "TotalPoints": 10,
+                            "AveragePoints": 10.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 100,
+                            "Correct10s": 1,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": 2
+                    },
+                    {
+                        "Name": "Kelso Christian Assembly Dragons",
+                        "ChurchName": "Kelso Christian Assembly",
+                        "CoachName": "Taylor Cottrell",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 1,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Newhope B3",
+                        "ChurchName": "Newhope",
+                        "CoachName": "Paul Velasquez",
+                        "Quizzers": [
+                            4,
+                            7,
+                            9
+                        ],
+                        "Matches": [
+                            {
+                                "Result": "L",
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": 0,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": 0,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 4,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 1,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Seattle Tamil Assembly Church - Little Lambs",
+                        "ChurchName": "Seattle Tamil Assembly Church",
+                        "CoachName": "Preethi Devaraj",
+                        "Quizzers": [
+                            1,
+                            3,
+                            5,
+                            10
+                        ],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": 0,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": 2,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "B2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "B1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 3,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": 2
+                    }
+                ],
+                "RankedTeams": [
+                    1,
+                    0,
+                    3,
+                    2
+                ],
+                "Quizzers": [
+                    {
+                        "Name": "Alex Erram",
+                        "TeamName": "Bellevue Neighborhood Church (Bellevue) #8",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": false,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        }
+                    },
+                    {
+                        "Name": "Bethany Stanislause",
+                        "TeamName": "Seattle Tamil Assembly Church - Little Lambs",
+                        "ChurchName": "Seattle Tamil Assembly Church",
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": true,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        }
+                    },
+                    {
+                        "Name": "Cyril Kesireddy",
+                        "TeamName": "Bellevue Neighborhood Church (Bellevue) #8",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "Scores": {
+                            "Rank": 1,
+                            "IsTie": false,
+                            "TotalPoints": 10,
+                            "AveragePoints": 10.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 100,
+                            "Correct10s": 1,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        }
+                    },
+                    {
+                        "Name": "Gianna Prabin Paul",
+                        "TeamName": "Seattle Tamil Assembly Church - Little Lambs",
+                        "ChurchName": "Seattle Tamil Assembly Church",
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": true,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        }
+                    },
+                    {
+                        "Name": "Harper Scott",
+                        "TeamName": "Newhope B3",
+                        "ChurchName": "Newhope",
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": true,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        }
+                    },
+                    {
+                        "Name": "Joanna Prem",
+                        "TeamName": "Seattle Tamil Assembly Church - Little Lambs",
+                        "ChurchName": "Seattle Tamil Assembly Church",
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": true,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        }
+                    },
+                    {
+                        "Name": "Jyotham OOO",
+                        "TeamName": "Bellevue Neighborhood Church (Bellevue) #8",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": true,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        }
+                    },
+                    {
+                        "Name": "Leia Long",
+                        "TeamName": "Newhope B3",
+                        "ChurchName": "Newhope",
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": true,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        }
+                    },
+                    {
+                        "Name": "Manas Surapaneni",
+                        "TeamName": "Bellevue Neighborhood Church (Bellevue) #8",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": true,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        }
+                    },
+                    {
+                        "Name": "Tiana Long",
+                        "TeamName": "Newhope B3",
+                        "ChurchName": "Newhope",
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": true,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        }
+                    },
+                    {
+                        "Name": "Timothy Samuel",
+                        "TeamName": "Seattle Tamil Assembly Church - Little Lambs",
+                        "ChurchName": "Seattle Tamil Assembly Church",
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": true,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        }
+                    }
+                ],
+                "RankedQuizzers": [
+                    2,
+                    0,
+                    1,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                ],
+                "Rooms": [
+                    {
+                        "Name": "B1",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": 2,
+                                "Team1": 0,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 3
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "B2",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 2
+                            }
+                        ]
+                    }
+                ],
+                "TeamRankingLabel": "Ranked by win/loss record. 2-way ties broken by head-to-head matches and 3+-way ties broken by points.",
+                "QuizzerRankingLabel": "Ranked by average points, then by total quiz outs..",
+                "Matches": [
+                    {
+                        "Id": 1,
+                        "MatchTime": "11:00 AM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 2,
+                        "MatchTime": "11:30 AM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 3,
+                        "MatchTime": "12:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 4,
+                        "MatchTime": "12:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 5,
+                        "MatchTime": "01:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 6,
+                        "MatchTime": "01:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 7,
+                        "MatchTime": "02:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 8,
+                        "MatchTime": "02:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 9,
+                        "MatchTime": "03:00 PM",
+                        "PlayoffIndex": null
+                    }
+                ],
+                "HasRoomCompletionMismatch": true,
+                "HasScoringCompleted": false,
+                "ScoringProgressMessage": "0 of 9 Match(es) Done, +2 by some Room(s)"
+            },
+            {
+                "DatabaseId": "f0f62f82-19d6-422a-a09f-f8b3cb46b481",
+                "MeetId": 1,
+                "Name": "Diamond (A1)",
+                "LastUpdated": "12/4/23 4:24 PM",
+                "Teams": [
+                    {
+                        "Name": "Bellevue Neighborhood Church (Bellevue) #1",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "CoachName": "Kevin Gallo",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 1,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Bellevue Neighborhood Church (Bellevue) #2",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "CoachName": "Josh Arasavelli",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Cedar Park Assembly of God (Bothell) #1",
+                        "ChurchName": "Cedar Park Assembly of God",
+                        "CoachName": "Sancia Gladwin",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 3,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Deeper Church (Burien) #1",
+                        "ChurchName": "Deeper Church",
+                        "CoachName": null,
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 4,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Deeper Church (Burien) #2",
+                        "ChurchName": "Deeper Church",
+                        "CoachName": null,
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 5,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Kelso Christian Assembly Double Trouble",
+                        "ChurchName": "Kelso Christian Assembly",
+                        "CoachName": "Christopher Lyons",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 6,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Newhope Bible Barbarians",
+                        "ChurchName": "Newhope",
+                        "CoachName": "Jaclyn Button",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 7,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Winlock",
+                        "ChurchName": "Winlock Assembly of God Church",
+                        "CoachName": "Samuel Hunt",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "D4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "D2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "D3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "D1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 8,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    }
+                ],
+                "RankedTeams": [
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7
+                ],
+                "Quizzers": [],
+                "RankedQuizzers": [],
+                "Rooms": [
+                    {
+                        "Name": "D1",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 7
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 4
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 6,
+                                "Team2": 7
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "D2",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 7
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 7
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 4
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "D3",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 4
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 7
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 5,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 1
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 5,
+                                "Team2": 7
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 3
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "D4",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 4
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 7
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 5
+                            }
+                        ]
+                    }
+                ],
+                "TeamRankingLabel": null,
+                "QuizzerRankingLabel": null,
+                "Matches": [
+                    {
+                        "Id": 1,
+                        "MatchTime": "11:00 AM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 2,
+                        "MatchTime": "11:30 AM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 3,
+                        "MatchTime": "12:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 4,
+                        "MatchTime": "12:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 5,
+                        "MatchTime": "01:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 6,
+                        "MatchTime": "01:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 7,
+                        "MatchTime": "02:00 PM",
+                        "PlayoffIndex": null
+                    }
+                ],
+                "HasRoomCompletionMismatch": false,
+                "HasScoringCompleted": false,
+                "ScoringProgressMessage": ""
+            },
+            {
+                "DatabaseId": "f0f62f82-19d6-422a-a09f-f8b3cb46b481",
+                "MeetId": 3,
+                "Name": "Gold (B1)",
+                "LastUpdated": "12/4/23 4:24 PM",
+                "Teams": [
+                    {
+                        "Name": "Assembly of God (Onalaska) #1",
+                        "ChurchName": "Assembly of God",
+                        "CoachName": "Paul Croft",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 8
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 10
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 9
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            null
+                        ],
+                        "Scores": {
+                            "Rank": 6,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Bellevue Neighborhood Church (Bellevue) #6",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "CoachName": "Paul Talari",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 10
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 8
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 9
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 3,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Bridge Church (Belfair) Assembly of God",
+                        "ChurchName": "Belfair Assembly of God",
+                        "CoachName": "Keith Blossom",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 9
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 8
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 10
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 4,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Cedar Park Assembly of God (Bothell) #3",
+                        "ChurchName": "Cedar Park Assembly of God",
+                        "CoachName": "Christina Raj",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 9
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 8
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 10
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 1,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Cedar Park Assembly of God (Bothell) #4",
+                        "ChurchName": "Cedar Park Assembly of God",
+                        "CoachName": "Nimi Moses",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 8
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 10
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 9
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Kelso Christian Assembly Blossoms",
+                        "ChurchName": "Kelso Christian Assembly",
+                        "CoachName": "Adele Woodward",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 10
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 9
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 8
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 9,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Newhope B1",
+                        "ChurchName": "Newhope",
+                        "CoachName": "Jenny Nolten",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 9
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 8
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 10
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 8,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Seattle Tamil Assembly Church - Miracle Makers (M&Ms)",
+                        "ChurchName": "Seattle Tamil Assembly Church",
+                        "CoachName": "Noel Devaneyan",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 10
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 9
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 8
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 7,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Seattle Tamil Assembly Church - The Disciples",
+                        "ChurchName": "Seattle Tamil Assembly Church",
+                        "CoachName": "Judith Tina Benjamin",
+                        "Quizzers": [],
+                        "Matches": [
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 10
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 9
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 5,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Seattle Tamil Assembly Church - Word Warriors",
+                        "ChurchName": "Seattle Tamil Assembly Church",
+                        "CoachName": "Shwetha Karthik",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 10
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 8
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 11,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Winlock",
+                        "ChurchName": "Winlock Assembly of God Church",
+                        "CoachName": "Heather Croft",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 7
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "G3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 5,
+                                "Room": "G5",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 9
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "G1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 4,
+                                "Room": "G4",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 8
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "G2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 10,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    }
+                ],
+                "RankedTeams": [
+                    3,
+                    4,
+                    1,
+                    2,
+                    8,
+                    0,
+                    7,
+                    6,
+                    5,
+                    10,
+                    9
+                ],
+                "Quizzers": [],
+                "RankedQuizzers": [],
+                "Rooms": [
+                    {
+                        "Name": "",
+                        "Matches": [
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null
+                        ]
+                    },
+                    {
+                        "Name": "G1",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 7,
+                                "Team2": 10
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 8
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 9
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 8,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 7
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 10
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 8,
+                                "Team2": 9
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "G2",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 8
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 6,
+                                "Team2": 9
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 10
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 1
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 8
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 7,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 10
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "G3",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 10
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 7,
+                                "Team2": 9
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 4
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 8,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 5,
+                                "Team2": 9
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 6,
+                                "Team2": 10
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 7
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 8
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 6
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "G4",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 9
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 6,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 8,
+                                "Team2": 7
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 10
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 1
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 9
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 9
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 8,
+                                "Team2": 10
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 7
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "G5",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 7
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 9
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 5,
+                                "Team2": 10
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 7,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 8,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 10,
+                                "Team2": 9
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 0,
+                                "Team2": 6
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 7
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 5
+                            }
+                        ]
+                    }
+                ],
+                "TeamRankingLabel": null,
+                "QuizzerRankingLabel": null,
+                "Matches": [
+                    {
+                        "Id": 1,
+                        "MatchTime": "11:00 AM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 2,
+                        "MatchTime": "11:30 AM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 3,
+                        "MatchTime": "12:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 4,
+                        "MatchTime": "12:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 5,
+                        "MatchTime": "01:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 6,
+                        "MatchTime": "01:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 7,
+                        "MatchTime": "02:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 8,
+                        "MatchTime": "02:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 9,
+                        "MatchTime": "03:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 10,
+                        "MatchTime": "03:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 11,
+                        "MatchTime": "04:00 PM",
+                        "PlayoffIndex": null
+                    }
+                ],
+                "HasRoomCompletionMismatch": false,
+                "HasScoringCompleted": false,
+                "ScoringProgressMessage": ""
+            },
+            {
+                "DatabaseId": "f0f62f82-19d6-422a-a09f-f8b3cb46b481",
+                "MeetId": 2,
+                "Name": "Platinum (A2)",
+                "LastUpdated": "12/4/23 4:24 PM",
+                "Teams": [
+                    {
+                        "Name": "Bellevue Neighborhood Church (Bellevue) #3",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "CoachName": "Talitha Konda",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 4,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Bellevue Neighborhood Church (Bellevue) #4",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "CoachName": "Raj Chirumamilla",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 1,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Bellevue Neighborhood Church (Bellevue) #5",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "CoachName": "Christopher Lamm",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 3,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Deeper Church (Burien) #3",
+                        "ChurchName": "Deeper Church",
+                        "CoachName": null,
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "P1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "P2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    }
+                ],
+                "RankedTeams": [
+                    1,
+                    3,
+                    2,
+                    0
+                ],
+                "Quizzers": [],
+                "RankedQuizzers": [],
+                "Rooms": [
+                    {
+                        "Name": "P1",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 0
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "P2",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 2
+                            }
+                        ]
+                    }
+                ],
+                "TeamRankingLabel": null,
+                "QuizzerRankingLabel": null,
+                "Matches": [
+                    {
+                        "Id": 1,
+                        "MatchTime": "11:00 AM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 2,
+                        "MatchTime": "11:30 AM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 3,
+                        "MatchTime": "12:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 4,
+                        "MatchTime": "12:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 5,
+                        "MatchTime": "01:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 6,
+                        "MatchTime": "01:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 7,
+                        "MatchTime": "02:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 8,
+                        "MatchTime": "02:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 9,
+                        "MatchTime": "03:00 PM",
+                        "PlayoffIndex": null
+                    }
+                ],
+                "HasRoomCompletionMismatch": false,
+                "HasScoringCompleted": false,
+                "ScoringProgressMessage": ""
+            },
+            {
+                "DatabaseId": "f0f62f82-19d6-422a-a09f-f8b3cb46b481",
+                "MeetId": 4,
+                "Name": "Silver (B2)",
+                "LastUpdated": "12/4/23 4:24 PM",
+                "Teams": [
+                    {
+                        "Name": "Bellevue Neighborhood Church (Bellevue) #7",
+                        "ChurchName": "Bellevue Neighborhood Church",
+                        "CoachName": "Jessica Gallo",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            null
+                        ],
+                        "Scores": {
+                            "Rank": 7,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Bridge Church (Belfair) Assembly of God",
+                        "ChurchName": "Belfair Assembly of God",
+                        "CoachName": "Julia Watkins",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 5,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Cedar Park Assembly of God (Bothell) #2",
+                        "ChurchName": "Cedar Park Assembly of God",
+                        "CoachName": "Steven English",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 6,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Deeper Church (Burien) #4",
+                        "ChurchName": "Deeper Church",
+                        "CoachName": null,
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 3,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Kelso Christian Assembly Ninjas",
+                        "ChurchName": "Kelso Christian Assembly",
+                        "CoachName": "Charlotte Lyons",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 2,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Seattle Tamil Assembly Church - Bible Battlers",
+                        "ChurchName": "Seattle Tamil Assembly Church",
+                        "CoachName": "Angeline Lincy Mary Ravi",
+                        "Quizzers": [],
+                        "Matches": [
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 6
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 4,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    },
+                    {
+                        "Name": "Seattle Tamil Assembly Church - Bible Buffs",
+                        "ChurchName": "Seattle Tamil Assembly Church",
+                        "CoachName": "Mercelin SamJacob",
+                        "Quizzers": [],
+                        "Matches": [
+                            null,
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 3
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 1
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 0
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 3,
+                                "Room": "S3",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 4
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 2,
+                                "Room": "S2",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 5
+                            },
+                            {
+                                "Result": null,
+                                "RoomId": 1,
+                                "Room": "S1",
+                                "CurrentQuestion": null,
+                                "Score": null,
+                                "OtherTeam": 2
+                            }
+                        ],
+                        "Scores": {
+                            "Rank": 1,
+                            "IsTie": false,
+                            "Wins": 0,
+                            "Losses": 0,
+                            "WinPercentage": 0,
+                            "TotalPoints": 0,
+                            "AveragePoints": 0.0,
+                            "QuizOuts": 0,
+                            "QuestionCorrectPercentage": 0,
+                            "Correct10s": 0,
+                            "Correct20s": 0,
+                            "Correct30s": 0
+                        },
+                        "CurrentMatchId": null
+                    }
+                ],
+                "RankedTeams": [
+                    6,
+                    4,
+                    3,
+                    5,
+                    1,
+                    2,
+                    0
+                ],
+                "Quizzers": [],
+                "RankedQuizzers": [],
+                "Rooms": [
+                    {
+                        "Name": "",
+                        "Matches": [
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null
+                        ]
+                    },
+                    {
+                        "Name": "S1",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 6,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 1
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 5,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 6,
+                                "Team2": 2
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "S2",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 5,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 6,
+                                "Team2": 1
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 6,
+                                "Team2": 5
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 1
+                            }
+                        ]
+                    },
+                    {
+                        "Name": "S3",
+                        "Matches": [
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 5,
+                                "Team2": 1
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 1,
+                                "Team2": 2
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 2,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 6,
+                                "Team2": 0
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 6,
+                                "Team2": 4
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 4,
+                                "Team2": 3
+                            },
+                            {
+                                "CurrentQuestion": null,
+                                "Team1": 3,
+                                "Team2": 5
+                            }
+                        ]
+                    }
+                ],
+                "TeamRankingLabel": null,
+                "QuizzerRankingLabel": null,
+                "Matches": [
+                    {
+                        "Id": 1,
+                        "MatchTime": "11:00 AM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 2,
+                        "MatchTime": "11:30 AM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 3,
+                        "MatchTime": "12:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 4,
+                        "MatchTime": "12:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 5,
+                        "MatchTime": "01:00 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 6,
+                        "MatchTime": "01:30 PM",
+                        "PlayoffIndex": null
+                    },
+                    {
+                        "Id": 7,
+                        "MatchTime": "02:00 PM",
+                        "PlayoffIndex": null
+                    }
+                ],
+                "HasRoomCompletionMismatch": false,
+                "HasScoringCompleted": false,
+                "ScoringProgressMessage": ""
+            }
+        ]
+    },
+    "Freshness": "2024-01-21T16:38:18.8261438+00:00"
+}


### PR DESCRIPTION
## Issue
The updated Schedules tab in live scores was designed to display the scores in a mobile friendly way. The old grid system didn't print well and was targeted at the event coordinator. Unfortunately, the existing system forces the user to go to the registration site to look at the database settings.

## Fix
Introduced a new View button on the page:
![image](https://github.com/biblequiz/BibleQuiz.com/assets/15827689/1e7d6664-a849-454d-ac94-d20139c3b4bb)

This enables several new scenarios:
* **Room View**
Officials often want to see what teams are coming to their room next. The existing view is team-centric, which makes this more difficult. This change introduces a view pivoted by room. Additional improvements in the future may make it easier to determine which room is delaying the match.

* **Grid View**
Displays the old view (currently accessible from the database settings page) to allow event coordinators to more easily print and see the dashboard for an event.

## Other Fixes
The change also includes some fixes to the loading bar which wasn't being displayed correctly.