### PR TITLE
Add Filter by Event Type

### DIFF
--- a/src/components/EventListContent.tsx
+++ b/src/components/EventListContent.tsx
@@ -91,7 +91,7 @@ export default function EventListContent({
     }
 
     const filteredEvents = eventFilters
-        ? mergedEvents.filter(event => matchesFilter(eventFilters, event.info, event.type))
+        ? mergedEvents.filter(event => matchesFilter(eventFilters, event.urlSlug, event.info, event.type))
         : mergedEvents;
 
     if (filteredEvents.length === 0) {

--- a/src/components/apps/liveAndUpcoming/LiveAndUpcomingRoot.tsx
+++ b/src/components/apps/liveAndUpcoming/LiveAndUpcomingRoot.tsx
@@ -44,7 +44,7 @@ function renderEventSection(
     }
 
     const filteredEvents = eventFilters
-        ? events.filter(event => matchesFilter(eventFilters, event.info, event.type))
+        ? events.filter(event => matchesFilter(eventFilters, event.urlSlug, event.info, event.type))
         : events;
 
     return (
@@ -203,6 +203,7 @@ export default function LiveAndUpcomingRoot({
             <EventListFilters
                 regions={regions}
                 districts={districts}
+                allowTypeFilter={true}
             />
             {renderEventSection("LIVE EVENTS", "success", "faTowerBroadcast", liveEvents, eventFilters, true)}
             {renderEventSection("JUST HAPPENED", "info", "faClockRotateLeft", recentEvents, eventFilters, true)}

--- a/src/utils/SharedState.ts
+++ b/src/utils/SharedState.ts
@@ -124,6 +124,11 @@ export interface EventFilterConfiguration {
      * Temporary override for the type filter from the URL parameter. This won't be persisted.
      */
     typeFilterOverride: "jbq" | "tbq" | undefined;
+
+    /**
+     * Filter on the URL prefix for different types of events.
+     */
+    urlPrefix: string | undefined;
 }
 
 export const $eventFilters = atom<EventFilterConfiguration>({ isLoaded: false } as EventFilterConfiguration);


### PR DESCRIPTION
* **Add Filter by Event Type**
Introduced a new filter by event type (e.g., Tournaments) in the event filters. This makes it easier to trim down the matching events.

* **Add JBQ & TBQ Filter on Home Page**