### PR TITLE
Add Live Events to the Current Season Page

### DIFF
--- a/src/components/EventList.astro
+++ b/src/components/EventList.astro
@@ -6,6 +6,7 @@ import type { EventTypeList, EventList } from "types/EventTypes";
 import regions from "data/regions.json";
 import districts from "data/districts.json";
 import EventListContent from "./EventListContent";
+import futureEvents from "data/generated/futureEvents.json";
 
 interface Props {
     season: number;
@@ -56,6 +57,7 @@ const events: EventTypeList | null =
     />
     <EventListContent
         events={events || {}}
+        futureEvents={(futureEvents as any as EventTypeList) || {}}
         loadingElementId="events-fallback"
         containerElementId="events-list"
         excludeMissingDates={source === "generated"}

--- a/src/components/EventListContent.tsx
+++ b/src/components/EventListContent.tsx
@@ -9,6 +9,7 @@ import FontAwesomeIcon from "./FontAwesomeIcon.tsx";
 
 interface Props {
     events: EventTypeList;
+    futureEvents: EventTypeList | null;
     loadingElementId: string;
     containerElementId: string;
     excludeMissingDates: boolean;
@@ -24,54 +25,91 @@ interface EventItem {
 
 export default function EventListContent({
     events,
+    futureEvents,
     loadingElementId,
     containerElementId,
     excludeMissingDates }: Props) {
 
     const eventFilters = useStore($eventFilters);
 
-    const mergedEvents = useMemo(
+    const { mergedEvents, mergedLiveEvents } = useMemo(
         () => {
-            if (!events) {
-                return [];
-            }
-
-            const allEvents: EventItem[] = [];
-
             // Collect all the events.
             const today: Date = new Date();
             today.setHours(0, 0, 0, 0);
 
-            for (const type in events) {
-                const typeEvents = events[type];
-                for (const urlSlug in typeEvents) {
-                    const event = typeEvents[urlSlug];
-                    if (!event.isVisible) {
-                        continue;
-                    }
+            const allEvents: EventItem[] = [];
+            if (events) {
+                for (const type in events) {
+                    const typeEvents = events[type];
+                    for (const urlSlug in typeEvents) {
+                        const event = typeEvents[urlSlug];
+                        if (!event.isVisible) {
+                            continue;
+                        }
 
-                    if (excludeMissingDates && (!event.startDate || !event.endDate)) {
-                        continue;
-                    }
+                        if (excludeMissingDates && (!event.startDate || !event.endDate)) {
+                            continue;
+                        }
 
-                    allEvents.push({
-                        info: event,
-                        sortDate: excludeMissingDates
-                            ? DataTypeHelpers.parseDateOnly(event.startDate)!
-                            : undefined,
-                        type: type,
-                        urlSlug: urlSlug,
-                        isNationals: urlSlug === "nationals/results/",
-                    } as EventItem);
+                        allEvents.push({
+                            info: event,
+                            sortDate: excludeMissingDates
+                                ? DataTypeHelpers.parseDateOnly(event.startDate)!
+                                : undefined,
+                            type: type,
+                            urlSlug: urlSlug,
+                            isNationals: urlSlug === "nationals/results/",
+                        } as EventItem);
+                    }
                 }
             }
 
-            if (excludeMissingDates) {
-                return allEvents.sort((a, b) => b.sortDate!.getTime() - a.sortDate!.getTime());
+            const liveEvents: EventItem[] = [];
+            if (futureEvents) {
+                for (const type in events) {
+                    const typeEvents = events[type];
+                    for (const urlSlug in typeEvents) {
+                        const event = typeEvents[urlSlug];
+                        if (!event.isVisible) {
+                            continue;
+                        }
+
+                        if (!event.startDate || !event.endDate) {
+                            continue;
+                        }
+
+                        const startDate = DataTypeHelpers.parseDateOnly(event.startDate)!;
+                        const endDate = DataTypeHelpers.parseDateOnly(event.endDate)!;
+
+                        const isLive = startDate <= today && endDate >= today;
+                        if (!isLive) {
+                            continue;
+                        }
+
+                        liveEvents.push({
+                            info: event,
+                            sortDate: startDate,
+                            type: type,
+                            urlSlug: urlSlug,
+                            isNationals: urlSlug === "nationals/results/",
+                        } as EventItem);
+                    }
+                }
             }
 
-            return allEvents;
-        }, [events]);
+            const sortedLiveEvents = liveEvents
+                .sort((a, b) => b.sortDate!.getTime() - a.sortDate!.getTime());
+
+            if (excludeMissingDates) {
+                return {
+                    mergedEvents: allEvents.sort((a, b) => b.sortDate!.getTime() - a.sortDate!.getTime()),
+                    mergedLiveEvents: sortedLiveEvents,
+                };
+            }
+
+            return { mergedEvents: allEvents, mergedLiveEvents: sortedLiveEvents };
+        }, [events, futureEvents, excludeMissingDates]);
 
     // Hide the loading element once the page is loaded.
     useEffect(() => {
@@ -90,12 +128,16 @@ export default function EventListContent({
             </div>);
     }
 
+    const filteredLiveEvents = eventFilters
+        ? mergedLiveEvents.filter(event => matchesFilter(eventFilters, event.urlSlug, event.info, event.type))
+        : mergedLiveEvents;
+
     const filteredEvents = eventFilters
         ? mergedEvents.filter(event => matchesFilter(eventFilters, event.urlSlug, event.info, event.type))
         : mergedEvents;
 
-    if (filteredEvents.length === 0) {
-        return (
+    const pastEventsSection = filteredEvents.length === 0
+        ? (
             <div role="alert" className="alert alert-info alert-outline">
                 <FontAwesomeIcon icon="far faLightbulb" />
                 <span className="text-base-content">
@@ -105,25 +147,61 @@ export default function EventListContent({
                         Reset Search Filters</div> button above
                     to clear all filters.
                 </span>
+            </div>)
+        : (
+            <div className="flex flex-wrap gap-4">
+                {filteredEvents.map(event => {
+                    return (
+                        <EventCard
+                            key={event.info.id}
+                            info={{
+                                type: event.type,
+                                urlSlug: event.urlSlug,
+                                event: event.info,
+                                isNationals: event.isNationals,
+                                isRegistrationOpen: false
+                            }}
+                            isLive={true}
+                        />
+                    );
+                })}
             </div>);
-    }
 
     return (
-        <div className="flex flex-wrap gap-4">
-            {filteredEvents.map(event => {
-                return (
-                    <EventCard
-                        key={event.info.id}
-                        info={{
-                            type: event.type,
-                            urlSlug: event.urlSlug,
-                            event: event.info,
-                            isNationals: event.isNationals,
-                            isRegistrationOpen: false
-                        }}
-                        isLive={true}
-                    />
-                );
-            })}
-        </div>);
+        <>
+            {filteredLiveEvents.length > 0 && (
+                <>
+                    <div className="mt-0">
+                        <div className="badge badge-success text-md p-4 mt-0">
+                            <FontAwesomeIcon icon="fas faTowerBroadcast" />
+                            <span className="font-bold">LIVE EVENTS</span>
+                        </div>
+                        <div className="flex flex-wrap gap-4">
+                            {filteredLiveEvents.map(event => {
+                                return (
+                                    <EventCard
+                                        key={event.info.id}
+                                        info={{
+                                            type: event.type,
+                                            urlSlug: event.urlSlug,
+                                            event: event.info,
+                                            isNationals: event.isNationals,
+                                            isRegistrationOpen: false
+                                        }}
+                                        isLive={true}
+                                    />
+                                );
+                            })}
+                        </div>
+                    </div>
+                    <div className="mt-4">
+                        <div className="badge badge-info text-md p-4 mt-0">
+                            <FontAwesomeIcon icon="fas faClockRotateLeft" />
+                            <span className="font-bold">PAST EVENTS</span>
+                        </div>
+                        {pastEventsSection}
+                    </div>
+                </>)}
+            {filteredLiveEvents.length === 0 && pastEventsSection}
+        </>);
 }

--- a/src/components/apps/liveAndUpcoming/LiveAndUpcomingRoot.tsx
+++ b/src/components/apps/liveAndUpcoming/LiveAndUpcomingRoot.tsx
@@ -135,7 +135,7 @@ export default function LiveAndUpcomingRoot({
                             continue;
                         }
 
-                        let startDate = DataTypeHelpers.parseDateOnly(event.startDate)!;
+                        const startDate = DataTypeHelpers.parseDateOnly(event.startDate)!;
                         const endDate = DataTypeHelpers.parseDateOnly(event.endDate)!;
 
                         const eventItem: EventItem = {


### PR DESCRIPTION
Fixes #1816 by adding live events to the current seasons page. This avoids any confusion if the parent or coach goes to the current season looking for the current event.