### PR TITLE
Fix frontmatter for indexing

### DIFF
--- a/src/content/docs/jbq/index.mdx
+++ b/src/content/docs/jbq/index.mdx
@@ -1,7 +1,9 @@
 ---
 title: "Junior Bible Quiz"
-description: "An exciting way to teach kids using games with questions and answers about the Bible using 576 questions
-    teaching about the Bible covering Genesis to Revelation from the Bible Fact-Pak."
+description: |
+    An exciting way to teach kids using games with questions and answers about the Bible
+    using 576 questions teaching about the Bible covering Genesis to Revelation from the Bible
+    Fact-Pak.
 tableOfContents: false
 eventType: jbq
 showSeasonButtons: true

--- a/src/content/docs/tbq/index.mdx
+++ b/src/content/docs/tbq/index.mdx
@@ -1,9 +1,11 @@
 ---
 title: "Teen Bible Quiz"
-description: "Discipleship ministry geared for grades 6 - 12 memorizing different book(s) of the New Testament each year. Competitions
-are happening across the nation at tournaments, league, district, regional, and national level events. Each year, thousands
-of dollars in scholarships are awarded to students for their hard work. If you love God, enjoy the thrill of competition, and
-want to have fun, then TBQ is for you!"
+description: |
+    Discipleship ministry geared for grades 6 - 12 memorizing different book(s) of the New
+    Testament each year. Competitions are happening across the nation at tournaments, league, 
+    district, regional, and national level events. Each year, thousands of dollars in
+    scholarships are awarded to students for their hard work. If you love God, enjoy the
+    thrill of competition, and want to have fun, then TBQ is for you!
 eventType: tbq
 showSeasonButtons: true
 sidebar:


### PR DESCRIPTION
The Quizzer Index is built during the same process that refreshes the list of events. This is currently failing due to invalid YAML in the frontmatter. This change fixes the frontmatter.