### PR TITLE
Handle Reused Events

### DIFF
--- a/src/pages/[type]/seasons/[season]/[container]/[slug].astro
+++ b/src/pages/[type]/seasons/[season]/[container]/[slug].astro
@@ -154,9 +154,10 @@ const eventFilePath = path.resolve(
 
 // Determine whether the archive can be used. In some cases, dates for existing events that are
 // already in the archive are changed into the future (i.e., reusing the same event).
+const eventEndDate = DataTypeHelpers.parseDateOnly(eventInfo.endDate);
 const isArchiveAllowed =
-    new Date().getTime() >
-    DataTypeHelpers.parseDateOnly(eventInfo.endDate)!.setHours(23, 59, 59, 999);
+    !eventEndDate ||
+    new Date().getTime() > eventEndDate.setHours(23, 59, 59, 999);
 
 const event = isArchiveAllowed
     ? await tryReadFileAsJson<EventScoringReport>(eventFilePath)


### PR DESCRIPTION
If the dates for an event already published to the archive are moved into the future, the new scores will not appear on the web site until after an archive sync. As a performance improvement, the event page prefers the file in the archive despite the dates. This change updates it to consider the end date of the event before checking for the existence of the file.