### PR TITLE
Users/michsco/live events

### DIFF
--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -37,12 +37,11 @@ import EventScopeBadge from "./EventScopeBadge";
         eventType && eventId && (
             <span>
                 <PrintDialogButton isLoaded={eventIsLoaded ?? false} />
-                <ExcelExportButton
-                    eventId={eventId}
-                    eventName={title}
+                <ExcelExportButton isLoaded={eventIsLoaded ?? false} />
+                <ToggleFavoritesOnlyButton
                     isLoaded={eventIsLoaded ?? false}
+                    client:only="react"
                 />
-                <ToggleFavoritesOnlyButton isLoaded={eventIsLoaded ?? false} client:only="react" />
             </span>
         )
     }

--- a/src/components/scores/EventScoringReportLoader.tsx
+++ b/src/components/scores/EventScoringReportLoader.tsx
@@ -1,16 +1,14 @@
 import { useEffect } from "react";
 import Fuse from "fuse.js";
-
 import { useStore } from "@nanostores/react";
-import { sharedEventScoringReportState, sharedPrintConfiguration } from "@utils/SharedState";
-import type { EventScoringReportSearchIndexItem, EventScoringReportSearchIndexSection } from "@utils/SharedState";
-import { PrintDialogModalId } from "./PrintDialogContent";
-import FontAwesomeIcon from "../FontAwesomeIcon";
-import type { EventInfo } from "@types/EventTypes";
-import type { EventScoringReport, ScoringReportMeet, ScoringReportQuizzer, ScoringReportTeam } from "@types/EventScoringReport";
-import { TeamAndQuizzerFavorites } from "@types/TeamAndQuizzerFavorites";
-import { ReportService } from "../../types/services/ReportService";
+import { EventScoringReport, ScoringReportTeam, ScoringReportMeet, ScoringReportQuizzer } from "../../types/EventScoringReport";
+import type { EventInfo } from "../../types/EventTypes";
 import type { RemoteServiceError } from "../../types/services/RemoteServiceUtility";
