### PR TITLE
Updating Live Scores to show in-room matches at all times

### DIFF
--- a/_includes/event-live-scores.html
+++ b/_includes/event-live-scores.html
@@ -310,12 +310,12 @@
       <table class="table is-striped is-fullwidth is-bordered is-narrow">
         <thead>
           <tr id="scheduleTeamTableHeaderRow">
-            <th width="30" class="has-text-right hide-if-schedule">#</th>
+            <th id="rankColumn" width="30" class="has-text-right hide-if-schedule">#</th>
             <th width="33%">Team (Church)</th>
-            <th width="30" class="has-text-right hide-if-schedule">W</th>
-            <th width="30" class="has-text-right hide-if-schedule">L</th>
-            <th width="65" class="has-text-right hide-if-schedule">Total</th>
-            <th width="65" class="has-text-right hide-if-schedule">Avg</th>
+            <th id="winColumn" width="30" class="has-text-right hide-if-schedule">W</th>
+            <th id="lossColumn" width="30" class="has-text-right hide-if-schedule">L</th>
+            <th id="totalColumn" width="65" class="has-text-right hide-if-schedule">Total</th>
+            <th id="averageColumn" width="65" class="has-text-right hide-if-schedule">Avg</th>
             <th class="has-text-centered" id="matchItem" />
           </tr>
         </thead>


### PR DESCRIPTION
If scoring is disabled by the event coordinator, the in-room matches should still be displayed in the live scores. This will be changing in the back-end APIs, but this change is doing the preliminary work.