### PR TITLE
Move Events to the right location

### DIFF
--- a/src/content/docs/tbq/Seasons/2026/events.mdx
+++ b/src/content/docs/tbq/Seasons/2026/events.mdx
@@ -1,5 +1,5 @@
 ---
-title: "2025 Season Events"
+title: "2026 Season Events"
 tableOfContents: false
 sidebar:
   label: "Events"
@@ -14,8 +14,9 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
   <TabItem label="Tournaments">
     <CardGrid>
       <Card title="Liberty Classic" icon="rocket">
-        **Date(s):** Sep 28, 2024\
-        **Location:** Wyckoff, NJ\
+        **Date(s):** Sep 27, 2025\
+        **Location:** NJ (Location TBD)\
+        **Divisions**: Championship, Contender, XP5\
         **Contact:** Jesse Czubkowski
 
         <LinkButton
@@ -26,10 +27,10 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
         </LinkButton>
       </Card>
       
-      <Card title="40<sup>st</sup> Annual Gold Cup" icon="rocket">
-        **Date(s):** Oct 26, 2024\
+      <Card title="41<sup>st</sup> Annual Gold Cup" icon="rocket">
+        **Date(s):** Oct 25, 2025\
         **Location:** Trinity Church, Cedar Hill, TX\
-        **Divisions:** Gold, Silver, XP5
+        **Divisions:** Gold and Silver
         **Contact:** Lori Sullivan
 
         <LinkButton
@@ -40,8 +41,8 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
         </LinkButton>
       </Card>
 
-      <Card title="7<sup>th</sup> Annual Bluegrass Classic" icon="rocket">
-        **Date(s):** Oct 26, 2024\
+      <Card title="8<sup>th</sup> Annual Bluegrass Classic" icon="rocket">
+        **Date(s):** Oct 25, 2025\
         **Location:** Lexington First Assembly, Lexington, KY\
         **Divisions:** Championship, Contender, XP5
 
@@ -53,8 +54,8 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
         </LinkButton>
       </Card>
 
-      <Card title="31<sup>st</sup> Gobblefest Bible Quiz Tournament" icon="rocket">
-        **Date(s):** Nov 22 - 23, 2024\
+      <Card title="32<sup>nd</sup> Gobblefest Bible Quiz Tournament" icon="rocket">
+        **Date(s):** Nov 21 - 22, 2025\
         **Location:** University of Valley Forge, PA\
         **Divisions:** Championship, Contender, XP5\
         **Contact:** Bernie Elliot\
@@ -69,8 +70,8 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
       </Card>
 
       <Card title="Mid-Winter Classic BQ Tournament" icon="rocket">
-        **Date(s):** Jan 10 - 11, 2025\
-        **Location:** Sioux Falls, SD\
+        **Date(s):** Jan 9 - 10, 2026\
+        **Location:** Life Change Church, Sioux Falls, SD\
         **Divisions:** Championship, Contender, XP5, Adult\
         **Contact:** Don Batty\
         *E-mail or 608-566-6255*
@@ -83,8 +84,8 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
         </LinkButton>
       </Card>
 
-      <Card title="39<sup>th</sup> Friendship Classic" icon="rocket">
-        **Date(s):** Jan 24 - 25, 2025\
+      <Card title="40<sup>th</sup> Friendship Classic" icon="rocket">
+        **Date(s):** Jan 23 - 24, 2026\
         **Location:** Oxford AG, Oxford, FL\
         **Divisions:** Championship Only\
         **Contact:** Bernie Elliot\
@@ -99,8 +100,9 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
       </Card>
 
       <Card title="President's Cup" icon="rocket">
-        **Date(s):** Feb 1, 2025\
+        **Date(s):** Feb 7, 2026\
         **Location:** Swedesboro, NJ\
+        **Divisions**: Championship, Contender, XP5\
         **Contact:** Jesse Czubkowski
 
         <LinkButton
@@ -112,7 +114,7 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
       </Card>
 
       <Card title="Windy City Classic" icon="rocket">
-        **Date(s):** Feb 28 - Mar 1, 2025\
+        **Date(s):** Mar 6 - 7, 2026\
         **Location:** Calvary Church, Naperville, IL\
         **Contact:** David Powell
 
@@ -125,7 +127,7 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
       </Card>
       
       <Card title="Emerald City Tournament" icon="rocket">
-        **Date(s):** April, 2025 <Badge text="Day TBD" variant="note" />\
+        **Date(s):** April, 2026 <Badge text="Day TBD" variant="note" />\
         **Location:** Seattle, WA Area\
         **Divisions**: Championship only\
         **Contact:** Richie Nelson\
