### PR TITLE
Improve Handling for Event Reports

### DIFF
--- a/_includes/event-live-scores.html
+++ b/_includes/event-live-scores.html
@@ -157,7 +157,7 @@
       <strong>IN PROGRESS: <span id="meetProgressLabel" /></strong>
     </div>
     <div id="teamsSection">
-      <p class="title is-4" style="margin-top: 0px;">Teams</p>
+      <p class="title is-4" id="teamsTitle" style="margin-top: 0px;">Teams</p>
       <div class="is-size-6" id="teamRankingRow">
         <i><strong>Team Report:</strong> <span id="teamRankingLabel" /></i>
       </div>
@@ -203,7 +203,7 @@
       </div>
     </div>
     <div id="quizzersSection" class="mt-4">
-      <p class="title is-4">Quizzers</p>
+      <p class="title is-4" id="quizzersTitle">Quizzers</p>
       <div class="is-size-6" id="quizzersRankingRow">
         <i><strong>Individual Report:</strong> <span id="quizzerRankingLabel" /></i>
       </div>

--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -800,6 +800,8 @@ function initializeLiveEvents() {
                         const teamsContainer = getByAndRemoveId(meetCell, "teamsSection")
                             .prop("id", teamsAnchorId);
 
+                        const teamsTitle = getByAndRemoveId(teamsContainer, "teamsTitle");
+
                         let hasTie = false;
                         if (!meet.RankedTeams) {
                             teamsContainer.remove();
@@ -894,12 +896,24 @@ function initializeLiveEvents() {
                         const quizzersContainer = getByAndRemoveId(meetCell, "quizzersSection")
                             .prop("id", quizzersAnchorId);
 
+                        const quizzersTitle = getByAndRemoveId(quizzersContainer, "quizzersTitle");
+
                         hasTie = false;
                         if (!meet.RankedQuizzers) {
                             quizzersContainer.remove();
+
+                            if (meet.RankedTeams) {
+                                teamsTitle.remove();
+                                quizzersTitle.remove();
+                            }
                         }
                         else {
                             noScoresWarning.remove();
+
+                            if (!meet.RankedTeams) {
+                                teamsTitle.remove();
+                                quizzersTitle.remove();
+                            }
 
                             if (meet.QuizzerRankingLabel) {
                                 getByAndRemoveId(quizzersContainer, "quizzerRankingLabel")
@@ -984,7 +998,7 @@ function initializeLiveEvents() {
                         }
 
                         // Update the table of contents.
-                        if (meet.RankedTeams || meet.RankedQuizzers) {
+                        if (meet.RankedTeams && meet.RankedQuizzers) {
                             tocEntry.append(
                                 $("<ul />")
                                     .append($("<li />")
@@ -1098,6 +1112,10 @@ function initializeLiveEvents() {
 
                             default:
                                 cardItems = meet.Teams;
+                                if (null == cardItems) {
+                                    continue;
+                                }
+
                                 isCardReport = true;
                                 isRoomReport = false;
                                 isTeamRedirect = false;


### PR DESCRIPTION
The new event reports feature on BibleQuiz.com wasn't rendering correctly when there were only teams or only quizzers. This change updates the handling to allow for the teams to be missing.