### PR TITLE
Fix Room Schedule when Linked Meets are out of order

### DIFF
--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -646,11 +646,12 @@ function initializeLiveEvents() {
                             linkedMeetNames[i] += ",";
                         }
 
-                        linkedMeetNames[linkedMeetNames.length - 2] += " and";
+                        linkedMeetNames[linkedMeetNames.length - 2] += `${linkedMeetNames.length > 2 ? "," : ""} and`;
 
                         meet.Name = linkedMeetNames.join(" ");
                     }
                     else {
+                        meetIndex++;
                         continue;
                     }
                 }


### PR DESCRIPTION
If the first meet in the linked list of meets has a larger Meet.Id, that whole meet will be excluded.