### PR TITLE
Update Schedule Grid to Honor Ranking

### DIFF
--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -920,10 +920,18 @@ function initializeLiveEvents() {
                             break;
 
                         case ScheduleViewType.Grid:
-                            cardItems = meet.RankedTeams;
+
+                            if (meet.RankedTeams) {
+                                cardItems = meet.RankedTeams;
+                                isTeamRedirect = true;
+                            }
+                            else {
+                                cardItems = meet.Teams;
+                                isTeamRedirect = false;
+                            }
+                            
                             isCardReport = false;
                             isRoomReport = false;
-                            isTeamRedirect = true;
 
                             // Configure the table.
                             const teamTableHeaderRow = getByAndRemoveId(scheduleGridTableContainer, "scheduleTeamTableHeaderRow");

--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -907,20 +907,23 @@ function initializeLiveEvents() {
                     // Capture the data needed for the report.
                     let isRoomReport;
                     let isCardReport;
+                    let isTeamRedirect;
                     let cardItems;
                     switch (currentScheduleView) {
                         case ScheduleViewType.Room:
                             cardItems = meet.Rooms;
                             isRoomReport = true;
                             isCardReport = true;
+                            isTeamRedirect = false;
 
                             scheduleGridTableContainer.remove();
                             break;
 
                         case ScheduleViewType.Grid:
-                            cardItems = meet.Teams;
+                            cardItems = meet.RankedTeams;
                             isCardReport = false;
                             isRoomReport = false;
+                            isTeamRedirect = true;
 
                             // Configure the table.
                             const teamTableHeaderRow = getByAndRemoveId(scheduleGridTableContainer, "scheduleTeamTableHeaderRow");
@@ -969,6 +972,7 @@ function initializeLiveEvents() {
                             cardItems = meet.Teams;
                             isCardReport = true;
                             isRoomReport = false;
+                            isTeamRedirect = false;
 
                             scheduleGridTableContainer.remove();
                             break;
@@ -1070,7 +1074,9 @@ function initializeLiveEvents() {
 
                     for (let i = 0; i < cardItems.length; i++) {
 
-                        const team = cardItems[i];
+                        const team = isTeamRedirect
+                            ? meet.Teams[cardItems[i]]
+                            : cardItems[i];
 
                         const teamCardOrRow = cloneTemplate(teamCardTemplate);
 


### PR DESCRIPTION
The Schedule Grid doesn't show teams in ranked order, making it more cumbersome to compare between similarly ranked teams. In this change, the teams will be displayed in ranked order if the information is known.