### PR TITLE
Fix the spacing issue in the table of contents

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -102,10 +102,6 @@ export default defineConfig({
                 {
                     label: "Manage Events",
                     collapsed: true,
-                    badge: {
-                        text: "ALPHA",
-                        variant: "caution"
-                    },
                     items: [
                         {
                             label: "All Events & Reports",

--- a/src/components/sidebar/ReactSidebar.tsx
+++ b/src/components/sidebar/ReactSidebar.tsx
@@ -17,8 +17,7 @@ export interface ReactSidebarManifest {
 }
 
 export interface ReactSidebarBadge {
-    variant: string;
-    class: string;
+    variant: 'info' | 'warning' | 'success' | 'error' | 'primary' | 'secondary' | 'neutral';
     text: string;
 }
 
@@ -29,6 +28,7 @@ export interface ReactSidebarLink {
     icon?: string;
     iconClass?: string[];
     attrs?: any;
+    badge?: ReactSidebarBadge;
     navigate: () => void | Promise<void>;
 }
 

--- a/src/components/sidebar/ReactSidebarSublist.tsx
+++ b/src/components/sidebar/ReactSidebarSublist.tsx
@@ -64,6 +64,11 @@ export default function ReactSidebarSublist({
                                         <FontAwesomeIcon icon={entry.icon} classNames={iconClassNames} />
                                     )}
                                     <span>{entry.label}</span>
+                                    {entry.badge && (
+                                        <div className={`badge badge-${entry.badge.variant}`}>
+                                            {entry.badge.text}
+                                        </div>
+                                    )}
                                 </a>
                             </div>
                         )

--- a/src/content/docs/quizzer-search.mdx
+++ b/src/content/docs/quizzer-search.mdx
@@ -1,5 +1,6 @@
 ---
 title: Quizzer History Search
+tableOfContents: false
 sidebar:
   attrs:
     icon: fas faUsers

--- a/src/pages/manage-events/index.astro
+++ b/src/pages/manage-events/index.astro
@@ -12,6 +12,7 @@ const seasons = await getSeasons(import.meta.url, 2019);
 const frontmatter: StarlightPageFrontmatter = {
     title: "Manage Events",
     hidePageTitle: true,
+    tableOfContents: false,
     pagefind: false,
 };
 ---

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1,7 +1,15 @@
-/* Fix for single-item TOC: When TwoColumnContent hides the right sidebar,
-   make the main pane take full width using CSS :has() selector */
+/* Fix for pages without TOC: make content full width when no right sidebar */
 @media (min-width: 72rem) {
+    /* Case 1: TOC is explicitly disabled via frontmatter (no data-has-toc attribute) */
+    [data-has-sidebar]:not([data-has-toc]) .lg\:sl-flex .main-pane {
+        --sl-content-width: 100%;
+        width: 100%;
+        --sl-content-margin-inline: auto;
+    }
+    
+    /* Case 2: TOC exists but is hidden due to single item (no right-sidebar-container) */
     [data-has-sidebar][data-has-toc] .lg\:sl-flex:not(:has(.right-sidebar-container)) .main-pane {
+        --sl-content-width: 100%;
         width: 100%;
         --sl-content-margin-inline: auto;
     }


### PR DESCRIPTION
* Fixed the spacing issue in the Table of Contents when there was no table of contents.
* Remove the `ALPHA` from the `Manage Events`