### PR TITLE
Fix navigation within Current Season and null reference bug

### DIFF
--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -68,11 +68,13 @@ import EventScopeBadge from "./EventScopeBadge";
         `${PrintDialogModalId}-button`,
     )!;
 
-    const title = button.closest("h1.page-title");
-    if (title && title.classList.contains("hide-on-print")) {
-        const ancestor = title.closest("div.content-panel");
-        if (ancestor) {
-            ancestor.classList.add("hide-on-print");
+    if (button) {
+        const title = button.closest("h1.page-title");
+        if (title && title.classList.contains("hide-on-print")) {
+            const ancestor = title.closest("div.content-panel");
+            if (ancestor) {
+                ancestor.classList.add("hide-on-print");
+            }
         }
     }
 </script>

--- a/src/content/docs/tbq/Seasons/2026/awards.mdx
+++ b/src/content/docs/tbq/Seasons/2026/awards.mdx
@@ -2,7 +2,7 @@
 title: "Awards"
 sidebar:
     label: Awards
-    order: 20
+    order: -8
     attrs:
         icon: fas faTrophy
 ---


### PR DESCRIPTION
* **Fix Current Season Navigation**
#1684 missed moving `Awards` above `Nationals` within `Current Season` to eliminate the possibility of a group being above a leaf node as this is difficult to distinguish in the UI.

* **Addressed Null Reference Bug**
The `PageTitle` throws an error whenever there isn't a print button on the page with the changes from #1684.