### PR TITLE
Update the Live Score API URLs

### DIFF
--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -351,7 +351,7 @@ function initializeLiveEvents() {
         teamModalContainer.addClass("is-active");
 
         // Load the in-room scores.
-        fetch(`https://scores.biblequiz.com/Events/${eventId}/Reports/${databaseId}/Scores/${meetId}/${matchId}/${roomId}?m=true`)
+        fetch(`https://scores.biblequiz.com/api/1.0/reports/Events/${eventId}/Reports/${databaseId}/Scores/${meetId}/${matchId}/${roomId}?m=true`)
             .then(response => response.text())
             .then(html => {
                 teamModalBody.html(html);
@@ -604,7 +604,7 @@ function initializeLiveEvents() {
     }
 
     // Retrieve the score report that contains all the information about the event.
-    fetch(`https://scores.biblequiz.com/api/Events/${eventId}/ScoringReport`)
+    fetch(`https://scores.biblequiz.com/api/1.0/reports/Events/${eventId}/ScoringReport`)
         .then(response => response.json())
         .then(report => {
 


### PR DESCRIPTION
The URLs for scores.biblequiz.com now include a version of the API, which requires updates to the `*.js` scripts.