### PR TITLE
Fix in-room score links

### DIFF
--- a/src/components/scores/RoomDialogLink.tsx
+++ b/src/components/scores/RoomDialogLink.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from "react";
-
 interface Props {
     id: string;
     label: string;
@@ -21,16 +19,10 @@ export const RoomDialogModalId = "room-dialog";
 
 export default function RoomDialogLink({ id, label, eventId, databaseId, meetId, matchId, roomId, children }: Props) {
 
-    const link = (
+    return (
         <a style={{ cursor: "pointer" }} id={id} data-label={label} data-event-id={eventId}
             data-database-id={databaseId} data-meet-id={meetId} data-match-id={matchId}
-            data-room-id={roomId}>
+            data-room-id={roomId} onClick={e => window.openRoomDialog(e)}>
             {children}
         </a>);
-
-    useEffect(() => {
-        document.getElementById(id)?.addEventListener("click", window.openRoomDialog);
-    }, []);
-
-    return link;
 };

--- a/src/components/scores/ScheduleGridTabContent.tsx
+++ b/src/components/scores/ScheduleGridTabContent.tsx
@@ -4,7 +4,7 @@ import { ScoringReportMeet, ScoringReportTeam, ScoringReportTeamMatch, ScoringRe
 import { useStore } from "@nanostores/react";
 import { sharedEventScoringReportState, sharedEventScoringReportFilterState, showFavoritesOnlyToggle } from "utils/SharedState";
 import CollapsableMeetSection from './CollapsableMeetSection';
-import RoomLink from './RoomDialogLink';
+import RoomDialogLink from './RoomDialogLink';
 import { EventScoringReport } from "types/EventScoringReport";
 import { isTabActive } from "utils/Tabs";
 import type { TeamAndQuizzerFavorites } from "types/TeamAndQuizzerFavorites";
@@ -152,7 +152,7 @@ export default function ScheduleGridTabContent({
                                     <td className="text-center" key={matchKey}>
                                         {!isLiveMatch && match.Score == null && (<span>{match.Room}</span>)}
                                         {(isLiveMatch || match.Score != null) && (
-                                            <RoomLink
+                                            <RoomDialogLink
                                                 id={matchKey}
                                                 label={`Match ${resolvedMatch.Id} in ${match.Room} @ ${resolvedMeet.Name}`}
                                                 eventId={eventId}
@@ -174,7 +174,7 @@ export default function ScheduleGridTabContent({
                                                         </span>
                                                     </>
                                                 )}
-                                            </RoomLink>)}
+                                            </RoomDialogLink>)}
                                     </td>
                                 )
                             })}


### PR DESCRIPTION
* **Always Add the Event Handler**
For unknown reasons, the `useEffect` in `RoomDialogLink` didn't always get applied. It was added to support the scenario where the component is rendered server-side, but it doesn't appear to function in those scenarios. This change moves the event handler directly to the element and this appears to function as expected.

* **Clean-up Naming**