### PR TITLE
Add a link for the current season's past events

### DIFF
--- a/_includes/events-future.html
+++ b/_includes/events-future.html
@@ -2,6 +2,17 @@
 {% assign event_count = events | size %}
 
 {% if event_count > 0 %}
+
+{% assign first_event = events | first %}
+
+<div class="columns is-desktop">
+  <div class="column has-text-centered">
+    <a href="{{ include.history_base_url }}/{{ first_event.season }}" class="button is-primary">
+      See Past Events from the {{ first_event.season }} Season&nbsp;<i class="far fa-arrow-alt-circle-right"></i>
+    </a>
+  </div>
+</div>
+
 <table class="table is-striped is-narrow is-hoverable is-fullwidth">
   <thead>
     <tr>
@@ -31,7 +42,8 @@
       </td>
       <td>{{ event.scopeLabel }}</td>
       <td>
-        {% if event.isVisible %}<a href="https://registration.biblequiz.com/#/Registration/{{ event.id }}">{% endif %}{{ event.name }}{% if event.isVisible %}</a>{% endif %}
+        {% if event.isVisible %}<a href="https://registration.biblequiz.com/#/Registration/{{ event.id }}">{% endif %}{{
+          event.name }}{% if event.isVisible %}</a>{% endif %}
       </td>
       <td>{{ event.locationName }}<br><em>{{ event.locationCity }}</em></td>
       <td>

--- a/_pages/upcoming-events/index.md
+++ b/_pages/upcoming-events/index.md
@@ -4,6 +4,7 @@ permalink: /upcoming-events/jbq/
 title: "Upcoming & Live JBQ Events"
 date: "2023-04-26"
 tabs: tabs_upcoming_events
+hide_hero: true
 ---
 
-{% include events-future.html type="jbq" liveScoresLink="/jbq/live-events" %}
+{% include events-future.html type="jbq" history_base_url="/jbq" liveScoresLink="/jbq/live-events" %}

--- a/_pages/upcoming-events/tbq.md
+++ b/_pages/upcoming-events/tbq.md
@@ -4,6 +4,7 @@ permalink: /upcoming-events/tbq/
 title: "Upcoming & Live TBQ Events"
 date: "2023-04-26"
 tabs: tabs_upcoming_events
+hide_hero: true
 ---
 
-{% include events-future.html type="tbq" liveScoresLink="/live-events" %}
+{% include events-future.html type="tbq" history_base_url="/history" liveScoresLink="/live-events" %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "BibleQuiz.com",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Once an event stops being "live" (i.e., it's in the past), it's not always obvious for users where the event will appears. This change introduces a button for navigating directly to the season's past events.

**NOTE:** The button will only appear if there is at least one live event.