### PR TITLE
Fix rendering issue on iOS

### DIFF
--- a/src/components/apps/event/scoring/teamsAndQuizzers/BulkTeamRenameDialog.tsx
+++ b/src/components/apps/event/scoring/teamsAndQuizzers/BulkTeamRenameDialog.tsx
@@ -426,7 +426,7 @@ export default function BulkTeamRenameDialog({ teams, onSave, onCancel }: Props)
                         <table className="table table-zebra table-sm w-full">
                             <thead className="bg-base-200">
                                 <tr>
-                                    <th>&nbsp;</th>
+                                    <th className="w-8"></th>
                                     <th>Original Name</th>
                                     <th>Original Church</th>
                                     <th>Final Name</th>


### PR DESCRIPTION
iOS was rendering the drag and drop control as a black box.

<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/dc593b34-9f15-4306-b29f-491425f2e56f" />