### PR TITLE
Fix redirects for the current and past season

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,3 +2,7 @@
 /jbq/live-events/ /?type=jbq 301
 /tbq/live-events /?type=tbq 301
 /tbq/live-events/ /?type=tbq 301
+/scores/jbq /?type=jbq 301
+/scores/jbq/ /?type=jbq 301
+/scores/tbq /?type=tbq 301
+/scores/tbq/ /?type=tbq 301

--- a/src/components/EventListFilters.tsx
+++ b/src/components/EventListFilters.tsx
@@ -32,6 +32,7 @@ const setSharedStateAndPersist = (newFilters: EventFilterConfiguration) => {
  * @param event The event to check against the filter.
  * @param type The type of the event.
  * @param includeHidden Whether to include hidden events in the match check.
+ * @param filterTypeOverride Optional override for the type filter.
  *
  * @returns True if the event matches the filter; otherwise, false.
  */
@@ -40,7 +41,8 @@ export function matchesFilter(
   urlSlug: string,
   event: EventInfo,
   type: string,
-  includeHidden?: boolean): boolean {
+  includeHidden?: boolean,
+  filterTypeOverride?: string): boolean {
 
   if (!event.isVisible && !includeHidden) {
     return false;
@@ -49,7 +51,7 @@ export function matchesFilter(
     return true;
   }
 
-  const requireType = filter.typeFilterOverride ?? filter.typeFilter;
+  const requireType = filterTypeOverride ?? filter.typeFilterOverride ?? filter.typeFilter;
   if (requireType && requireType !== type) {
     return false;
   }

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -18,25 +18,12 @@ import ExcelExportButton from "./scores/ExcelExportButton.astro";
 import PrintDialogButton from "./scores/PrintDialogButton.astro";
 import ToggleFavoritesOnlyButton from "./scores/ToggleFavoritesOnlyButton";
 import EventScopeBadge from "./EventScopeBadge";
-import { getAstroRootSourcePath } from "utils/FileSystem";
-import { fileExists } from "utils/FileSystem";
-import { getSeasons } from "utils/Seasons";
+import { getCurrentSeasonResultsUrl } from "utils/Seasons";
 
-const rootSourcePath = await getAstroRootSourcePath(import.meta.url);
-
-let currentSeasonLink: string | undefined = undefined;
-if (eventType && showSeasonButtons) {
-    const rootSeasonsForType = `${rootSourcePath}/content/docs/${eventType}/Seasons`;
-
-    const seasons = await getSeasons(import.meta.url);
-    if (
-        await fileExists(`${rootSeasonsForType}/${seasons[1]}/results.mdx`)
-    ) {
-        currentSeasonLink = `/${eventType}/seasons/${seasons[1]}/results/`;
-    } else {
-        currentSeasonLink = `/${eventType}/seasons/${seasons[1]}/`;
-    }
-}
+const currentSeasonLink =
+    eventType && showSeasonButtons
+        ? await getCurrentSeasonResultsUrl(import.meta.url, eventType)
+        : undefined;
 
 let resolvedEventType = eventType;
 if (!resolvedEventType) {
@@ -67,18 +54,26 @@ if (!resolvedEventType) {
                     />
                 </div>
             )}
-            <span class="event-title-text">
+            <div class="event-title-text">
                 {title}
                 {description && <p class="italic text-sm">{description}</p>}
                 {showSeasonButtons && currentSeasonLink && (
-                    <a
-                        class="btn btn-primary cursor-pointer hide-on-print whitespace-nowrap"
-                        href={currentSeasonLink}
-                    >
-                        Current Season Results
-                    </a>
+                    <div class="flex flex-wrap items-start gap-2 mt-2">
+                        <a
+                            class="btn btn-primary cursor-pointer hide-on-print whitespace-nowrap"
+                            href={`/?type=${eventType}`}
+                        >
+                            Live & Upcoming Events
+                        </a>
+                        <a
+                            class="btn btn-primary cursor-pointer hide-on-print whitespace-nowrap"
+                            href={currentSeasonLink}
+                        >
+                            Past Results for this Season
+                        </a>
+                    </div>
                 )}
-            </span>
+            </div>
             {eventType && eventId && (
                 <span>
                     <PrintDialogButton isLoaded={eventIsLoaded ?? false} />

--- a/src/components/apps/liveAndUpcoming/LiveAndUpcomingApp.astro
+++ b/src/components/apps/liveAndUpcoming/LiveAndUpcomingApp.astro
@@ -8,16 +8,31 @@ import districts from "data/districts.json";
 
 import path from "path";
 import { getAstroRootSourcePath, tryReadFileAsJson } from "utils/FileSystem";
-import { getSeasons } from "utils/Seasons";
+import { getCurrentSeasonResultsUrl, getSeasons } from "utils/Seasons";
 
-const seasons = await getSeasons(import.meta.url);
-const rootSourcePath = await getAstroRootSourcePath(import.meta.url);
+const metaUrl = import.meta.url;
+const seasons = await getSeasons(metaUrl);
+const rootSourcePath = await getAstroRootSourcePath(metaUrl);
 
-const maxSeasonPath = path.resolve(rootSourcePath, `data/generated/seasons/${seasons[0]}/events.json`);
-const lastSeasonPath = path.resolve(rootSourcePath, `data/generated/seasons/${seasons[1]}/events.json`);
+const maxSeasonPath = path.resolve(
+    rootSourcePath,
+    `data/generated/seasons/${seasons[0]}/events.json`,
+);
+const lastSeasonPath = path.resolve(
+    rootSourcePath,
+    `data/generated/seasons/${seasons[1]}/events.json`,
+);
 
-const recentSeasonEvents = (await tryReadFileAsJson<EventTypeList>(maxSeasonPath)) ??
-    (await tryReadFileAsJson<EventTypeList>(lastSeasonPath));
+const maxSeasonEvents = await tryReadFileAsJson<EventTypeList>(maxSeasonPath);
+
+const currentSeason = maxSeasonEvents ? seasons[0] : seasons[1];
+const currentSeasonLinks = {
+    jbq: await getCurrentSeasonResultsUrl(metaUrl, "jbq"),
+    tbq: await getCurrentSeasonResultsUrl(metaUrl, "tbq"),
+};
+
+const recentSeasonEvents =
+    maxSeasonEvents ?? (await tryReadFileAsJson<EventTypeList>(lastSeasonPath));
 ---
 
 <div id="generator-fallback" class="flex justify-center items-center">
@@ -29,7 +44,8 @@ const recentSeasonEvents = (await tryReadFileAsJson<EventTypeList>(maxSeasonPath
     regions={regions}
     districts={districts}
     recentSeasonEvents={recentSeasonEvents}
-    futureEvents={(futureEvents as any) as EventTypeList}
+    currentSeason={currentSeason}
+    currentSeasonLinks={currentSeasonLinks}
+    futureEvents={futureEvents as any as EventTypeList}
     loadingElementId="generator-fallback"
 />
-

--- a/src/components/apps/liveAndUpcoming/LiveAndUpcomingRoot.tsx
+++ b/src/components/apps/liveAndUpcoming/LiveAndUpcomingRoot.tsx
@@ -1,5 +1,5 @@
 import FontAwesomeIcon from "components/FontAwesomeIcon";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { EventInfo, EventTypeList } from "types/EventTypes";
 import { DataTypeHelpers } from "utils/DataTypeHelpers";
 import EventCard from "./EventCard";
@@ -11,6 +11,8 @@ import { useStore } from "@nanostores/react";
 interface Props {
     regions: RegionInfo[];
     districts: DistrictInfo[];
+    currentSeason: number;
+    currentSeasonLinks: Record<string, string | undefined>;
     recentSeasonEvents: EventTypeList | null;
     futureEvents: EventTypeList | null;
     loadingElementId: string;
@@ -37,14 +39,17 @@ function renderEventSection(
     icon: string,
     events: EventItem[],
     eventFilters: EventFilterConfiguration,
-    isLive: boolean) {
+    typeFilterOverride: string | undefined,
+    isLive: boolean,
+    currentSeason?: number,
+    seasonLink?: string) {
 
     if (events.length === 0) {
         return null;
     }
 
     const filteredEvents = eventFilters
-        ? events.filter(event => matchesFilter(eventFilters, event.urlSlug, event.info, event.type))
+        ? events.filter(event => matchesFilter(eventFilters, event.urlSlug, event.info, event.type, false, typeFilterOverride))
         : events;
 
     return (
@@ -53,46 +58,86 @@ function renderEventSection(
                 <FontAwesomeIcon icon={`fas ${icon}`} />
                 <span className="font-bold">{title}</span>
             </div>
-            {filteredEvents.length > 0 && (
-                <div className="flex flex-wrap gap-4">
-                    {filteredEvents.map(event => {
-                        return (
-                            <EventCard
-                                key={event.info.id}
-                                info={{
-                                    type: event.type,
-                                    urlSlug: event.urlSlug,
-                                    event: event.info,
-                                    isNationals: event.isNationals,
-                                    isRegistrationOpen: event.isRegistrationOpen
-                                }}
-                                isLive={isLive}
-                            />
-                        );
-                    })}
-                </div>)}
-            {filteredEvents.length === 0 && (
-                <div role="alert" className="alert alert-info alert-outline">
-                    <FontAwesomeIcon icon="far faLightbulb" />
-                    <span className="text-base-content">
-                        No events match your filter criteria. Click the
-                        <div className="border-1 p-1 rounded-md inline-block ml-1 mr-1">
-                            <FontAwesomeIcon icon="fas faFilterCircleXmark" />&nbsp;
-                            Reset Search Filters</div> button above
-                        to clear all filters.
-                    </span>
-                </div>)}
+            {seasonLink && (
+                <a
+                    className="card live-events-card w-90 card-sm shadow-sm border-2 border-solid mt-4 relative"
+                    href={seasonLink}
+                    target="_self">
+                    <div className="card-body p-2 pl-4">
+                        <div className="mt-3">
+                            <h2 className="card-title">
+                                Past {typeFilterOverride?.toUpperCase()} Events for {currentSeason} Season
+                            </h2>
+                            <p className="text-base mt-1">
+                                Search through the full list of past events across the current season.
+                            </p>
+                        </div>
+                        <FontAwesomeIcon
+                            icon="fas faArrowRight"
+                            classNames={["icon text-lg rtl:flip absolute top-4 right-4"]}
+                        />
+                    </div>
+                </a>)}
+            {!seasonLink && (
+                <>
+                    {filteredEvents.length > 0 && (
+                        <div className="flex flex-wrap gap-4">
+                            {filteredEvents.map(event => {
+                                return (
+                                    <EventCard
+                                        key={event.info.id}
+                                        info={{
+                                            type: event.type,
+                                            urlSlug: event.urlSlug,
+                                            event: event.info,
+                                            isNationals: event.isNationals,
+                                            isRegistrationOpen: event.isRegistrationOpen
+                                        }}
+                                        isLive={isLive}
+                                    />
+                                );
+                            })}
+                        </div>)}
+                    {filteredEvents.length === 0 && (
+                        <div role="alert" className="alert alert-info alert-outline">
+                            <FontAwesomeIcon icon="far faLightbulb" />
+                            <span className="text-base-content">
+                                No events match your filter criteria. Click the
+                                <div className="border-1 p-1 rounded-md inline-block ml-1 mr-1">
+                                    <FontAwesomeIcon icon="fas faFilterCircleXmark" />&nbsp;
+                                    Reset Search Filters</div> button above
+                                to clear all filters.
+                            </span>
+                        </div>)}
+                </>)}
         </div>);
 }
 
 export default function LiveAndUpcomingRoot({
     regions,
     districts,
+    currentSeason,
+    currentSeasonLinks,
     recentSeasonEvents,
     futureEvents,
     loadingElementId }: Props) {
 
     const eventFilters = useStore($eventFilters);
+    const [urlParameters, setUrlParameters] = useState(() => new URLSearchParams(window.location.search));
+
+    useEffect(() => {
+        const handleUrlChange = () => {
+            setUrlParameters(new URLSearchParams(window.location.search));
+        };
+
+        window.addEventListener('popstate', handleUrlChange);
+        return () => window.removeEventListener('popstate', handleUrlChange);
+    }, []);
+
+    // Parse the parameter you need
+    const urlType = useMemo(() => {
+        return urlParameters.get('type') || undefined;
+    }, [urlParameters]);
 
     const { liveEvents, upcomingEvents, recentEvents } = useMemo(
         () => {
@@ -197,10 +242,33 @@ export default function LiveAndUpcomingRoot({
             <EventListFilters
                 regions={regions}
                 districts={districts}
-                allowTypeFilter={true}
+                allowTypeFilter={!urlType}
             />
-            {renderEventSection("LIVE EVENTS", "success", "faTowerBroadcast", liveEvents, eventFilters, true)}
-            {renderEventSection("JUST HAPPENED", "info", "faClockRotateLeft", recentEvents, eventFilters, true)}
-            {renderEventSection("COMING UP", "primary", "faCalendarDays", upcomingEvents, eventFilters, false)}
+            {renderEventSection(
+                "LIVE EVENTS",
+                "success",
+                "faTowerBroadcast",
+                liveEvents,
+                eventFilters,
+                urlType,
+                true)}
+            {renderEventSection(
+                "JUST HAPPENED",
+                "info",
+                "faClockRotateLeft",
+                recentEvents,
+                eventFilters,
+                urlType,
+                true,
+                currentSeason,
+                urlType ? currentSeasonLinks[urlType] : undefined)}
+            {renderEventSection(
+                "COMING UP",
+                "primary",
+                "faCalendarDays",
+                upcomingEvents,
+                eventFilters,
+                urlType,
+                false)}
         </div>);
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,8 +14,8 @@ const frontmatter: StarlightPageFrontmatter = {
         order: 1,
         attrs: {
             icon: "fas faBroadcastTower",
-        }
-    }
+        },
+    },
 };
 ---
 
@@ -24,7 +24,34 @@ const frontmatter: StarlightPageFrontmatter = {
         style="display: flex; flex-direction: column"
         class="home-flex-container mb-0"
     >
-        <div class="m-0">
+        <h1
+            id="type-label"
+            class="page-title mb-4 flex items-center gap-4"
+            style="display:none"
+        >
+            <div class="shrink-0">
+                <img
+                    src={`/assets/logos/jbq/jbq-logo.png`}
+                    alt="Junior Bible Quiz"
+                    width="72"
+                    height="72"
+                    class="event-icon"
+                    id="jbq-title-icon"
+                    style="display:none"
+                />
+                <img
+                    src={`/assets/logos/tbq/tbq-logo.png`}
+                    alt="Teen Bible Quiz"
+                    width="72"
+                    height="72"
+                    class="event-icon"
+                    id="tbq-title-icon"
+                    style="display:none"
+                />
+            </div>
+            <div class="align-middle text-md">LIVE & UPCOMING EVENTS</div>
+        </h1>
+        <div class="m-0" id="type-card-deck">
             <CardGrid>
                 <LinkCard
                     title="Junior Bible Quiz (JBQ)"
@@ -51,4 +78,31 @@ const frontmatter: StarlightPageFrontmatter = {
             <LiveAndUpcomingApp />
         </div>
     </div>
+
+    <script>
+        const titleElement = document.getElementById("type-label");
+        const cardDeckElement = document.getElementById("type-card-deck");
+
+        if (titleElement && cardDeckElement) {
+            const type = new URLSearchParams(window.location.search).get(
+                "type",
+            );
+
+            if (type) {
+                const isTbq = type.toLowerCase() === "tbq";
+                document.getElementById("jbq-title-icon")!.style.display = isTbq
+                    ? "none"
+                    : "";
+                document.getElementById("tbq-title-icon")!.style.display = isTbq
+                    ? ""
+                    : "none";
+
+                titleElement.style.display = "";
+                cardDeckElement.style.display = "none";
+            } else {
+                titleElement.style.display = "none";
+                cardDeckElement.style.display = "";
+            }
+        }
+    </script>
 </StarlightPage>

--- a/src/utils/Seasons.ts
+++ b/src/utils/Seasons.ts
@@ -1,4 +1,4 @@
-import { getAstroRootSourcePath, getFilesByWildcard } from "./FileSystem";
+import { fileExists, getAstroRootSourcePath, getFilesByWildcard } from "./FileSystem";
 
 /**
  * Retrieves all available seasons.
@@ -39,4 +39,33 @@ export async function getSeasons(metaUrl: string, minSeason?: number): Promise<n
     seasons.sort((a, b) => b - a);
 
     return seasons;
+}
+
+/**
+ * Calculates the link to the current season's results page.
+ * @param metaUrl URL for the current module.
+ * @param eventType Type of the event.
+ * 
+ * @returns URL for the current season's results page (if it exists) or the season page if not.
+ */
+export async function getCurrentSeasonResultsUrl(
+    metaUrl: string,
+    eventType: string): Promise<string | undefined> {
+
+    const rootSourcePath = await getAstroRootSourcePath(metaUrl);
+
+    const rootSeasonsForType = `${rootSourcePath}/content/docs/${eventType}/Seasons`;
+
+    const seasons = await getSeasons(metaUrl);
+    for (const season of seasons) {
+        if (await fileExists(`${rootSourcePath}/data/generated/seasons/${season}/events.json`)) {
+            if (
+                await fileExists(`${rootSeasonsForType}/${season}/results.mdx`)
+            ) {
+                return `/${eventType}/seasons/${season}/results/`;
+            } else {
+                return `/${eventType}/seasons/${season}/`;
+            }
+        }
+    }
 }


### PR DESCRIPTION
* **Add ?type Support**
Introduced `?type=<type>` support for events on the home page. There were already redirects to this, but they weren't honored. When this is set, the `Just Happened` section will show a link to the current season.

* **Fixed Redirects**
Moved `/scores/<type>` from Cloudflare redirects to statically defined redirects to `/?type=<type>`.

* **Add Link to the Live & Upcoming Results**
Introduce a link to the `Live & Upcoming Results` page from the `Overview` section for each type of competition.