### PR TITLE
Fix Season Path handling

### DIFF
--- a/src/pages/[type]/seasons/[season]/[container]/[slug].astro
+++ b/src/pages/[type]/seasons/[season]/[container]/[slug].astro
@@ -97,6 +97,7 @@ const { type, season, container, slug } = Astro.params as Props;
 async function getEventIdFromUrl(
     eventsFilePath: string,
     type: string,
+    season: number,
     container: string,
     slug: string,
 ): Promise<EventInfo | null> {
@@ -110,7 +111,7 @@ async function getEventIdFromUrl(
     }
 
     const event = typeEvents[`${container}/${slug}/`] as EventInfo;
-    if (!event) {
+    if (!event || event.season !== season) {
         return null;
     }
 
@@ -129,6 +130,7 @@ const eventInfo =
     (await getEventIdFromUrl(
         path.resolve(rootSourcePath, `data/generated/futureEvents.json`),
         type,
+        parseInt(season as any as string),
         container,
         slug,
     )) ||
@@ -138,6 +140,7 @@ const eventInfo =
             `data/generated/seasons/${season}/events.json`,
         ),
         type,
+        parseInt(season as any as string),
         container,
         slug,
     ));


### PR DESCRIPTION
When an event (e.g., `/districts/northwest`) is in `futureEvents.json`, past events (e.g., 2025 season) will always show the most recent season. This will happen for any scenario where there are non-unique URLs when the season is excluded. This change adds a check for the season.