### PR TITLE
Add Redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+# Add the registration API.
+/api/reg/* https://registration.biblequiz.com/api/:splat 200


### PR DESCRIPTION
Introduce redirects to BibleQuiz.com that will proxy requests to the registration APIs via biblequiz.com. This will avoid CORS triggering when the service is running remotely.