### PR TITLE
Hide the hero when printing live events

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,4 +1,5 @@
 <section
+    id="pageHero"
     class="hero {% if page.hero_height %} {{ page.hero_height }} {% else %} is-medium {% endif %} is-bold is-primary"
     {% if page.hero_image %}
         style="background: url('{{ page.hero_image }}') no-repeat center center; background-size: cover;"

--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -668,6 +668,7 @@ function initializeLiveEvents() {
 
             // Update the title of the page.
             $(document).prop("title", report.EventName);
+            $("#pageHero").addClass("hide-on-print");
             $("#pageTitle").text(report.EventName);
 
             // Initialize the table of contents.


### PR DESCRIPTION
The hero at the top of the page is adding a blank page when printing some of the live event schedules or scores. This change hides the hero when printing which eliminates this issue entirely.