+import { ReportService } from "../../types/services/ReportService";
+import { TeamAndQuizzerFavorites } from "../../types/TeamAndQuizzerFavorites";
+import { sharedEventScoringReportState, sharedPrintConfiguration, type EventScoringReportSearchIndexItem } from "../../utils/SharedState";
+import FontAwesomeIcon from "../FontAwesomeIcon";
+import { PrintDialogModalId } from "./PrintDialogContent";
 
 interface Props {
     parentTabId: string;
@@ -89,7 +87,7 @@ export default function EventScoringReportLoader({ parentTabId, eventInfo, event
                 {
                     report: report,
                     favorites: TeamAndQuizzerFavorites.load(),
-                    teamIndex: new Fuse<ScoringReportTeam>(
+                    teamIndex: new Fuse<EventScoringReportSearchIndexItem<ScoringReportTeam>>(
                         teamIndexSource,
                         {
                             shouldSort: false,
@@ -98,7 +96,7 @@ export default function EventScoringReportLoader({ parentTabId, eventInfo, event
                             keys: ["item.Name", "item.ChurchName"],
                             threshold: 0.4
                         }),
-                    quizzerIndex: new Fuse<ScoringReportQuizzer>(
+                    quizzerIndex: new Fuse<EventScoringReportSearchIndexItem<ScoringReportQuizzer>>(
                         quizzerIndexSource,
                         {
                             shouldSort: false,
@@ -160,7 +158,7 @@ export default function EventScoringReportLoader({ parentTabId, eventInfo, event
                     sharedEventScoringReportState.set(
                         {
                             report: null,
-                            favorites: null,
+                            favorites: null!,
                             teamIndex: null,
                             quizzerIndex: null,
                             error: error.message || "Failed to download the report for unknown reasons.",
@@ -190,7 +188,7 @@ export default function EventScoringReportLoader({ parentTabId, eventInfo, event
             // Drop the unsupported tabs.
             let hasStats = false;
             let hasQStats = false;
-            for (let meet of reportState.report.Report.Meets) {
+            for (let meet of reportState.report!.Report.Meets) {
 
                 // If there are any question stats, mark the flag.
                 if (meet.HasQuestionStats) {

--- a/src/components/scores/EventScoringReportLoader.tsx
+++ b/src/components/scores/EventScoringReportLoader.tsx
@@ -9,6 +9,7 @@ import FontAwesomeIcon from "../FontAwesomeIcon";
 import type { EventInfo } from "@types/EventTypes";
 import type { EventScoringReport, ScoringReportMeet, ScoringReportQuizzer, ScoringReportTeam } from "@types/EventScoringReport";
 import { TeamAndQuizzerFavorites } from "@types/TeamAndQuizzerFavorites";
+import { ReportService } from "../../types/services/ReportService";
 
 interface Props {
     parentTabId: string;
@@ -111,6 +112,27 @@ export default function EventScoringReportLoader({ parentTabId, eventInfo, event
             const excelButton: HTMLElement | null = document.getElementById("excel-export-button");
             if (excelButton) {
                 excelButton.removeAttribute("disabled");
+                
+                excelButton.addEventListener(
+                    "click",
+                    () => {
+                        excelButton.setAttribute("disabled", "true");
+
+                        ReportService.downloadEventStatsExcelFile(
+                            null, // No auth.
+                            eventInfo.id,
+                            `Stats - ${eventInfo.name}.xlsx`)
+                            .then(() => {
+                                excelButton.removeAttribute("disabled");
+                            })
+                            .catch((error) => {
+                                // eslint-disable-next-line no-console
+                                console.error("Failed to download the excel file: ", error);
+                                alert(`Failed to download the excel file: ${error}`);
+
+                                excelButton.removeAttribute("disabled");
+                            });
+                    });
             }
 
             const printButton: HTMLElement | null = document.getElementById(`${PrintDialogModalId}-button`);

--- a/src/components/scores/EventScoringReportSearch.tsx
+++ b/src/components/scores/EventScoringReportSearch.tsx
@@ -1,12 +1,12 @@
 import type React from "react";
 import { useStore } from "@nanostores/react";
 
-import FontAwesomeIcon from "../FontAwesomeIcon";
 import type { FuseResult } from "fuse.js";
-import ToggleTeamOrQuizzerFavoriteButton from "./ToggleTeamOrQuizzerFavoriteButton";
 import type { ScoringReportTeam, ScoringReportQuizzer, ScoringReportMeet } from "../../types/EventScoringReport";
 import type { TeamAndQuizzerFavorites } from "../../types/TeamAndQuizzerFavorites";
-import { type SharedEventScoringReportState, sharedEventScoringReportState, type SharedEventScoringReportFilterState, sharedEventScoringReportFilterState, showFavoritesOnlyToggle, EventScoringReportSearchIndexItem } from "../../utils/SharedState";
+import { type SharedEventScoringReportState, sharedEventScoringReportState, type SharedEventScoringReportFilterState, sharedEventScoringReportFilterState, showFavoritesOnlyToggle, type EventScoringReportSearchIndexItem } from "../../utils/SharedState";
+import FontAwesomeIcon from "../FontAwesomeIcon";
+import ToggleTeamOrQuizzerFavoriteButton from "./ToggleTeamOrQuizzerFavoriteButton";
 
 interface Props {
     parentTabId: string;
@@ -41,8 +41,8 @@ export default function EventScoringReportSearch({ parentTabId }: Props) {
             return;
         }
 
-        const teamResults: FuseResult<ScoringReportTeam>[] | null = reportState?.teamIndex?.search(searchText) ?? null;
-        const quizzerResults: FuseResult<ScoringReportQuizzer>[] | null = reportState?.quizzerIndex?.search(searchText) ?? null;
+        const teamResults = reportState?.teamIndex?.search(searchText) ?? null;
+        const quizzerResults = reportState?.quizzerIndex?.search(searchText) ?? null;
 
         function sortSearchResults(a: any, b: any) {
             if (a.score < b.score) {
@@ -85,25 +85,6 @@ export default function EventScoringReportSearch({ parentTabId }: Props) {
         }
 
         sharedEventScoringReportFilterState.set(null);
-    };
-
-    const handleFavoritesButtonClick = (updateFavorites: (f: TeamAndQuizzerFavorites) => void) => {
-
-        // Update the favorites object.
-        updateFavorites(favorites);
-        favorites.save();
-
-        // Update the state.
-        sharedEventScoringReportFilterState.set({
-            searchText: eventFilters?.searchText ?? null,
-            teamResults: eventFilters?.teamResults ?? null,
-            quizzerResults: eventFilters?.quizzerResults ?? null,
-            openMeetDatabaseId: null,
-            openMeetMeetId: null,
-            highlightTeamId: null,
-            highlightQuizzerId: null,
-            favoritesVersion: favorites.version,
-        });
     };
 
     const handleHighlightButtonClick = (meet: ScoringReportMeet, highlightTeamId: string | null, highlightQuizzerId: string | null) => {
@@ -150,7 +131,7 @@ export default function EventScoringReportSearch({ parentTabId }: Props) {
                         <div>
                             <p className="text-lg"><b>Teams</b></p>
                             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-2">
-                                {eventFilters.teamResults.map((result: FuseResult<EventScoringReportSearchIndexItem<ScoringReportTeam>>) => {
+                                {eventFilters.teamResults!.map((result: FuseResult<EventScoringReportSearchIndexItem<ScoringReportTeam>>) => {
                                     hasAnyResults = true;
 
                                     const indexItem = result.item;
@@ -189,7 +170,7 @@ export default function EventScoringReportSearch({ parentTabId }: Props) {
                         <div>
                             <p className="text-lg"><b>Quizzers</b></p>
                             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-2">
-                                {eventFilters.quizzerResults.map((result: FuseResult<EventScoringReportSearchIndexItem<ScoringReportQuizzer>>) => {
+                                {eventFilters.quizzerResults!.map((result: FuseResult<EventScoringReportSearchIndexItem<ScoringReportQuizzer>>) => {
 
                                     hasAnyResults = true;
 

--- a/src/components/scores/EventScoringReportSearch.tsx
+++ b/src/components/scores/EventScoringReportSearch.tsx
@@ -1,13 +1,12 @@
 import type React from "react";
 import { useStore } from "@nanostores/react";
-import { sharedEventScoringReportState, sharedEventScoringReportFilterState, showFavoritesOnlyToggle } from "@utils/SharedState";
-import type { SharedEventScoringReportFilterState, SharedEventScoringReportState, EventScoringReportSearchIndexItem } from "@utils/SharedState";
 
 import FontAwesomeIcon from "../FontAwesomeIcon";
 import type { FuseResult } from "fuse.js";
-import type { ScoringReportMeet, ScoringReportQuizzer, ScoringReportTeam } from "@types/EventScoringReport";
-import type { TeamAndQuizzerFavorites } from "@types/TeamAndQuizzerFavorites";
 import ToggleTeamOrQuizzerFavoriteButton from "./ToggleTeamOrQuizzerFavoriteButton";
+import type { ScoringReportTeam, ScoringReportQuizzer, ScoringReportMeet } from "../../types/EventScoringReport";
+import type { TeamAndQuizzerFavorites } from "../../types/TeamAndQuizzerFavorites";
+import { type SharedEventScoringReportState, sharedEventScoringReportState, type SharedEventScoringReportFilterState, sharedEventScoringReportFilterState, showFavoritesOnlyToggle, EventScoringReportSearchIndexItem } from "../../utils/SharedState";
 
 interface Props {
     parentTabId: string;
@@ -20,7 +19,7 @@ export default function EventScoringReportSearch({ parentTabId }: Props) {
     const showOnlyFavorites: boolean = useStore(showFavoritesOnlyToggle);
 
     // If there is no report, it is still loading.
-    if (!reportState) {
+    if (!reportState || !reportState.report) {
         return null;
     }
 

--- a/src/components/scores/ExcelExportButton.astro
+++ b/src/components/scores/ExcelExportButton.astro
@@ -2,20 +2,16 @@
 import FontAwesomeIcon from "@components/FontAwesomeIcon";
 
 interface Props {
-    eventId: string;
-    eventName: string;
     isLoaded: boolean;
 }
 
-const { eventId, eventName, isLoaded } = Astro.props as Props;
+const { isLoaded } = Astro.props as Props;
 ---
 
-<a
+<button
     id="excel-export-button"
-    href={`https://scores.biblequiz.com/api/v1.0/reports/Events/${eventId}/Stats`}
-    download={`Stats - ${eventName}.xlsx`}
     class="btn btn-warning cursor-pointer hide-on-print"
     disabled={!isLoaded}
 >
     <FontAwesomeIcon icon="fas faFileExcel" />
-</a>
+</button>

--- a/src/components/scores/RoomDialogContent.tsx
+++ b/src/components/scores/RoomDialogContent.tsx
@@ -3,6 +3,8 @@ import { useStore } from "@nanostores/react";
 import { sharedRoomScoringReportState } from "@utils/SharedState";
 import { RoomScoringReport, RoomScoringReportTeam, RoomScoringReportQuizzer, QuizzedOutState } from "@types/RoomScoringReport";
 import FontAwesomeIcon from "../FontAwesomeIcon";
+import { ReportService } from "../../types/services/ReportService";
+import type { RemoteServiceError } from "../../types/services/RemoteServiceUtility";
 
 export default function RoomDialogContent() {
 
@@ -17,27 +19,26 @@ export default function RoomDialogContent() {
                 return;
             }
 
-            fetch(`https://scores.biblequiz.com/api/v1.0/reports/Events/${eventId}/ScoringReport/${databaseId}/${meetId}/${matchId}/${roomId}`)
-                .then(async (response) => {
-                    const body = await response.json();
-                    if (response.ok) {
-                        sharedRoomScoringReportState.set(
-                            {
-                                criteria: reportState.criteria,
-                                report: body,
-                                error: null
-                            });
-                    } else {
-                        sharedRoomScoringReportState.set(
-                            {
-                                criteria: null,
-                                report: null,
-                                error: body.Message || "Failed to download the report for unknown reasons."
-                            });
-                    }
-                })
-                .catch((error) => {
-                    sharedRoomScoringReportState.set({ report: null, error: `Unknown error occurred: ${error}` });
+            ReportService
+                .getRoomScoringReport(
+                    null, // No auth
+                    eventId,
+                    databaseId,
+                    meetId,
+                    matchId,
+                    roomId)
+                .then(report =>
+                    sharedRoomScoringReportState.set(
+                        {
+                            criteria: reportState.criteria,
+                            report: report,
+                            error: null
+                        }))
+                .catch((error: RemoteServiceError) => {
+                    sharedRoomScoringReportState.set({
+                        report: null,
+                        error: `Unknown error occurred: ${error.message}`
+                    });
                 });
         }
     }, [reportState]);

--- a/src/types/services/QuestionGeneratorService.ts
+++ b/src/types/services/QuestionGeneratorService.ts
@@ -85,8 +85,6 @@ export class QuestionGeneratorService {
      * @param fontName Name of the font when format is Pdf.
      * @param fontSize Size of the font when format is Pdf.
      * @param columns Number of columns to use when format is Pdf.
-     * 
-     * @returns URL to download the file.
      */
     public static downloadGeneratedFile(
         auth: AuthManager,
@@ -94,7 +92,7 @@ export class QuestionGeneratorService {
         format: QuestionOutputFormat,
         fontName: string | null = null,
         fontSize: number | null = null,
-        columns: number | null = null): Promise<Blob> {
+        columns: number | null = null): Promise<void> {
 
         return RemoteServiceUtility.downloadFromHttpRequest(
             auth,

--- a/src/types/services/ReportService.ts
+++ b/src/types/services/ReportService.ts
@@ -1,0 +1,75 @@
+﻿import { RemoteServiceUrlBase, RemoteServiceUtility } from "./RemoteServiceUtility";
+import type { AuthManager } from "../AuthManager";
+import type { EventScoringReport } from "../EventScoringReport";
+import type { RoomScoringReport } from "../RoomScoringReport";
+
+const URL_ROOT_PATH = "/api/v1.0/Reports";
+
+/**
+ * Wrapper for the Reports service.
+ */
+export class ReportService {
+
+    /**
+     * Retrieves the scoring report for all databases in the specified event.
+     *
+     * @param auth Optional AuthManager if the report should be retrieved with  to use for authentication if the user is logged in.
+     * @param eventId Id for the event.
+     */
+    public static getScoringReportForAllDatabases(
+        auth: AuthManager | null,
+        eventId: string): Promise<EventScoringReport> {
+
+        return RemoteServiceUtility.executeHttpRequest<EventScoringReport>(
+            auth,
+            "GET",
+            RemoteServiceUrlBase.Scores,
+            `${URL_ROOT_PATH}/events/${eventId}/ScoringReport`);
+    }
+
+    /**
+     * Retrieves the scoring report for an individual room.
+     *
+     * @param auth Optional AuthManager if the report should be retrieved with  to use for authentication if the user is logged in.
+     * @param eventId Id for the event.
+     * @param databaseId Id for the database.
+     * @param meetId Id for the meet.
+     * @param matchId Id for the match.
+     * @param roomId Id for the room.
+     */
+    public static getRoomScoringReport(
+        auth: AuthManager | null,
+        eventId: string,
+        databaseId: string,
+        meetId: number,
+        matchId: number,
+        roomId: number): Promise<RoomScoringReport> {
+
+        return RemoteServiceUtility.executeHttpRequest<RoomScoringReport>(
+            auth,
+            "GET",
+            RemoteServiceUrlBase.Scores,
+            `${URL_ROOT_PATH}/events/${eventId}/ScoringReport/${databaseId}/${meetId}/${matchId}/${roomId}`);
+    }
+
+    /**
+     * Downloads the excel file for the event stats report.
+     *
+     * @param auth Optional AuthManager if the report should be retrieved with  to use for authentication if the user is logged in.
+     * @param eventId Id for the event.
+     * @param fileName Suggested file name for the downloaded file.
+     */
+    public static downloadEventStatsExcelFile(
+        auth: AuthManager | null,
+        eventId: string,
+        fileName: string): Promise<void> {
+
+        return RemoteServiceUtility.downloadFromHttpRequest(
+            auth,
+            "GET",
+            RemoteServiceUrlBase.Scores,
+            `${URL_ROOT_PATH}/events/${eventId}/Stats`,
+            null,
+            fileName);
+    }
+}

--- a/src/types/services/ReportService.ts
+++ b/src/types/services/ReportService.ts
@@ -3,7 +3,7 @@ import type { AuthManager } from "../AuthManager";
 import type { EventScoringReport } from "../EventScoringReport";
 import type { RoomScoringReport } from "../RoomScoringReport";
 
-const URL_ROOT_PATH = "/api/v1.0/Reports";
+const URL_ROOT_PATH = "/api/v1.0/reports";
 
 /**
  * Wrapper for the Reports service.
@@ -24,7 +24,7 @@ export class ReportService {
             auth,
             "GET",
             RemoteServiceUrlBase.Scores,
-            `${URL_ROOT_PATH}/events/${eventId}/ScoringReport`);
+            `${URL_ROOT_PATH}/Events/${eventId}/ScoringReport`);
     }
 
     /**

--- a/src/utils/SharedState.ts
+++ b/src/utils/SharedState.ts
@@ -1,11 +1,10 @@
 import { atom } from 'nanostores';
 import Fuse, { type FuseResult } from "fuse.js";
 
-import { EventScoringReport } from "@types/EventScoringReport";
-import { RoomScoringReport } from "@types/RoomScoringReport";
 import type { QuizzerIndex } from "../types/QuizzerSearch";
-import type { ScoringReportMeet, ScoringReportQuizzer, ScoringReportTeam } from '../types/EventScoringReport';
+import type { EventScoringReport, ScoringReportMeet, ScoringReportQuizzer, ScoringReportTeam } from '../types/EventScoringReport';
 import type { TeamAndQuizzerFavorites } from '../types/TeamAndQuizzerFavorites';
+import type { RoomScoringReport } from '../types/RoomScoringReport';
 
 /* Downloaded Event Report */
 export interface EventScoringReportSearchIndexItem<T> {
@@ -27,7 +26,7 @@ export const sharedEventScoringReportState = atom<SharedEventScoringReportState 
 export interface SharedEventScoringReportFilterState {
     searchText: string | null;
     teamResults: FuseResult<EventScoringReportSearchIndexItem<ScoringReportTeam>>[] | null;
-    quizzerResults: FuseResult<EventScoringReportSearchIndexItem<ScoringReportTeam>>[] | null;
+    quizzerResults: FuseResult<EventScoringReportSearchIndexItem<ScoringReportQuizzer>>[] | null;
     openMeetDatabaseId: string | null;
     openMeetMeetId: number | null;
     highlightTeamId: string | null;

--- a/src/utils/SharedState.ts
+++ b/src/utils/SharedState.ts
@@ -6,7 +6,6 @@ import { RoomScoringReport } from "@types/RoomScoringReport";
 import type { QuizzerIndex } from "../types/QuizzerSearch";
 import type { ScoringReportMeet, ScoringReportQuizzer, ScoringReportTeam } from '../types/EventScoringReport';
 import type { TeamAndQuizzerFavorites } from '../types/TeamAndQuizzerFavorites';
-import type { IPublicClientApplication } from '@azure/msal-browser';
 
 /* Downloaded Event Report */
 export interface EventScoringReportSearchIndexItem<T> {


### PR DESCRIPTION
* **Use RemoteServiceUtility for Live Scores**
Move the calls currently using `fetch` directly to make use of `RemoteServiceUtility`.

* **Move Away from Aliases**
Migrate away from aliases (e.g., `@types`) as Visual Studio Code doesn't follow the complete setup.