### PR TITLE
Add Prefix for Single Team Schedule or Scores

### DIFF
--- a/_includes/event-live-scores.html
+++ b/_includes/event-live-scores.html
@@ -256,7 +256,7 @@
   </template>
 
   <template id="schedulesTemplate">
-    <div class="columns is-mobile mt-2">
+    <div class="columns is-mobile mt-2 meet-cell-title">
       <div class="column is-four-fifths">
         <p class="title is-3" id="meetName" />
         <p class="subtitle is-7"><i>Last Updated: <span id="lastUpdated" /></i></p>

--- a/assets/js/live-event-scores.js
+++ b/assets/js/live-event-scores.js
@@ -1225,7 +1225,13 @@ function initializeLiveEvents() {
 
                                     formatElementTextSizes(allResizableIfSingleTeamElements, true);
 
+                                    allMeetCellTitles.hide();
+                                    allTeamNamePrefixes.show();
+
                                     printScheduleAndScores.triggerHandler("click");
+
+                                    allTeamNamePrefixes.hide();
+                                    allMeetCellTitles.show();
 
                                     formatElementTextSizes(allResizableIfSingleTeamElements, false);
 
@@ -1247,7 +1253,13 @@ function initializeLiveEvents() {
 
                                     formatElementTextSizes(allResizableIfSingleTeamElements, true);
 
+                                    allMeetCellTitles.hide();
+                                    allTeamNamePrefixes.show();
+
                                     printScheduleOnly.triggerHandler("click");
+
+                                    allTeamNamePrefixes.hide();
+                                    allMeetCellTitles.show();
 
                                     formatElementTextSizes(allResizableIfSingleTeamElements, false);
 
@@ -1282,7 +1294,8 @@ function initializeLiveEvents() {
 
                             // Add the team information.
                             const highlightTeamName = getByAndRemoveId(teamCardOrRow, isCardReport ? "teamName" : "nameColumn")
-                                .text(team.Name);
+                                .append($("<span />").addClass("team-name-prefix").hide().text(`${meet.Name}: `))
+                                .append($("<span />").text(team.Name));
                             if (!isRoomReport) {
 
                                 // Update the search index.
@@ -1868,6 +1881,8 @@ function initializeLiveEvents() {
 
             // Capture all the meet cells.
             const allMeetCells = $(".meet-cell");
+            const allMeetCellTitles = $(".meet-cell-title");
+            const allTeamNamePrefixes = $(".team-name-prefix");
             const allScheduleOnlyCells = $(".show-if-schedule");
             const allShowIfTeamCells = $(".show-if-single-team");
             const allIsFullIfSingleTeamElements = $(".is-full-if-single-team");


### PR DESCRIPTION
When printing single team schedule or scores, the meet name doesn't appear on any other page than the first. This can make it difficult for the coordinator to keep track of the church's division when handing out schedules. This change prefixes the team name with the name of the event in this scenario.