### PR TITLE
Enable proxying of biblequiz.com/api

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,1 @@
-/api/reg/* https://registration.biblequiz.com/api/:splat
+/api/reg/* https://registration.biblequiz.com/api/:splat 200


### PR DESCRIPTION
The `biblequiz.com/api/reg` URLs aren't being proxied. Instead they are 302s back to the client.