### PR TITLE
Disable Search Button if no text on Church Lookup

### DIFF
--- a/src/components/ChurchLookup.tsx
+++ b/src/components/ChurchLookup.tsx
@@ -152,7 +152,7 @@ export default function ChurchLookup({
             type="button"
             className="btn btn-primary"
             onClick={e => startSearch()}
-            disabled={searchState?.isLoading ?? false}
+            disabled={!searchText || (searchState?.isLoading ?? false)}
           >
             <FontAwesomeIcon icon="fas faSearch" />
             Search


### PR DESCRIPTION
* When there is no text, the church lookup search button is still enabled, which causes confusion. This change disables the button if there is no text.
* Apply Dependabot change.