### PR TITLE
Fix Dark Mode Issues

### DIFF
--- a/src/content/docs/jbq/Seasons/2009/index.mdx
+++ b/src/content/docs/jbq/Seasons/2009/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2009 JBQ Season Overview"
+title: "2009 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2010/index.mdx
+++ b/src/content/docs/jbq/Seasons/2010/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2010 JBQ Season Overview"
+title: "2010 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2011/index.mdx
+++ b/src/content/docs/jbq/Seasons/2011/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2011 JBQ Season Overview"
+title: "2011 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2012/index.mdx
+++ b/src/content/docs/jbq/Seasons/2012/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2012 JBQ Season Overview"
+title: "2012 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2013/index.mdx
+++ b/src/content/docs/jbq/Seasons/2013/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2013 JBQ Season Overview"
+title: "2013 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2014/index.mdx
+++ b/src/content/docs/jbq/Seasons/2014/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2014 JBQ Season Overview"
+title: "2014 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2015/index.mdx
+++ b/src/content/docs/jbq/Seasons/2015/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2015 JBQ Season Overview"
+title: "2015 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2016/index.mdx
+++ b/src/content/docs/jbq/Seasons/2016/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2016 JBQ Season Overview"
+title: "2016 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2017/index.mdx
+++ b/src/content/docs/jbq/Seasons/2017/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2017 JBQ Season Overview"
+title: "2017 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2018/index.mdx
+++ b/src/content/docs/jbq/Seasons/2018/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2018 JBQ Season Overview"
+title: "2018 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2019/index.mdx
+++ b/src/content/docs/jbq/Seasons/2019/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2019 JBQ Season Overview"
+title: "2019 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2020/index.mdx
+++ b/src/content/docs/jbq/Seasons/2020/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2020 JBQ Season Overview"
+title: "2020 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2021/index.mdx
+++ b/src/content/docs/jbq/Seasons/2021/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2021 JBQ Season Overview"
+title: "2021 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2022/index.mdx
+++ b/src/content/docs/jbq/Seasons/2022/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2022 JBQ Season Overview"
+title: "2022 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2023/index.mdx
+++ b/src/content/docs/jbq/Seasons/2023/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2023 JBQ Season Overview"
+title: "2023 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2024/index.mdx
+++ b/src/content/docs/jbq/Seasons/2024/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2024 JBQ Season Overview"
+title: "2024 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2025/index.mdx
+++ b/src/content/docs/jbq/Seasons/2025/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2025 JBQ Season Overview"
+title: "2025 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2026/index.mdx
+++ b/src/content/docs/jbq/Seasons/2026/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2026 JBQ Season Overview"
+title: "2026 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/content/docs/jbq/Seasons/2027/index.mdx
+++ b/src/content/docs/jbq/Seasons/2027/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "2027 JBQ Season Overview"
+title: "2027 JBQ Season Results"
 sidebar:
-  label: Overview
+  label: "Results"
   attrs:
-    icon: fas faIgloo
+    icon: fas faSquarePollVertical
 ---
 
 import EventList from 'components/EventList.astro';

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -86,35 +86,43 @@ ol.schedule-list {
 /* Styles for the point numbers */
 td.header-point-10 {
     background-color: white;
+    color: black;
 }
 
 td.header-point-20 {
     background-color: yellow;
+    color: black;
 }
 
 td.header-point-30 {
     background-color: lightgreen;
+    color: black;
 }
 
 td.header-point-default {
     background-color: lightgray;
+    color: black;
 }
 
 /* Styles for the live scoring */
 tr.red-room-score {
     background-color: #ffc0cb;
+    color: black;
 }
 
 tr.red-room-score-alt {
     background-color: #ffffff;
+    color: black;
 }
 
 tr.green-room-score {
     background-color: #98fb98;
+    color: black;
 }
 
 tr.green-room-score-alt {
     background-color: #ffffff;
+    color: black;
 }
 
 td.quiz-out {


### PR DESCRIPTION
* Rename the JBQ Results pages from `Overview` to `Results`, since it only contains `Results`.
* Fix the colors on the room scores to make the in-room score easier to read in Dark Mode.