### PR TITLE
Add Years Quizzing to the Team & Quizzer Stats

### DIFF
--- a/_includes/event-live-scores.html
+++ b/_includes/event-live-scores.html
@@ -215,11 +215,12 @@
         <i><strong>Individual Report:</strong> <span id="quizzerRankingLabel" /></i>
       </div>
       <table class="table is-striped is-fullwidth is-bordered is-narrow">
-        <thead>
+        <thead id="quizzersTableHeader">
           <tr>
             <th class="has-text-right" width="30">#</th>
             <th>Quizzer</th>
             <th>Team (Church)</th>
+            <th class="has-text-right" width="65" id="yearsQuizzingColumn">Yrs</th>
             <th class="has-text-right" width="65">Total</th>
             <th class="has-text-right" width="65">Avg</th>
             <th class="has-text-right" width="45">QO</th>
@@ -234,6 +235,7 @@
             <td class="has-text-right" id="rankColumn" />
             <td id="nameColumn" />
             <td id="teamNameColumn" />
+            <td class="has-text-right" id="yearsQuizzingColumn" />
             <td class="has-text-right" id="totalColumn" />
             <td class="has-text-right" id="averageColumn" />
             <td class="has-text-right" id="quizOutColumn" />

--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -966,6 +966,12 @@ function initializeLiveEvents() {
                             }
 
                             // Build the Quizzers table.
+                            const quizzerTableHeader = getByAndRemoveId(quizzersContainer, "quizzersTableHeader");
+                            const quizzerTableYearsHeader = getByAndRemoveId(quizzerTableHeader, "yearsQuizzingColumn");
+                            if (!meet.ShowYearsQuizzing) {
+                                quizzerTableYearsHeader.remove();
+                            }
+
                             const quizzerTableBody = getByAndRemoveId(quizzersContainer, "quizzersTableBody");
                             const quizzerTableRowTemplate = getByAndRemoveId(quizzerTableBody, "tableRow")
                                 .remove()
@@ -973,7 +979,7 @@ function initializeLiveEvents() {
 
                             for (let i = 0; i < meet.RankedQuizzers.length; i++) {
 
-                                const quizzer = meet.Quizzers[meet.RankedQuizzers[i]]
+                                const quizzer = meet.Quizzers[meet.RankedQuizzers[i]];
 
                                 const tableRow = cloneTemplate(quizzerTableRowTemplate);
 
@@ -1001,6 +1007,14 @@ function initializeLiveEvents() {
                                 getByAndRemoveId(tableRow, "question30sColumn").append(quizzer.Scores.Correct30s ? quizzer.Scores.Correct30s : "&nbsp;");
                                 getByAndRemoveId(tableRow, "question20sColumn").append(quizzer.Scores.Correct20s ? quizzer.Scores.Correct20s : "&nbsp;");
                                 getByAndRemoveId(tableRow, "question10sColumn").append(quizzer.Scores.Correct10s ? quizzer.Scores.Correct10s : "&nbsp;");
+
+                                const yearsQuizzingColumn = getByAndRemoveId(tableRow, "yearsQuizzingColumn");
+                                if (meet.ShowYearsQuizzing) {
+                                    yearsQuizzingColumn.append(null == quizzer.YearsQuizzing ? "&nbsp;" : quizzer.YearsQuizzing);
+                                }
+                                else {
+                                    yearsQuizzingColumn.remove();
+                                }
 
                                 // Update the search index.
                                 searchIndexSource.quizzers.push({


### PR DESCRIPTION
A new column has been added for quizzers -- `Years Quizzing` -- to be entered by the event coordinator. If this field is present, it needs to be added as a column on the quizzers table.