@@ -140,8 +142,9 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
       </Card>
 
       <Card title="Jersey Shore Pre-Nats" icon="rocket">
-        **Date(s):** May 31 - Jun 1, 2025\
+        **Date(s):** Jun 5 - 6, 2026\
         **Location:** Tinton Falls, NJ\
+        **Divisions**: All material covered\
         **Contact:** Jesse Czubkowski
 
         <LinkButton
@@ -155,10 +158,13 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
   </TabItem>
   <TabItem label="Training">
     <CardGrid>
-      <Card title="Pen-Florida BQ Training" icon="rocket">
-        **Date(s):** Jul 27, 2024\
-        **Location:** Oxford, FL\
-        **Contact:** Dan Anderson
+      <Card title="Pen-Florida BQ Training Day" icon="rocket">
+        **Date(s):** Jul 26, 2025\
+        **Location:** Oxford Assembly of God, Oxford, FL\
+        **Contact:** Dan Anderson\
+        *E-mail or 407-947-9927*
+
+        Training for coaches, officials and those interested in learning more about JBQ & TBQ!
 
         <LinkButton
           href="mailto:cfcitykidsdan@gmail.com"
@@ -169,8 +175,8 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
       </Card>
 
       <Card title="Dakota Quiz" icon="rocket">
-        **Date(s):** Aug 15 - 17, 2024\
-        **Location:** Camp Rimrock, Rapid City, SD\
+        **Date(s):** Aug 14 - 16, 2025 (deadline for registration is July 14)\
+        **Location:** Rimrock Camp & Retreat Center, Rapid City, SD\
         **Contact:** David & Denise Sullivan
 
         <LinkButton
@@ -181,28 +187,16 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
         </LinkButton>
       </Card>
 
-      <Card title="Penn-Del BQ Camp" icon="rocket">
-        **Date(s):** Aug 16 - 18, 2024\
-        **Location:** Bongiorno Conference Center, Carlisle, PA\
-        **Registration**: [penndelyouth.com/biblequiz](https://www.penndelyouth.com/biblequiz)\
-        **Contact:** Patty Blake\
-        *E-mail or 610-659-2059*
+      <Card title="Northeast Bible Quiz Training Conference" icon="rocket">
+        **Date(s):** Aug 15 - 16, 2025\
+        **Location:** River Of God, Enola, PA\
+        **Training:** Quizzers, Coaches, Officials, and Parents!\
+        **Cost:** $30 (if registered by July 15)
+        **Contact:** Beth Heller\
+        *E-mail or 717-317-4233*
 
         <LinkButton
-          href="mailto:biblequiz@penndel.org"
-          icon="email"
-          iconPlacement="start">
-          Send E-mail
-        </LinkButton>
-      </Card>
-
-      <Card title="Great Lakes Quiz Camp" icon="rocket">
-        **Date(s):** Aug 24, 2024\
-        **Location:** Lexington First Assembly\
-        **Cost**: $25 (includes lunch)\
-
-        <LinkButton
-          href="mailto:tbqkentucky@gmail.com"
+          href="mailto:CapitalTBQ@gmail.com"
           icon="email"
           iconPlacement="start">
           Send E-mail
@@ -210,7 +204,7 @@ import { Badge, CardGrid, Card, Tabs, TabItem, LinkButton, Icon } from '@astrojs
       </Card>
 
       <Card title="Georgia BQ Training" icon="rocket">
-        **Date(s):** Sep 7, 2024\
+        **Date(s):** Sep 6, 2025\
         **Location:** Johns Creek, GA\
         **Training:** Coaches & All Quizzers\
         **Contact:** Doug Black\

--- a/src/content/docs/tbq/Seasons/2027/events.mdx
+++ b/src/content/docs/tbq/Seasons/2027/events.mdx
@@ -1,0 +1,11 @@
+---
+title: "2027 Season Events"
+tableOfContents: false
+sidebar:
+  label: "Events"
+  order: -9
+  attrs:
+    icon: fas faShuttleVan
+---
+
+For the 2026-2027 season we will be quizzing over the book of Mark. This page will be updated as information becomes available.


### PR DESCRIPTION
# Background
The events for the 2026 season were incorrectly left in the 2025 season during the migration to Astro.

# Changes
1. **Move 2026 Events**
    Moved the `events.mdx` from 2025 to 2026, since it includes the 2026 events.
2. **Bring back 2025 events**
    Brought back the events from the GitHub history for the 2025 season for historical context.
3. **Add 2027 Placeholder**
    Introduced a placeholder for the 2027 season.