### PR TITLE
Fix linked meet handling

### DIFF
--- a/src/components/scores/TeamOrRoomScheduleTabContent.tsx
+++ b/src/components/scores/TeamOrRoomScheduleTabContent.tsx
@@ -195,7 +195,8 @@ export default function TeamOrRoomScheduleTabContent({
                             return (<li key={matchKey} className="ml-6">BYE</li>);
                         }
 
-                        const resolvedMeet = !meet.HasLinkedMeets || !(matchItem as ScoringReportRoomMatch).LinkedMeet
+                        const resolvedMeet = !meet.HasLinkedMeets || 
+                            (!(matchItem as ScoringReportRoomMatch).LinkedMeet && (matchItem as ScoringReportRoomMatch).LinkedMeet !== 0)
                             ? meet
                             : event.Report.Meets[(matchItem as ScoringReportRoomMatch).LinkedMeet!];
 


### PR DESCRIPTION
If the linked meet has a `0` index, it is treated as not present, which can lead to bugs. This change addresses this filtering issue.