### PR TITLE
Address first round of feedback

### DIFF
--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -62,3 +62,17 @@ import EventScopeBadge from "./EventScopeBadge";
     )
 }
 
+<script>
+    import { PrintDialogModalId } from "./scores/PrintDialogContent";
+    const button: HTMLElement = document.getElementById(
+        `${PrintDialogModalId}-button`,
+    )!;
+
+    const title = button.closest("h1.page-title");
+    if (title && title.classList.contains("hide-on-print")) {
+        const ancestor = title.closest("div.content-panel");
+        if (ancestor) {
+            ancestor.classList.add("hide-on-print");
+        }
+    }
+</script>

--- a/src/components/scores/EventScoringReportLoader.tsx
+++ b/src/components/scores/EventScoringReportLoader.tsx
@@ -17,7 +17,10 @@ interface Props {
 }
 
 function removeTabAndPanel(tabLinkElement: HTMLAnchorElement): void {
-    tabLinkElement.parentElement?.remove();
+    const style = tabLinkElement?.parentElement?.style;
+    if (style) {
+        style.display = "none";
+    }
 }
 
 export default function EventScoringReportLoader({ parentTabId, eventInfo, event }: Props) {

--- a/src/components/scores/EventScoringReportSearch.tsx
+++ b/src/components/scores/EventScoringReportSearch.tsx
@@ -106,7 +106,7 @@ export default function EventScoringReportSearch({ parentTabId }: Props) {
     let hasAnyResults = false;
 
     return (
-        <>
+        <div className="hide-on-print">
             <div className="flex w-full">
                 <label className="input w-full mt-0 mb-4">
                     <FontAwesomeIcon icon="fas faSearch" classNames={["h-[1em]", "opacity-50"]} />
@@ -214,5 +214,5 @@ export default function EventScoringReportSearch({ parentTabId }: Props) {
                         the&nbsp;<FontAwesomeIcon icon="fas faStar" />&nbsp;button in the top-right.
                     </span>
                 </div>)}
-        </>);
+        </div>);
 };

--- a/src/components/scores/PrintDialogContent.tsx
+++ b/src/components/scores/PrintDialogContent.tsx
@@ -144,6 +144,10 @@ export default function PrintDialogContent({ eventId, eventName, meets }: Props)
         sharedPrintConfiguration.set(printConfig);
 
         // Close the dialog.
+        handleCloseClick();
+    };
+
+    const handleCloseClick = () => {
         (document.getElementById(PrintDialogModalId) as any).close();
     };
 
@@ -262,7 +266,12 @@ export default function PrintDialogContent({ eventId, eventName, meets }: Props)
                     onClick={handlePrintClick}>
                     <FontAwesomeIcon icon="fas faPrint" />&nbsp;Print
                 </button>
-                <button type="button" className="btn">Close</button>
+                <button
+                    type="button"
+                    className="btn"
+                    onClick={handleCloseClick}>
+                    Close
+                </button>
             </div>
         </div>);
 }

--- a/src/components/scores/PrintDialogResolver.tsx
+++ b/src/components/scores/PrintDialogResolver.tsx
@@ -56,6 +56,7 @@ export default function PrintDialogResolver({
                         event={resolvedReport}
                         isPrinting={true}
                         printingStatsFormat={printDialogState.statsFormat}
+                        selectedMeets={printDialogState.selectedMeets}
                     />
                 </div>);
         }
@@ -71,6 +72,7 @@ export default function PrintDialogResolver({
                         isPrinting={true}
                         printSinglePerPage={printDialogState.showSinglePerPage}
                         printStats={printDialogState.includeStats}
+                        selectedMeets={printDialogState.selectedMeets}
                     />
                 </div>);
         }
@@ -86,6 +88,7 @@ export default function PrintDialogResolver({
                         isPrinting={true}
                         printSinglePerPage={printDialogState.showSinglePerPage}
                         printStats={printDialogState.includeStats}
+                        selectedMeets={printDialogState.selectedMeets}
                     />
                 </div>);
         }
@@ -99,6 +102,7 @@ export default function PrintDialogResolver({
                         schedulesTabId={scheduleGridTabId}
                         isPrinting={true}
                         printStats={printDialogState.includeStats}
+                        selectedMeets={printDialogState.selectedMeets}
                     />
                 </div>);
         }

