### PR TITLE
Fix Links during Live match

### DIFF
--- a/src/components/scores/TeamOrRoomScheduleTabContent.tsx
+++ b/src/components/scores/TeamOrRoomScheduleTabContent.tsx
@@ -158,7 +158,7 @@ export default function TeamOrRoomScheduleTabContent({
                         }
 
                         const isLiveMatch = null != match && null != match.CurrentQuestion;
-                        const isScheduleOnly = !hasRanking || (!isLiveMatch && (match as ScoringReportTeamMatch).Score);
+                        const isScheduleOnly = !hasRanking || (!isLiveMatch && (match as ScoringReportTeamMatch).Score === undefined);
 
                         // Determine the prefix before each match.
                         let cellText = [];


### PR DESCRIPTION
The Team and Room scores tab is not displaying the results of scores or the proper schedule. Instead, it is trying to show scores for matches not yet played and schedules for matches already played.