### PR TITLE
Allow in-room scoring for live matches

### DIFF
--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -1396,7 +1396,7 @@ function initializeLiveEvents() {
                                         }
                                     }
 
-                                    if (null != match.Score) {
+                                    if (isLiveMatch || null != match.Score) {
                                         statsLink.click(
                                             null,
                                             e => openMatchScoresheet(`Match ${resolvedMatch.Id} in ${match.Room} @ ${resolvedMeet.Name}`, resolvedMeet.DatabaseId, resolvedMeet.MeetId, resolvedMatch.Id, match.RoomId))


### PR DESCRIPTION
The link for in-room scores isn't working for live matches. This change fixes the bug.