--- a/src/components/scores/ScheduleGridTabContent.tsx
+++ b/src/components/scores/ScheduleGridTabContent.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { ScoringReportMeet, ScoringReportTeam, ScoringReportTeamMatch, ScoringReportMeetMatch } from "types/EventScoringReport";
 
 import { useStore } from "@nanostores/react";
-import { sharedEventScoringReportState, sharedEventScoringReportFilterState, showFavoritesOnlyToggle } from "utils/SharedState";
+import { sharedEventScoringReportState, sharedEventScoringReportFilterState, showFavoritesOnlyToggle, type MeetReference } from "utils/SharedState";
 import CollapsableMeetSection from './CollapsableMeetSection';
 import RoomDialogLink from './RoomDialogLink';
 import { EventScoringReport } from "types/EventScoringReport";
@@ -16,6 +16,7 @@ export interface Props {
     isPrinting?: boolean;
     printStats?: boolean;
     schedulesTabId: string;
+    selectedMeets?: MeetReference[];
 };
 
 export default function ScheduleGridTabContent({
@@ -23,7 +24,8 @@ export default function ScheduleGridTabContent({
     event,
     isPrinting,
     printStats,
-    schedulesTabId }: Props) {
+    schedulesTabId,
+    selectedMeets }: Props) {
 
     const scrollToViewElementId = `schedule_grid_scroll_elem`;
 
@@ -54,6 +56,13 @@ export default function ScheduleGridTabContent({
                 const key = `schedulegrid_${meet.DatabaseId}_${meet.MeetId}`;
                 if (meet.IsCombinedReport || !meet.Matches) {
                     return null;
+                }
+                else if (selectedMeets && selectedMeets.length > 0) {
+                    const selectedMeetRef = selectedMeets.find(
+                        m => m.databaseId === meet.DatabaseId && m.meetId === meet.MeetId);
+                    if (!selectedMeetRef) {
+                        return null;
+                    }
                 }
 
                 let teams: ScoringReportTeam[] | number[];

--- a/src/components/scores/StatsTabContent.tsx
+++ b/src/components/scores/StatsTabContent.tsx
@@ -31,7 +31,8 @@ export default function StatsTabContent({
     event,
     isPrinting,
     printingStatsFormat,
-    parentTabId }: EventScoresProps) {
+    parentTabId,
+    selectedMeets }: EventScoresProps) {
 
     const scrollToViewElementId = `stats_tab_scroll_elem`;
 
@@ -58,6 +59,14 @@ export default function StatsTabContent({
     return (
         <>
             {event.Report.Meets.map((meet: ScoringReportMeet) => {
+                
+                if (selectedMeets && selectedMeets.length > 0) {
+                    const selectedMeetRef = selectedMeets.find(
+                        m => m.databaseId === meet.DatabaseId && m.meetId === meet.MeetId);
+                    if (!selectedMeetRef) {
+                        return null;
+                    }
+                }
 
                 let hasTeamTie = false;
                 let hasQuizzerTie = false;

--- a/src/components/scores/TeamOrRoomScheduleTabContent.tsx
+++ b/src/components/scores/TeamOrRoomScheduleTabContent.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { EventScoringReport, ScoringReportMeet, ScoringReportTeamMatch, ScoringReportRoom } from "types/EventScoringReport";
 
 import { useStore } from "@nanostores/react";
-import { sharedEventScoringReportState, sharedEventScoringReportFilterState, showFavoritesOnlyToggle } from "utils/SharedState";
+import { sharedEventScoringReportState, sharedEventScoringReportFilterState, showFavoritesOnlyToggle, type MeetReference } from "utils/SharedState";
 import CollapsableMeetSection from "components/scores/CollapsableMeetSection";
 import type { ScoringReportRoomMatch, ScoringReportTeam } from 'types/EventScoringReport';
 import RoomDialogLink from './RoomDialogLink';
@@ -17,6 +17,7 @@ export interface Props {
     printSinglePerPage?: boolean;
     printStats?: boolean;
     schedulesTabId: string;
+    selectedMeets?: MeetReference[];
 };
 
 function ordinalWithSuffix(number: number): string {
@@ -43,7 +44,8 @@ export default function TeamOrRoomScheduleTabContent({
     isPrinting,
     printSinglePerPage,
     printStats,
-    schedulesTabId }: Props) {
+    schedulesTabId,
+    selectedMeets }: Props) {
 
     const scrollToViewElementId = `schedule_${type}_scroll_elem`;
 
@@ -73,6 +75,13 @@ export default function TeamOrRoomScheduleTabContent({
 
                 if (meet.IsCombinedReport) {
                     return null;
+                }
+                else if (selectedMeets && selectedMeets.length > 0) {
+                    const selectedMeetRef = selectedMeets.find(
+                        m => m.databaseId === meet.DatabaseId && m.meetId === meet.MeetId);
+                    if (!selectedMeetRef) {
+                        return null;
+                    }
                 }
 
                 const hasRanking = meet.RankedTeams && (!isPrinting || printStats);
@@ -280,22 +289,22 @@ export default function TeamOrRoomScheduleTabContent({
                             >
                                 {isScheduleOnly && (<>{cellHtml}</>)}
                                 {!isScheduleOnly && (
-                                        <RoomDialogLink
-                                            id={matchKey}
-                                            label={`Match ${resolvedMatch.Id} in ${match!.Room} @ ${resolvedMeet.Name}`}
-                                            eventId={eventId}
-                                            databaseId={resolvedMeet.DatabaseId}
-                                            meetId={resolvedMeet.MeetId}
-                                            matchId={resolvedMatch.Id}
-                                            roomId={match!.RoomId}>
-                                            {cellHtml}
-                                            {isLiveMatch && (
-                                                <>
-                                                    <br />
-                                                    <i className="fas fa-satellite-dish"></i>&nbsp;Question #{match!.CurrentQuestion}
-                                                </>
-                                            )}
-                                        </RoomDialogLink>
+                                    <RoomDialogLink
+                                        id={matchKey}
+                                        label={`Match ${resolvedMatch.Id} in ${match!.Room} @ ${resolvedMeet.Name}`}
+                                        eventId={eventId}
+                                        databaseId={resolvedMeet.DatabaseId}
+                                        meetId={resolvedMeet.MeetId}
+                                        matchId={resolvedMatch.Id}
+                                        roomId={match!.RoomId}>
+                                        {cellHtml}
+                                        {isLiveMatch && (
+                                            <>
+                                                <br />
+                                                <i className="fas fa-satellite-dish"></i>&nbsp;Question #{match!.CurrentQuestion}
+                                            </>
+                                        )}
+                                    </RoomDialogLink>
                                 )}
                             </li>
                         );

--- a/src/content/docs/tbq/current-season.mdx
+++ b/src/content/docs/tbq/current-season.mdx
@@ -2,7 +2,7 @@
 title: "Current Season"
 pagefind: false
 sidebar:
-  order: -99
+  order: -95
 ---
 
 :::note

--- a/src/utils/Scores.ts
+++ b/src/utils/Scores.ts
@@ -1,5 +1,5 @@
 import { EventScoringReport, ScoringReportMeet } from "types/EventScoringReport";
-import { StatsFormat } from "utils/SharedState";
+import { StatsFormat, type MeetReference } from "utils/SharedState";
 
 export function formatLastUpdated(meet: ScoringReportMeet): string {
     const lastUpdatedDate = new Date(meet.LastUpdated);
@@ -19,4 +19,5 @@ export interface EventScoresProps {
     isPrinting?: boolean;
     printingStatsFormat?: StatsFormat;
     parentTabId?: string;
+    selectedMeets?: MeetReference[];
 };


### PR DESCRIPTION
* **Hide Header when printing**
Hid the search box (#1677) and event title (#1682) when printing the page as this is just using up space. Furthermore, the title and search only appears on the first page. Subsequent events are missing the data.

* **Fixed Close Button on Print Dialog**
The `Close` button wasn't working correctly due to a missing event handler. This change adds the missing event handler.

* **Fixed Cancel Button on Print Dialog**
The `Cancel` button on the browser's print dialog caused an error to occur as the page attempted to remove the `QStats` tab a second time. This change addresses #1674 by hiding the element instead of removing it. This allows the code to be repeatable and avoids the error.

* **Moved Current Season**
The `Current Season` was confusing (#1671) in its current location as it causes users to believe it is already expanded. This change moves the TBQ version of `Current Season` to appear above `Next Season` (same behavior as JBQ).

* **Fixed Print Dialog Meet Filter**
The meets selected in the Print Dialog on the web site aren't honored when printing a page. This change addresses #1681 by honoring the settings.