### PR TITLE
Enable Bulk Seeding of Divisions

### DIFF
--- a/src/components/apps/event/EventLookupDialog.tsx
+++ b/src/components/apps/event/EventLookupDialog.tsx
@@ -58,7 +58,7 @@ export default function EventLookupDialog({
             const excludeIds = new Set<string>(excludeEventIds ?? []);
 
             if (eventCache?.events && eventCache.season === season) {
-                setAllEvents(eventCache!.events.filter(e => !excludeIds.has(e.id)));
+                setAllEvents(eventCache!.events.filter(e => !excludeIds.has(e.id) && !e.isReport));
             }
             else {
                 AstroEventsService.getOwnedEvents(
@@ -107,7 +107,7 @@ export default function EventLookupDialog({
 
             if (normalizedSearchText &&
                 !event.searchableName.includes(normalizedSearchText) &&
-                event.searchableLocation && !event.searchableLocation.includes(normalizedSearchText)) {
+                (!event.searchableLocation || !event.searchableLocation.includes(normalizedSearchText))) {
                 continue;
             }
 
@@ -120,7 +120,7 @@ export default function EventLookupDialog({
 
     return (
         <dialog ref={dialogRef} className="modal" open>
-            <div className="modal-box w-full max-w-3xl">
+            <div className="modal-box w-full max-w-3xl max-h-[90vh] overflow-y-auto">
                 <h3 className="font-bold text-lg">Select an Event</h3>
                 <button
                     type="button"

--- a/src/components/apps/event/rules/MatchRulesDialog.tsx
+++ b/src/components/apps/event/rules/MatchRulesDialog.tsx
@@ -63,7 +63,18 @@ export default function MatchRulesDialog({
     const validationError = actions.validate();
 
     return (
-        <dialog ref={dialogRef} className="modal" open>
+        <dialog 
+            ref={dialogRef} 
+            className="modal" 
+            open
+            onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                    e.stopPropagation();
+                    onSelect(null);
+                    dialogRef.current?.close();
+                }
+            }}
+        >
             <div className="modal-box w-full max-w-3xl max-h-[90vh] overflow-y-auto">
                 <h3 className="font-bold text-lg">Edit Rules</h3>
                 <button

--- a/src/components/apps/event/rules/MatchRulesDialog.tsx
+++ b/src/components/apps/event/rules/MatchRulesDialog.tsx
@@ -63,9 +63,9 @@ export default function MatchRulesDialog({
     const validationError = actions.validate();
 
     return (
-        <dialog 
-            ref={dialogRef} 
-            className="modal" 
+        <dialog
+            ref={dialogRef}
+            className="modal"
             open
             onKeyDown={(e) => {
                 if (e.key === 'Escape') {

--- a/src/components/apps/event/rules/hooks/useMatchRulesForm.ts
+++ b/src/components/apps/event/rules/hooks/useMatchRulesForm.ts
@@ -60,7 +60,7 @@ export interface UnseatRulesState {
     unseatIfNextRoomGuaranteed: boolean;
     unseatIfPositionGuaranteed: boolean;
     unseatIfCannotAdvance: boolean;
-    endMatchIfAllNextRoomsGuaranteed: boolean;
+    endMatchIfTopPositionsGuaranteed: boolean;
     unseatIfMaxScore: number | null;
 }
 
@@ -128,7 +128,7 @@ function extractUnseatState(rule: UnseatRule | null): UnseatRulesState {
         unseatIfNextRoomGuaranteed: rule?.UnseatIfNextRoomGuaranteed ?? false,
         unseatIfPositionGuaranteed: rule?.UnseatIfPositionGuaranteed ?? false,
         unseatIfCannotAdvance: rule?.UnseatIfCannotAdvance ?? false,
-        endMatchIfAllNextRoomsGuaranteed: rule?.EndMatchIfAllNextRoomsGuaranteed ?? false,
+        endMatchIfTopPositionsGuaranteed: rule?.EndMatchIfTopPositionsGuaranteed ?? false,
         unseatIfMaxScore: rule?.UnseatIfMaxScore ?? null
     };
 }
@@ -314,7 +314,7 @@ export function useMatchRulesForm(initialRules: MatchRules): [MatchRulesFormStat
         unseat.UnseatIfNextRoomGuaranteed = unseatRules.unseatIfNextRoomGuaranteed;
         unseat.UnseatIfPositionGuaranteed = unseatRules.unseatIfPositionGuaranteed;
         unseat.UnseatIfCannotAdvance = unseatRules.unseatIfCannotAdvance;
-        unseat.EndMatchIfAllNextRoomsGuaranteed = unseatRules.endMatchIfAllNextRoomsGuaranteed;
+        unseat.EndMatchIfTopPositionsGuaranteed = unseatRules.endMatchIfTopPositionsGuaranteed;
         unseat.UnseatIfMaxScore = unseatRules.unseatIfMaxScore;
         newRules.UnseatRule = unseat;
 

--- a/src/components/apps/event/rules/sections/UnseatRulesSection.tsx
+++ b/src/components/apps/event/rules/sections/UnseatRulesSection.tsx
@@ -57,12 +57,12 @@ export default function UnseatRulesSection({ state, onChange, disabled = false }
                         <input
                             type="checkbox"
                             className="checkbox checkbox-sm checkbox-info"
-                            checked={state.endMatchIfAllNextRoomsGuaranteed}
-                            onChange={e => onChange({ endMatchIfAllNextRoomsGuaranteed: e.target.checked })}
+                            checked={state.endMatchIfTopPositionsGuaranteed}
+                            onChange={e => onChange({ endMatchIfTopPositionsGuaranteed: e.target.checked })}
                             disabled={disabled}
                         />
                         <span className="label-text text-base-content">
-                            End match if top position(s) guaranteed
+                            End match if top 2 guaranteed (except final). Ties for other positions broken arbitrarily.
                         </span>
                     </label>
                 </div>

--- a/src/components/apps/event/scoring/ScoringDatabaseMeetsPage.tsx
+++ b/src/components/apps/event/scoring/ScoringDatabaseMeetsPage.tsx
@@ -58,6 +58,7 @@ export default function ScoringDatabaseMeetsPage() {
     const [isAddingNewTeamDivision, setIsAddingNewTeamDivision] = useState(false);
     const [isAddingNewIndividualDivision, setIsAddingNewIndividualDivision] = useState(false);
     const [isBulkAddingTeamDivisions, setIsBulkAddingTeamDivisions] = useState(false);
+    const [isBulkAddingIndividualDivisions, setIsBulkAddingIndividualDivisions] = useState(false);
     const [confirmDelete, setConfirmDelete] = useState<DeleteConfirmation | undefined>();
 
     // Drag state
@@ -406,6 +407,15 @@ export default function ScoringDatabaseMeetsPage() {
                                 <FontAwesomeIcon icon="fas faPlus" />
                                 Add Individual Division
                             </button>
+                            <button
+                                type="button"
+                                className="btn btn-accent btn-sm mt-0 mb-0"
+                                onClick={() => setIsBulkAddingIndividualDivisions(true)}
+                                disabled={isSaving}
+                            >
+                                <FontAwesomeIcon icon="fas faFileImport" />
+                                Bulk Add Individual Divisions
+                            </button>
                         </>
                     )}
                 </div>
@@ -585,22 +595,26 @@ export default function ScoringDatabaseMeetsPage() {
                 />
             )}
 
-            {isBulkAddingTeamDivisions && (
+            {(isBulkAddingTeamDivisions || isBulkAddingIndividualDivisions) && (
                 <BulkAddDivisionsDialog
                     auth={auth}
                     eventId={eventId}
                     eventType={eventType}
                     databaseId={databaseId!}
                     allMeets={currentDatabase.Meets}
-                    defaultRules={currentDatabase.DefaultTeamRules}
+                    defaultRules={isBulkAddingIndividualDivisions ? currentDatabase.DefaultIndividualRules : currentDatabase.DefaultTeamRules}
                     defaultMatchStartTime={currentDatabase.Settings.DefaultMatchStartTime}
-                    isScoreKeepDatabase={currentDatabase.IsScoreKeep || false}
+                    isIndividualCompetition={isBulkAddingIndividualDivisions}
                     onSave={(updatedDatabase) => {
                         setCurrentDatabase(updatedDatabase);
                         setMeetOrder(updatedDatabase.Meets.map(m => m.Display.Id));
                         setIsBulkAddingTeamDivisions(false);
+                        setIsBulkAddingIndividualDivisions(false);
                     }}
-                    onClose={() => setIsBulkAddingTeamDivisions(false)}
+                    onClose={() => {
+                        setIsBulkAddingTeamDivisions(false);
+                        setIsBulkAddingIndividualDivisions(false);
+                    }}
                 />
             )}
 

--- a/src/components/apps/event/scoring/ScoringDatabaseMeetsPage.tsx
+++ b/src/components/apps/event/scoring/ScoringDatabaseMeetsPage.tsx
@@ -13,6 +13,7 @@ import DivisionScheduleDialog from "./meets/DivisionScheduleDialog";
 import DivisionPlayoffsDialog from "./meets/DivisionPlayoffsDialog";
 import DivisionRankingDialog from "./meets/DivisionRankingDialog";
 import DivisionStatsDialog from "./meets/DivisionStatsDialog";
+import BulkAddDivisionsDialog from "./meets/BulkAddDivisionsDialog";
 import ConfirmationDialog from "components/ConfirmationDialog";
 
 interface PendingDisplayChanges {
@@ -56,6 +57,7 @@ export default function ScoringDatabaseMeetsPage() {
     const [editingMeet, setEditingMeet] = useState<EditingMeet | null>(null);
     const [isAddingNewTeamDivision, setIsAddingNewTeamDivision] = useState(false);
     const [isAddingNewIndividualDivision, setIsAddingNewIndividualDivision] = useState(false);
+    const [isBulkAddingTeamDivisions, setIsBulkAddingTeamDivisions] = useState(false);
     const [confirmDelete, setConfirmDelete] = useState<DeleteConfirmation | undefined>();
 
     // Drag state
@@ -388,6 +390,15 @@ export default function ScoringDatabaseMeetsPage() {
                             </button>
                             <button
                                 type="button"
+                                className="btn btn-accent btn-sm mt-0 mb-0"
+                                onClick={() => setIsBulkAddingTeamDivisions(true)}
+                                disabled={isSaving}
+                            >
+                                <FontAwesomeIcon icon="fas faFileImport" />
+                                Bulk Add Team Divisions
+                            </button>
+                            <button
+                                type="button"
                                 className="btn btn-secondary btn-sm mt-0 mb-0"
                                 onClick={handleAddIndividualDivision}
                                 disabled={isSaving}
@@ -571,6 +582,25 @@ export default function ScoringDatabaseMeetsPage() {
                     isIndividualCompetition={true}
                     onSave={handleDialogSave}
                     onClose={handleDialogClose}
+                />
+            )}
+
+            {isBulkAddingTeamDivisions && (
+                <BulkAddDivisionsDialog
+                    auth={auth}
+                    eventId={eventId}
+                    eventType={eventType}
+                    databaseId={databaseId!}
+                    allMeets={currentDatabase.Meets}
+                    defaultRules={currentDatabase.DefaultTeamRules}
+                    defaultMatchStartTime={currentDatabase.Settings.DefaultMatchStartTime}
+                    isScoreKeepDatabase={currentDatabase.IsScoreKeep || false}
+                    onSave={(updatedDatabase) => {
+                        setCurrentDatabase(updatedDatabase);
+                        setMeetOrder(updatedDatabase.Meets.map(m => m.Display.Id));
+                        setIsBulkAddingTeamDivisions(false);
+                    }}
+                    onClose={() => setIsBulkAddingTeamDivisions(false)}
                 />
             )}
 

--- a/src/components/apps/event/scoring/meets/BulkAddDivisionsDialog.tsx
+++ b/src/components/apps/event/scoring/meets/BulkAddDivisionsDialog.tsx
@@ -1,0 +1,462 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+import FontAwesomeIcon from "components/FontAwesomeIcon";
+import ConfirmationDialog from "components/ConfirmationDialog";
+import type { AuthManager } from "types/AuthManager";
+import type { OnlineDatabaseSummary, OnlineDatabaseMeetSummary } from "types/services/AstroDatabasesService";
+import { AstroMeetsService, type OnlineMeetSettings } from "types/services/AstroMeetsService";
+import type { MatchRules } from "types/MatchRules";
+import SeedFromDivisionsDialog from "./SeedFromDivisionsDialog";
+import DivisionScheduleDialog from "./DivisionScheduleDialog";
+
+interface Props {
+    auth: AuthManager;
+    eventId: string;
+    eventType: string;
+    databaseId: string;
+    allMeets: OnlineDatabaseMeetSummary[];
+    defaultRules: MatchRules;
+    defaultMatchStartTime: string;
+    isScoreKeepDatabase: boolean;
+    onSave: (updatedDatabase: OnlineDatabaseSummary) => void;
+    onClose: () => void;
+}
+
+/**
+ * Dialog for bulk-creating team divisions from a seeding template:
+ *  1. Export a seeding template based on selected source divisions (via SeedFromDivisionsDialog).
+ *  2. Upload the filled-out template to receive an array of in-memory OnlineMeetSettings.
+ *  3. List each parsed division with the ability to edit it via DivisionScheduleDialog
+ *     (using the dialog's in-memory mode so no server round-trip is made per edit).
+ *  4. Save all divisions in a single bulk request via AstroMeetsService.bulkCreateOrUpdateMeets.
+ *
+ * Escape closes this dialog only when no nested dialog is currently open; nested dialogs
+ * stop propagation of their own Escape so the bulk dialog is unaffected.
+ */
+export default function BulkAddDivisionsDialog({
+    auth,
+    eventId,
+    eventType,
+    databaseId,
+    allMeets,
+    defaultRules,
+    defaultMatchStartTime,
+    isScoreKeepDatabase,
+    onSave,
+    onClose
+}: Props) {
+    const dialogRef = useRef<HTMLDialogElement>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const [parsedDivisions, setParsedDivisions] = useState<OnlineMeetSettings[]>([]);
+    const [isDirty, setIsDirty] = useState(false);
+
+    // Operation state
+    const [isDownloadingTemplate, setIsDownloadingTemplate] = useState(false);
+    const [isUploading, setIsUploading] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    // Nested dialog state
+    const [showSeedDialog, setShowSeedDialog] = useState(false);
+    const [editingIndex, setEditingIndex] = useState<number | null>(null);
+    const [showCloseConfirmation, setShowCloseConfirmation] = useState(false);
+
+    /**
+     * Counts the teams (or quizzers, for individual competitions) included in a
+     * parsed OnlineMeetSettings object so the list can show a brief summary.
+     */
+    const getTeamOrQuizzerCount = (settings: OnlineMeetSettings): number => {
+        const schedule = settings.Schedule;
+        if (!schedule) {
+            return 0;
+        }
+        return settings.IsIndividualCompetition
+            ? (schedule.QuizzerIds?.length ?? 0)
+            : (schedule.TeamIds?.length ?? 0);
+    };
+
+    const hasParsedDivisions = parsedDivisions.length > 0;
+    const isAnyNestedDialogOpen = showSeedDialog || editingIndex !== null || showCloseConfirmation;
+
+    const handleClose = useCallback(() => {
+        if (isDirty) {
+            setShowCloseConfirmation(true);
+        } else {
+            onClose();
+        }
+    }, [isDirty, onClose]);
+
+    // Escape key handler - only closes the bulk dialog when no nested dialog is open.
+    // We also stopPropagation so this Escape doesn't bubble further up the DOM.
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (
+                e.key === "Escape"
+                && !isSaving
+                && !isUploading
+                && !isDownloadingTemplate
+                && !isAnyNestedDialogOpen
+            ) {
+                e.preventDefault();
+                e.stopPropagation();
+                handleClose();
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [handleClose, isSaving, isUploading, isDownloadingTemplate, isAnyNestedDialogOpen]);
+
+    /**
+     * Triggered when the user has selected a set of source divisions in the
+     * SeedFromDivisionsDialog (in "selectIds" mode). Downloads the template file.
+     */
+    const handleSeedSelected = useCallback(async (sourceMeetIds: number[]) => {
+        setShowSeedDialog(false);
+        if (sourceMeetIds.length === 0) {
+            return;
+        }
+
+        setError(null);
+        setIsDownloadingTemplate(true);
+        try {
+            await AstroMeetsService.getBulkSeedTemplate(auth, eventId, databaseId, sourceMeetIds);
+        } catch (err: any) {
+            setError(err.message || "Failed to download the bulk seeding template.");
+        } finally {
+            setIsDownloadingTemplate(false);
+        }
+    }, [auth, eventId, databaseId]);
+
+    /**
+     * Handler invoked when a file is selected for upload. Parses the file and
+     * replaces the in-memory list of divisions with the result.
+     */
+    const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        // Always reset the input so the same file can be re-uploaded after edits.
+        if (fileInputRef.current) {
+            fileInputRef.current.value = "";
+        }
+        if (!file) {
+            return;
+        }
+
+        setError(null);
+        setIsUploading(true);
+        try {
+            const formData = new FormData();
+            formData.append("file", file);
+            const result = await AstroMeetsService.parseBulkSeedTemplate(
+                auth,
+                eventId,
+                databaseId,
+                formData,
+            );
+            setParsedDivisions(result);
+            setIsDirty(true);
+        } catch (err: any) {
+            setError(err.message || "Failed to parse the bulk seeding template.");
+        } finally {
+            setIsUploading(false);
+        }
+    };
+
+    /**
+     * Called when the nested DivisionScheduleDialog saves its in-memory edits. Updates
+     * the corresponding entry in parsedDivisions and closes the nested dialog.
+     */
+    const handleDivisionEditSave = useCallback((updated: OnlineMeetSettings) => {
+        if (editingIndex === null) {
+            return;
+        }
+        setParsedDivisions(prev => {
+            const next = [...prev];
+            next[editingIndex] = updated;
+            return next;
+        });
+        setIsDirty(true);
+        setEditingIndex(null);
+    }, [editingIndex]);
+
+    const handleRemoveDivision = (index: number) => {
+        setParsedDivisions(prev => prev.filter((_, i) => i !== index));
+        setIsDirty(true);
+    };
+
+    /**
+     * Saves all parsed divisions in a single bulk request, then closes the dialog.
+     */
+    const handleSave = async () => {
+        if (parsedDivisions.length === 0) {
+            setError("Upload a filled-out bulk seeding template before saving.");
+            return;
+        }
+
+        setError(null);
+        setIsSaving(true);
+        try {
+            const result = await AstroMeetsService.bulkCreateOrUpdateMeets(
+                auth,
+                eventId,
+                databaseId,
+                parsedDivisions,
+            );
+            onSave(result);
+            dialogRef.current?.close();
+        } catch (err: any) {
+            setError(err.message || "Failed to save the divisions.");
+            setIsSaving(false);
+        }
+    };
+
+    const editingDivision = editingIndex !== null ? parsedDivisions[editingIndex] : null;
+
+    const dialogContent = (
+        <dialog ref={dialogRef} className="modal modal-open" open>
+            <div className="modal-box w-full max-w-3xl max-h-[90vh]">
+                <h3 className="font-bold text-lg flex items-center gap-2">
+                    <FontAwesomeIcon icon="fas faFileImport" />
+                    <span>Bulk Add Team Divisions</span>
+                </h3>
+                <button
+                    type="button"
+                    className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+                    onClick={handleClose}
+                    disabled={isSaving || isUploading || isDownloadingTemplate}
+                >✕</button>
+
+                {error && (
+                    <div role="alert" className="alert alert-error mt-4">
+                        <FontAwesomeIcon icon="fas faCircleExclamation" />
+                        <div>
+                            <span className="font-bold">Error: </span>
+                            <span>{error}</span>
+                        </div>
+                    </div>
+                )}
+
+                <div className="mt-4 overflow-y-auto max-h-[65vh]">
+                    <div className="alert alert-info mb-4">
+                        <FontAwesomeIcon icon="fas faCircleInfo" />
+                        <div className="text-sm">
+                            <p className="font-semibold">Bulk Create Team Divisions</p>
+                            <p>
+                                Export a seeding template based on one or more existing divisions,
+                                fill it out with the new divisions you want to create, then upload
+                                it here to create them all in a single step.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2 mb-4">
+                        <button
+                            type="button"
+                            className="btn btn-sm btn-outline"
+                            onClick={() => setShowSeedDialog(true)}
+                            disabled={isSaving || isUploading || isDownloadingTemplate}
+                        >
+                            {isDownloadingTemplate ? (
+                                <>
+                                    <span className="loading loading-spinner loading-sm"></span>
+                                    Downloading Template...
+                                </>
+                            ) : (
+                                <>
+                                    <FontAwesomeIcon icon="fas faDownload" />
+                                    Export Seeding Template
+                                </>
+                            )}
+                        </button>
+
+                        <label className={`btn btn-sm btn-outline ${isSaving || isUploading || isDownloadingTemplate ? "btn-disabled" : ""}`}>
+                            {isUploading ? (
+                                <>
+                                    <span className="loading loading-spinner loading-sm"></span>
+                                    Uploading...
+                                </>
+                            ) : (
+                                <>
+                                    <FontAwesomeIcon icon="fas faUpload" />
+                                    Upload Seeding Template
+                                </>
+                            )}
+                            <input
+                                ref={fileInputRef}
+                                type="file"
+                                accept=".xlsx"
+                                className="hidden"
+                                onChange={handleFileUpload}
+                                disabled={isSaving || isUploading || isDownloadingTemplate}
+                            />
+                        </label>
+                    </div>
+
+                    <div>
+                        <h4 className="font-semibold text-sm mb-2">
+                            Divisions to Create
+                            {hasParsedDivisions && (
+                                <span className="badge badge-info badge-sm ml-2">
+                                    {parsedDivisions.length}
+                                </span>
+                            )}
+                        </h4>
+
+                        {!hasParsedDivisions ? (
+                            <div className="text-center py-8 text-base-content/60 border border-dashed border-base-300 rounded-lg">
+                                <FontAwesomeIcon icon="fas faFileExcel" classNames={["text-3xl", "mb-2"]} />
+                                <p className="text-sm">
+                                    Upload a filled-out bulk seeding template to populate this list.
+                                </p>
+                            </div>
+                        ) : (
+                            <div className="space-y-2">
+                                {parsedDivisions.map((division, index) => (
+                                    <div
+                                        key={`${index}-${division.Name}`}
+                                        className="flex items-center justify-between gap-2 p-3 bg-base-200 rounded-lg"
+                                    >
+                                        <div className="flex-1 min-w-0">
+                                            <div className="font-medium truncate">{division.Name || "(Unnamed)"}</div>
+                                            <div className="text-xs text-base-content/70 mt-1 flex flex-wrap gap-2">
+                                                <span>
+                                                    <FontAwesomeIcon icon={division.IsIndividualCompetition ? "fas faUser" : "fas faUsers"} classNames={["mr-1"]} />
+                                                    {getTeamOrQuizzerCount(division)} {division.IsIndividualCompetition ? "quizzers" : "teams"}
+                                                </span>
+                                                <span>
+                                                    <FontAwesomeIcon icon="fas faDoorOpen" classNames={["mr-1"]} />
+                                                    {division.RoomNames?.length ?? 0} room{(division.RoomNames?.length ?? 0) === 1 ? "" : "s"}
+                                                </span>
+                                            </div>
+                                        </div>
+                                        <div className="flex gap-1">
+                                            <button
+                                                type="button"
+                                                className="btn btn-xs btn-primary"
+                                                onClick={() => setEditingIndex(index)}
+                                                disabled={isSaving || isUploading || isDownloadingTemplate}
+                                            >
+                                                <FontAwesomeIcon icon="fas faPencil" />
+                                                Edit
+                                            </button>
+                                            <button
+                                                type="button"
+                                                className="btn btn-xs btn-error btn-outline"
+                                                onClick={() => handleRemoveDivision(index)}
+                                                disabled={isSaving || isUploading || isDownloadingTemplate}
+                                            >
+                                                <FontAwesomeIcon icon="fas faTrash" />
+                                            </button>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                <div className="mt-4 text-right gap-2 flex justify-end">
+                    <button
+                        type="button"
+                        className="btn btn-sm btn-primary mt-0 mb-0"
+                        onClick={handleSave}
+                        disabled={isSaving || isUploading || isDownloadingTemplate || parsedDivisions.length === 0}
+                    >
+                        {isSaving ? (
+                            <>
+                                <span className="loading loading-spinner loading-sm"></span>
+                                Saving...
+                            </>
+                        ) : (
+                            <>
+                                <FontAwesomeIcon icon="fas faSave" />
+                                Save All Divisions
+                            </>
+                        )}
+                    </button>
+                    <button
+                        type="button"
+                        className="btn btn-sm btn-secondary mt-0 mb-0"
+                        onClick={handleClose}
+                        disabled={isSaving || isUploading || isDownloadingTemplate}
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </div>
+            <form method="dialog" className="modal-backdrop">
+                <button
+                    type="button"
+                    onClick={handleClose}
+                    disabled={isSaving || isUploading || isDownloadingTemplate}
+                >close</button>
+            </form>
+
+            {/* Close confirmation when the user tries to close with unsaved changes */}
+            {showCloseConfirmation && (
+                <ConfirmationDialog
+                    title="Unsaved Changes"
+                    yesLabel="Discard Changes"
+                    noLabel="Keep Editing"
+                    onYes={() => {
+                        setShowCloseConfirmation(false);
+                        onClose();
+                    }}
+                    onNo={() => setShowCloseConfirmation(false)}
+                    className="max-w-md"
+                >
+                    <p className="py-4">
+                        You have unsaved bulk-import changes. Are you sure you want to close
+                        without saving?
+                    </p>
+                </ConfirmationDialog>
+            )}
+
+            {/* Nested SeedFromDivisionsDialog used in selectIds mode to choose
+                which source divisions feed into the seeding template. */}
+            {showSeedDialog && (
+                <SeedFromDivisionsDialog
+                    auth={auth}
+                    eventId={eventId}
+                    databaseId={databaseId}
+                    isIndividualCompetition={false}
+                    mode="selectIds"
+                    title="Select Source Divisions"
+                    submitLabel="Download Template"
+                    submitIcon="fas faDownload"
+                    alertTitle="Export Bulk Seeding Template"
+                    alertDescription="Select the divisions whose teams should be used to seed the new divisions. The order determines the priority when combining seedings across divisions."
+                    onSeed={handleSeedSelected}
+                    onClose={() => setShowSeedDialog(false)}
+                />
+            )}
+
+            {/* Nested DivisionScheduleDialog used in in-memory mode to edit a
+                single parsed division without any per-edit server round-trip. */}
+            {editingDivision && (
+                <DivisionScheduleDialog
+                    auth={auth}
+                    eventId={eventId}
+                    eventType={eventType}
+                    databaseId={databaseId}
+                    meetId={0}
+                    meetName={editingDivision.Name || "New Division"}
+                    allMeets={allMeets}
+                    defaultRules={defaultRules}
+                    defaultMatchStartTime={defaultMatchStartTime}
+                    isScoreKeepDatabase={isScoreKeepDatabase}
+                    isNew={true}
+                    isIndividualCompetition={editingDivision.IsIndividualCompetition}
+                    initialSettings={editingDivision}
+                    onSaveInMemory={handleDivisionEditSave}
+                    // onSave is not used in in-memory mode but is required by the prop type.
+                    onSave={() => { /* no-op in in-memory mode */ }}
+                    onClose={() => setEditingIndex(null)}
+                />
+            )}
+        </dialog>
+    );
+
+    return createPortal(dialogContent, document.body);
+}

--- a/src/components/apps/event/scoring/meets/BulkAddDivisionsDialog.tsx
+++ b/src/components/apps/event/scoring/meets/BulkAddDivisionsDialog.tsx
@@ -72,7 +72,7 @@ export default function BulkAddDivisionsDialog({
         if (!schedule) {
             return 0;
         }
-        return settings.IsIndividualCompetition
+        return isIndividualCompetition
             ? (schedule.QuizzerIds?.length ?? 0)
             : (schedule.TeamIds?.length ?? 0);
     };
@@ -220,7 +220,7 @@ export default function BulkAddDivisionsDialog({
             <div className="modal-box w-full max-w-3xl max-h-[90vh]">
                 <h3 className="font-bold text-lg flex items-center gap-2">
                     <FontAwesomeIcon icon="fas faFileImport" />
-                    <span>Bulk Add Team Divisions</span>
+                    <span>Bulk Add {isIndividualCompetition ? "Individual" : "Team"} Divisions</span>
                 </h3>
                 <button
                     type="button"
@@ -323,8 +323,8 @@ export default function BulkAddDivisionsDialog({
                                             <div className="font-medium truncate">{division.Name || "(Unnamed)"}</div>
                                             <div className="text-xs text-base-content/70 mt-1 flex flex-wrap gap-2">
                                                 <span>
-                                                    <FontAwesomeIcon icon={division.IsIndividualCompetition ? "fas faUser" : "fas faUsers"} classNames={["mr-1"]} />
-                                                    {getTeamOrQuizzerCount(division)} {division.IsIndividualCompetition ? "quizzers" : "teams"}
+                                                    <FontAwesomeIcon icon={isIndividualCompetition ? "fas faUser" : "fas faUsers"} classNames={["mr-1"]} />
+                                                    {getTeamOrQuizzerCount(division)} {isIndividualCompetition ? "quizzers" : "teams"}
                                                 </span>
                                                 <span>
                                                     <FontAwesomeIcon icon="fas faDoorOpen" classNames={["mr-1"]} />
@@ -422,7 +422,7 @@ export default function BulkAddDivisionsDialog({
                     auth={auth}
                     eventId={eventId}
                     databaseId={databaseId}
-                    isIndividualCompetition={false}
+                    isIndividualCompetition={isIndividualCompetition}
                     mode="selectIds"
                     title="Select Source Divisions"
                     submitLabel="Download Template"
@@ -449,7 +449,7 @@ export default function BulkAddDivisionsDialog({
                     defaultMatchStartTime={defaultMatchStartTime}
                     isScoreKeepDatabase={false}
                     isNew={true}
-                    isIndividualCompetition={editingDivision.IsIndividualCompetition}
+                    isIndividualCompetition={isIndividualCompetition}
                     initialSettings={editingDivision}
                     onSaveInMemory={handleDivisionEditSave}
                     // onSave is not used in in-memory mode but is required by the prop type.

--- a/src/components/apps/event/scoring/meets/BulkAddDivisionsDialog.tsx
+++ b/src/components/apps/event/scoring/meets/BulkAddDivisionsDialog.tsx
@@ -8,6 +8,7 @@ import { AstroMeetsService, type OnlineMeetSettings } from "types/services/Astro
 import type { MatchRules } from "types/MatchRules";
 import SeedFromDivisionsDialog from "./SeedFromDivisionsDialog";
 import DivisionScheduleDialog from "./DivisionScheduleDialog";
+import { AstroTeamsAndQuizzersService } from "types/services/AstroTeamsAndQuizzersService";
 
 interface Props {
     auth: AuthManager;
@@ -17,7 +18,7 @@ interface Props {
     allMeets: OnlineDatabaseMeetSummary[];
     defaultRules: MatchRules;
     defaultMatchStartTime: string;
-    isScoreKeepDatabase: boolean;
+    isIndividualCompetition: boolean;
     onSave: (updatedDatabase: OnlineDatabaseSummary) => void;
     onClose: () => void;
 }
@@ -41,7 +42,7 @@ export default function BulkAddDivisionsDialog({
     allMeets,
     defaultRules,
     defaultMatchStartTime,
-    isScoreKeepDatabase,
+    isIndividualCompetition,
     onSave,
     onClose
 }: Props) {
@@ -121,7 +122,7 @@ export default function BulkAddDivisionsDialog({
         setError(null);
         setIsDownloadingTemplate(true);
         try {
-            await AstroMeetsService.getBulkSeedTemplate(auth, eventId, databaseId, sourceMeetIds);
+            await AstroTeamsAndQuizzersService.getRankedSeedReport(auth, eventId, databaseId, sourceMeetIds, isIndividualCompetition);
         } catch (err: any) {
             setError(err.message || "Failed to download the bulk seeding template.");
         } finally {
@@ -148,11 +149,12 @@ export default function BulkAddDivisionsDialog({
         try {
             const formData = new FormData();
             formData.append("file", file);
-            const result = await AstroMeetsService.parseBulkSeedTemplate(
+            const result = await AstroMeetsService.parseSeedReport(
                 auth,
                 eventId,
                 databaseId,
                 formData,
+                isIndividualCompetition,
             );
             setParsedDivisions(result);
             setIsDirty(true);
@@ -197,7 +199,7 @@ export default function BulkAddDivisionsDialog({
         setError(null);
         setIsSaving(true);
         try {
-            const result = await AstroMeetsService.bulkCreateOrUpdateMeets(
+            const result = await AstroMeetsService.bulkCreateMeets(
                 auth,
                 eventId,
                 databaseId,
@@ -426,7 +428,7 @@ export default function BulkAddDivisionsDialog({
                     submitLabel="Download Template"
                     submitIcon="fas faDownload"
                     alertTitle="Export Bulk Seeding Template"
-                    alertDescription="Select the divisions whose teams should be used to seed the new divisions. The order determines the priority when combining seedings across divisions."
+                    alertDescription={`Select the divisions whose ${isIndividualCompetition ? "quizzers" : "teams"} should be used to seed the new divisions. The order determines the priority when combining seedings across divisions.`}
                     onSeed={handleSeedSelected}
                     onClose={() => setShowSeedDialog(false)}
                 />
@@ -445,7 +447,7 @@ export default function BulkAddDivisionsDialog({
                     allMeets={allMeets}
                     defaultRules={defaultRules}
                     defaultMatchStartTime={defaultMatchStartTime}
-                    isScoreKeepDatabase={isScoreKeepDatabase}
+                    isScoreKeepDatabase={false}
                     isNew={true}
                     isIndividualCompetition={editingDivision.IsIndividualCompetition}
                     initialSettings={editingDivision}

--- a/src/components/apps/event/scoring/meets/DivisionScheduleDialog.tsx
+++ b/src/components/apps/event/scoring/meets/DivisionScheduleDialog.tsx
@@ -267,7 +267,7 @@ export default function DivisionScheduleDialog({
 
         const meetIdToLoad = isNew ? 0 : meetId;
 
-        AstroMeetsService.getMeet(auth, eventId, databaseId, meetIdToLoad, isNew ? isIndividualCompetition : false)
+        AstroMeetsService.getMeet(auth, eventId, databaseId, meetIdToLoad, isIndividualCompetition)
             .then(data => applySettings(data, true))
             .catch(err => {
                 setError(err.message || "Failed to load division settings.");

--- a/src/components/apps/event/scoring/meets/DivisionScheduleDialog.tsx
+++ b/src/components/apps/event/scoring/meets/DivisionScheduleDialog.tsx
@@ -232,25 +232,12 @@ export default function DivisionScheduleDialog({
                 setUseOptimizer(!isIndividualCompetition && !!data.Schedule.UseOptimizer);
             }
 
-            // Only honor a preloaded preview when this is a server load for an existing
-            // meet. In-memory edits start out of date so the preview is regenerated.
-            if (treatAsServerLoad && data.MatchTimes && data.Preview && !isNew) {
+            if ((!treatAsServerLoad || !isNew) && data.MatchTimes && data.Preview) {
                 setSchedulePreview(data.Preview);
                 setIsScheduleOutOfDate(false);
-                setHasOriginalSchedule(true);
+                setHasOriginalSchedule(treatAsServerLoad);
 
                 // Initialize match times from the preview
-                const initialMatchTimes: Record<number, string | null> = {};
-                let initialShowMatchTimes = false;
-                for (const [matchId, matchTime] of Object.entries(data.MatchTimes)) {
-                    initialShowMatchTimes = initialShowMatchTimes || !!matchTime;
-                    initialMatchTimes[Number(matchId)] = matchTime;
-                }
-
-                setMatchTimes(initialMatchTimes);
-                setShowMatchTimes(initialShowMatchTimes);
-            } else if (data.MatchTimes) {
-                // Even for in-memory edits, honor explicit match times the caller supplied.
                 const initialMatchTimes: Record<number, string | null> = {};
                 let initialShowMatchTimes = false;
                 for (const [matchId, matchTime] of Object.entries(data.MatchTimes)) {
@@ -784,7 +771,7 @@ export default function DivisionScheduleDialog({
                 } : {})
             };
 
-            // Build the settings to save
+            // Build the settings to save.
             const meetSettings: OnlineMeetSettings = {
                 Name: name.trim(),
                 RoomNames: roomNames,
@@ -792,7 +779,6 @@ export default function DivisionScheduleDialog({
                 MatchRanking: matchRanking ?? OnlineMeetMatchRankingType.HighestPointsWins,
                 CustomRules: useCustomRules ? customRules : null,
                 MatchTimes: matchTimes,
-                IsIndividualCompetition: isIndividualCompetition,
                 VersionId: settings?.VersionId || null,
                 Schedule: updatedSchedule
             };
@@ -801,6 +787,12 @@ export default function DivisionScheduleDialog({
             // in-memory callback and close without making any server request. The caller
             // is responsible for persisting the resulting OnlineMeetSettings later.
             if (onSaveInMemory) {
+                // Since the object will be reused in-memory, the properties supplied by the server must also be populated.
+                (meetSettings as any).Preview = schedulePreview;
+                (meetSettings as any).AllTeams = initialSettings?.AllTeams;
+                (meetSettings as any).AllQuizzers = initialSettings?.AllQuizzers;
+                (meetSettings as any).AllMeetsWithScores = initialSettings?.AllMeetsWithScores;
+
                 onSaveInMemory(meetSettings);
                 dialogRef.current?.close();
                 return;
@@ -945,7 +937,7 @@ export default function DivisionScheduleDialog({
                                     )}
                                 </div>
 
-                                {!isIndividualCompetition && (
+                                {(!isIndividualCompetition && !onSaveInMemory) && (
                                     <div className="p-2 mt-0">
                                         <button
                                             type="button"

--- a/src/components/apps/event/scoring/meets/DivisionScheduleDialog.tsx
+++ b/src/components/apps/event/scoring/meets/DivisionScheduleDialog.tsx
@@ -811,8 +811,7 @@ export default function DivisionScheduleDialog({
                 eventId,
                 databaseId,
                 meetId,
-                meetSettings,
-                useOptimizer
+                meetSettings
             );
 
             onSave(result);

--- a/src/components/apps/event/scoring/meets/DivisionScheduleDialog.tsx
+++ b/src/components/apps/event/scoring/meets/DivisionScheduleDialog.tsx
@@ -39,6 +39,20 @@ interface Props {
     isScoreKeepDatabase: boolean;
     isNew: boolean;
     isIndividualCompetition: boolean;
+    /**
+     * Optional pre-loaded meet settings to seed the dialog with. When provided, the dialog
+     * will skip the AstroMeetsService.getMeet call and use these settings directly. This is
+     * used by callers like the bulk-add flow that need to edit a meet that does not yet
+     * exist on the server.
+     */
+    initialSettings?: OnlineMeetSettings | null;
+    /**
+     * Optional callback for in-memory saves. When provided, the Save button will assemble
+     * the OnlineMeetSettings as usual but invoke this callback with the result instead of
+     * calling AstroMeetsService.createOrUpdateMeet. The dialog will then close (via onClose).
+     * The onSave callback will not be invoked in this case.
+     */
+    onSaveInMemory?: (updatedSettings: OnlineMeetSettings) => void;
     onSave: (updatedDatabase: OnlineDatabaseSummary) => void;
     onClose: () => void;
 }
@@ -56,6 +70,8 @@ export default function DivisionScheduleDialog({
     isScoreKeepDatabase,
     isNew,
     isIndividualCompetition,
+    initialSettings,
+    onSaveInMemory,
     onSave,
     onClose
 }: Props) {
@@ -139,98 +155,138 @@ export default function DivisionScheduleDialog({
         setIsLoading(true);
         setError(null);
 
+        /**
+         * Populates dialog state from a fully-formed OnlineMeetSettings object. Shared between
+         * the server-load path and the in-memory (initialSettings) path so that both behave
+         * consistently. When loading from initialSettings, treatAsServerLoad is false so that
+         * the dialog will not assume there is an existing schedule on the server.
+         */
+        const applySettings = (data: OnlineMeetSettings, treatAsServerLoad: boolean) => {
+            setSettings(data);
+
+            if (treatAsServerLoad && !isNew) {
+                setName(data.Name);
+            } else {
+                // For in-memory edits (initialSettings) we always honor the provided name,
+                // even when isNew is true (new divisions in the bulk flow have a real name).
+                if (data.Name) {
+                    setName(data.Name);
+                }
+            }
+
+            setRoomNames(data.RoomNames || []);
+            setMatchLengthInMinutes(data.MatchLengthInMinutes);
+            setAllTeams(data.AllTeams || {});
+            setAllQuizzers(data.AllQuizzers || {});
+
+            // Custom rules
+            if (data.CustomRules) {
+                setUseCustomRules(true);
+                setCustomRules(data.CustomRules);
+            }
+
+            // Match ranking (for individual competitions)
+            if (data.MatchRanking !== undefined) {
+                setMatchRanking(data.MatchRanking);
+            }
+
+            if (data.Schedule) {
+                // For in-memory edits we always seed from the provided schedule, even
+                // when isNew is true - the bulk flow generates real selections for "new" meets.
+                const seedScheduleSelections = !isNew || !treatAsServerLoad;
+                if (seedScheduleSelections) {
+                    setSelectedTeamIds(data.Schedule.TeamIds || []);
+                    setSelectedQuizzerIds(data.Schedule.QuizzerIds || []);
+                    setLinkedMeetIds(data.Schedule.LinkedMeetIds || []);
+                    setIncludeByesInScores(data.Schedule.IncludeByesInScores || false);
+                    setStartingRoundOverride(data.Schedule.StartingTemplateRoundOverride || null);
+                    setRoundCountOverride(data.Schedule.TemplateRoundCountOverride || null);
+
+                    // Individual competition scheduling options
+                    if (data.Schedule.MinQuizzersPerRoom !== undefined && data.Schedule.MinQuizzersPerRoom !== null) {
+                        setMinQuizzersPerRoom(data.Schedule.MinQuizzersPerRoom);
+                    }
+                    if (data.Schedule.DesiredQuizzersPerRoom !== undefined && data.Schedule.DesiredQuizzersPerRoom !== null) {
+                        setDesiredQuizzersPerRoom(data.Schedule.DesiredQuizzersPerRoom);
+                    }
+                    if (data.Schedule.MaxQuizzersPerRoom !== undefined && data.Schedule.MaxQuizzersPerRoom !== null) {
+                        setMaxQuizzersPerRoom(data.Schedule.MaxQuizzersPerRoom);
+                    }
+                    if (data.Schedule.MaxQuizzersPerSemiFinalRoom !== undefined) {
+                        setMaxQuizzersPerSemiFinalRoom(data.Schedule.MaxQuizzersPerSemiFinalRoom);
+                    }
+                    if (data.Schedule.QuizzerRoomAssignment !== undefined && data.Schedule.QuizzerRoomAssignment !== null) {
+                        setQuizzerRoomAssignment(data.Schedule.QuizzerRoomAssignment);
+                    }
+                    if (data.Schedule.QuizzerRoomOptimization !== undefined && data.Schedule.QuizzerRoomOptimization !== null) {
+                        setQuizzerRoomOptimization(data.Schedule.QuizzerRoomOptimization);
+                    }
+                }
+
+                // Custom schedule from server
+                const hasCustom = data.Schedule.HasCustomSchedule || false;
+                setHasCustomSchedule(hasCustom);
+                if (data.Schedule.CustomSchedule) {
+                    setCustomSchedule(data.Schedule.CustomSchedule);
+                }
+                setUseOptimizer(!isIndividualCompetition && !!data.Schedule.UseOptimizer);
+            }
+
+            // Only honor a preloaded preview when this is a server load for an existing
+            // meet. In-memory edits start out of date so the preview is regenerated.
+            if (treatAsServerLoad && data.MatchTimes && data.Preview && !isNew) {
+                setSchedulePreview(data.Preview);
+                setIsScheduleOutOfDate(false);
+                setHasOriginalSchedule(true);
+
+                // Initialize match times from the preview
+                const initialMatchTimes: Record<number, string | null> = {};
+                let initialShowMatchTimes = false;
+                for (const [matchId, matchTime] of Object.entries(data.MatchTimes)) {
+                    initialShowMatchTimes = initialShowMatchTimes || !!matchTime;
+                    initialMatchTimes[Number(matchId)] = matchTime;
+                }
+
+                setMatchTimes(initialMatchTimes);
+                setShowMatchTimes(initialShowMatchTimes);
+            } else if (data.MatchTimes) {
+                // Even for in-memory edits, honor explicit match times the caller supplied.
+                const initialMatchTimes: Record<number, string | null> = {};
+                let initialShowMatchTimes = false;
+                for (const [matchId, matchTime] of Object.entries(data.MatchTimes)) {
+                    initialShowMatchTimes = initialShowMatchTimes || !!matchTime;
+                    initialMatchTimes[Number(matchId)] = matchTime;
+                }
+
+                setMatchTimes(initialMatchTimes);
+                setShowMatchTimes(initialShowMatchTimes);
+            }
+
+            // Store which meets have scores
+            setMeetsWithScores(data.AllMeetsWithScores || []);
+
+            // Store the initial match length for comparison
+            setPrevMatchLengthInMinutes(data.MatchLengthInMinutes);
+
+            setIsLoading(false);
+        };
+
+        // When initialSettings is provided, skip the server load entirely. This is used
+        // by callers like the bulk-add flow that want to edit a not-yet-persisted meet.
+        if (initialSettings) {
+            applySettings(initialSettings, false);
+            return;
+        }
+
         const meetIdToLoad = isNew ? 0 : meetId;
 
         AstroMeetsService.getMeet(auth, eventId, databaseId, meetIdToLoad, isNew ? isIndividualCompetition : false)
-            .then(data => {
-                setSettings(data);
-
-                if (!isNew) {
-                    setName(data.Name);
-                }
-
-                setRoomNames(data.RoomNames || []);
-                setMatchLengthInMinutes(data.MatchLengthInMinutes);
-                setAllTeams(data.AllTeams || {});
-                setAllQuizzers(data.AllQuizzers || {});
-
-                // Custom rules
-                if (data.CustomRules) {
-                    setUseCustomRules(true);
-                    setCustomRules(data.CustomRules);
-                }
-
-                // Match ranking (for individual competitions)
-                if (data.MatchRanking !== undefined) {
-                    setMatchRanking(data.MatchRanking);
-                }
-
-                if (data.Schedule) {
-                    if (!isNew) {
-                        setSelectedTeamIds(data.Schedule.TeamIds || []);
-                        setSelectedQuizzerIds(data.Schedule.QuizzerIds || []);
-                        setLinkedMeetIds(data.Schedule.LinkedMeetIds || []);
-                        setIncludeByesInScores(data.Schedule.IncludeByesInScores || false);
-                        setStartingRoundOverride(data.Schedule.StartingTemplateRoundOverride || null);
-                        setRoundCountOverride(data.Schedule.TemplateRoundCountOverride || null);
-
-                        // Individual competition scheduling options
-                        if (data.Schedule.MinQuizzersPerRoom !== undefined && data.Schedule.MinQuizzersPerRoom !== null) {
-                            setMinQuizzersPerRoom(data.Schedule.MinQuizzersPerRoom);
-                        }
-                        if (data.Schedule.DesiredQuizzersPerRoom !== undefined && data.Schedule.DesiredQuizzersPerRoom !== null) {
-                            setDesiredQuizzersPerRoom(data.Schedule.DesiredQuizzersPerRoom);
-                        }
-                        if (data.Schedule.MaxQuizzersPerRoom !== undefined && data.Schedule.MaxQuizzersPerRoom !== null) {
-                            setMaxQuizzersPerRoom(data.Schedule.MaxQuizzersPerRoom);
-                        }
-                        if (data.Schedule.MaxQuizzersPerSemiFinalRoom !== undefined) {
-                            setMaxQuizzersPerSemiFinalRoom(data.Schedule.MaxQuizzersPerSemiFinalRoom);
-                        }
-                        if (data.Schedule.QuizzerRoomAssignment !== undefined && data.Schedule.QuizzerRoomAssignment !== null) {
-                            setQuizzerRoomAssignment(data.Schedule.QuizzerRoomAssignment);
-                        }
-                        if (data.Schedule.QuizzerRoomOptimization !== undefined && data.Schedule.QuizzerRoomOptimization !== null) {
-                            setQuizzerRoomOptimization(data.Schedule.QuizzerRoomOptimization);
-                        }
-                    }
-
-                    // Custom schedule from server
-                    const hasCustom = data.Schedule.HasCustomSchedule || false;
-                    setHasCustomSchedule(hasCustom);
-                    setUseOptimizer(!isIndividualCompetition && data.Schedule.UseOptimizer);
-                }
-
-                if (data.MatchTimes && data.Preview && !isNew) {
-                    setSchedulePreview(data.Preview);
-                    setIsScheduleOutOfDate(false);
-                    setHasOriginalSchedule(true);
-
-                    // Initialize match times from the preview
-                    const initialMatchTimes: Record<number, string | null> = {};
-                    let initialShowMatchTimes = false;
-                    for (const [matchId, matchTime] of Object.entries(data.MatchTimes)) {
-                        initialShowMatchTimes = initialShowMatchTimes || !!matchTime;
-                        initialMatchTimes[Number(matchId)] = matchTime;
-                    }
-
-                    setMatchTimes(initialMatchTimes);
-                    setShowMatchTimes(initialShowMatchTimes);
-                }
-
-                // Store which meets have scores
-                setMeetsWithScores(data.AllMeetsWithScores || []);
-
-                // Store the initial match length for comparison
-                setPrevMatchLengthInMinutes(data.MatchLengthInMinutes);
-
-                setIsLoading(false);
-            })
+            .then(data => applySettings(data, true))
             .catch(err => {
                 setError(err.message || "Failed to load division settings.");
                 setIsLoading(false);
             });
-    }, [auth, eventId, databaseId, meetId, isNew, isIndividualCompetition]);
+    }, [auth, eventId, databaseId, meetId, isNew, isIndividualCompetition, initialSettings]);
 
     // Sync room count with schedule preview
     useEffect(() => {
@@ -543,20 +599,31 @@ export default function DivisionScheduleDialog({
         }
     }, [isDirty, onClose]);
 
-    // Handle Escape key to close dialog (only when schedule preview is not in fullscreen)
+    // Handle Escape key to close dialog (only when no nested dialog or fullscreen UI is open).
+    // We always stopPropagation so the Escape doesn't bubble up to a parent dialog (e.g. the
+    // bulk-add dialog) when this dialog is hosted as a nested editor.
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             // Don't handle Escape if schedule preview is in fullscreen mode
-            // (the SchedulePreviewTable component handles it internally)
-            if (e.key === "Escape" && !isSaving && !showLinkedMeetsDialog && !isSchedulePreviewFullscreen) {
+            // (the SchedulePreviewTable component handles it internally), or if a nested
+            // dialog (linked meets, rules editor, close confirmation) is currently open.
+            if (
+                e.key === "Escape"
+                && !isSaving
+                && !showLinkedMeetsDialog
+                && !isEditingRules
+                && !showCloseConfirmation
+                && !isSchedulePreviewFullscreen
+            ) {
                 e.preventDefault();
+                e.stopPropagation();
                 handleClose();
             }
         };
 
         document.addEventListener("keydown", handleKeyDown);
         return () => document.removeEventListener("keydown", handleKeyDown);
-    }, [handleClose, isSaving, showLinkedMeetsDialog, isSchedulePreviewFullscreen]);
+    }, [handleClose, isSaving, showLinkedMeetsDialog, isEditingRules, showCloseConfirmation, isSchedulePreviewFullscreen]);
 
     // Export schedule stats
     const handleExportStats = async () => {
@@ -706,7 +773,15 @@ export default function DivisionScheduleDialog({
                 OptimizedSchedule: isRemovingCustomSchedule ? null : finalPreview?.OptimizedSchedule,
                 StartingTemplateRoundOverride: startingRoundOverride,
                 TemplateRoundCountOverride: roundCountOverride,
-                UseOptimizer: useOptimizer
+                UseOptimizer: useOptimizer,
+                ...(isIndividualCompetition ? {
+                    MinQuizzersPerRoom: minQuizzersPerRoom,
+                    DesiredQuizzersPerRoom: desiredQuizzersPerRoom,
+                    MaxQuizzersPerRoom: maxQuizzersPerRoom,
+                    MaxQuizzersPerSemiFinalRoom: maxQuizzersPerSemiFinalRoom,
+                    QuizzerRoomAssignment: quizzerRoomAssignment,
+                    QuizzerRoomOptimization: quizzerRoomOptimization
+                } : {})
             };
 
             // Build the settings to save
@@ -721,6 +796,15 @@ export default function DivisionScheduleDialog({
                 VersionId: settings?.VersionId || null,
                 Schedule: updatedSchedule
             };
+
+            // When the caller wants an in-memory save (e.g. bulk-add flow), invoke the
+            // in-memory callback and close without making any server request. The caller
+            // is responsible for persisting the resulting OnlineMeetSettings later.
+            if (onSaveInMemory) {
+                onSaveInMemory(meetSettings);
+                dialogRef.current?.close();
+                return;
+            }
 
             const result = await AstroMeetsService.createOrUpdateMeet(
                 auth,

--- a/src/components/apps/event/scoring/meets/SeedFromDivisionsDialog.tsx
+++ b/src/components/apps/event/scoring/meets/SeedFromDivisionsDialog.tsx
@@ -9,6 +9,33 @@ interface Props {
     eventId: string;
     databaseId: string;
     isIndividualCompetition: boolean;
+    /**
+     * Operating mode for the dialog.
+     * - "seed" (default): The selected meet ids are resolved into ranked team/quizzer ids via
+     *   AstroDatabasesService.getRankedTeamsOrQuizzers, and the resulting ids are passed to onSeed.
+     * - "selectIds": The selected meet ids are passed to onSeed directly without any server round-trip.
+     */
+    mode?: "seed" | "selectIds";
+    /**
+     * Override for the dialog title. Defaults to "Seed from Division(s)".
+     */
+    title?: string;
+    /**
+     * Override for the submit button label. Defaults to "Seed" (or "Working..." while running).
+     */
+    submitLabel?: string;
+    /**
+     * Override for the icon shown on the submit button. Defaults to "fas faSeedling".
+     */
+    submitIcon?: string;
+    /**
+     * Override for the alert title. Defaults to "Seed Quizzers from Rankings".
+     */
+    alertTitle?: string;
+    /**
+     * Override for the alert body. Defaults to the seed-from-rankings description.
+     */
+    alertDescription?: string;
     onSeed: (ids: number[]) => void;
     onClose: () => void;
 }
@@ -22,6 +49,12 @@ export default function SeedFromDivisionsDialog({
     eventId,
     databaseId,
     isIndividualCompetition,
+    mode = "seed",
+    title,
+    submitLabel,
+    submitIcon,
+    alertTitle,
+    alertDescription,
     onSeed,
     onClose
 }: Props) {
@@ -47,7 +80,7 @@ export default function SeedFromDivisionsDialog({
         setIsLoading(true);
         setError(null);
 
-        AstroDatabasesService.getMeetsWithRanks(auth, eventId, databaseId)
+        AstroDatabasesService.getMeetsWithRanks(auth, eventId, databaseId, isIndividualCompetition)
             .then(data => {
                 setMeetsWithRanks(data);
                 setIsLoading(false);
@@ -57,6 +90,20 @@ export default function SeedFromDivisionsDialog({
                 setIsLoading(false);
             });
     }, [auth, eventId, databaseId, isIndividualCompetition]);
+
+    // Handle Escape key to close dialog without propagating to parent dialogs.
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape" && !isSeeding) {
+                e.preventDefault();
+                e.stopPropagation();
+                onClose();
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [onClose, isSeeding]);
 
     // Get the order of a meet in the selected list
     const getOrderIndex = (meetId: number): number => {
@@ -143,6 +190,14 @@ export default function SeedFromDivisionsDialog({
             return;
         }
 
+        // In "selectIds" mode, the caller wants the raw selected meet ids without any
+        // server-side resolution. This is used by callers such as the bulk-add flow
+        // where the meet ids feed into a separate template generation step.
+        if (mode === "selectIds") {
+            onSeed([...selectedMeetIds]);
+            return;
+        }
+
         setIsSeeding(true);
         setError(null);
 
@@ -190,12 +245,19 @@ export default function SeedFromDivisionsDialog({
 
     const hasSelectedMeets = selectedMeetIds.length > 0;
 
+    const resolvedTitle = title ?? "Seed from Division(s)";
+    const resolvedSubmitLabel = submitLabel ?? "Seed";
+    const resolvedSubmitWorkingLabel = submitLabel ? `${submitLabel}...` : "Seeding...";
+    const resolvedSubmitIcon = submitIcon ?? "fas faSeedling";
+    const resolvedAlertTitle = alertTitle ?? "Seed Quizzers from Rankings";
+    const resolvedAlertDescription = alertDescription ?? "Select divisions to seed quizzers based on their rankings. The order of divisions determines the priority when combining rankings.";
+
     const dialogContent = (
         <dialog ref={dialogRef} className="modal modal-open" open>
             <div className="modal-box w-full max-w-lg">
                 <h3 className="font-bold text-lg">
-                    <FontAwesomeIcon icon="fas faSeedling" />
-                    <span className="ml-2">Seed from Division(s)</span>
+                    <FontAwesomeIcon icon={resolvedSubmitIcon} />
+                    <span className="ml-2">{resolvedTitle}</span>
                 </h3>
                 <button
                     type="button"
@@ -208,12 +270,8 @@ export default function SeedFromDivisionsDialog({
                     <div className="alert alert-info mb-4">
                         <FontAwesomeIcon icon="fas faCircleInfo" />
                         <div className="text-sm">
-                            <p className="font-semibold">Seed Quizzers from Rankings</p>
-                            <p>
-                                Select divisions to seed quizzers based on their rankings.
-                                The order of divisions determines the priority when combining
-                                rankings.
-                            </p>
+                            <p className="font-semibold">{resolvedAlertTitle}</p>
+                            <p>{resolvedAlertDescription}</p>
                             {hasSelectedMeets && (
                                 <p className="mt-1 text-info-content/80">
                                     <FontAwesomeIcon icon="fas faGripVertical" classNames={["mr-1"]} />
@@ -326,12 +384,12 @@ export default function SeedFromDivisionsDialog({
                         {isSeeding ? (
                             <>
                                 <span className="loading loading-spinner loading-sm"></span>
-                                Seeding...
+                                {resolvedSubmitWorkingLabel}
                             </>
                         ) : (
                             <>
-                                <FontAwesomeIcon icon="fas faSeedling" />
-                                Seed
+                                <FontAwesomeIcon icon={resolvedSubmitIcon} />
+                                {resolvedSubmitLabel}
                             </>
                         )}
                     </button>

--- a/src/types/MatchRules.ts
+++ b/src/types/MatchRules.ts
@@ -252,9 +252,16 @@ export class MatchRules {
                 conditions.push(`at least ${unseatRule.UnseatIfMaxScore} points`);
             }
 
-            if (conditions.length > 0) {
+            const conditionsText = conditions.length > 0 
+                ? ` Unseat if ${conditions.join(" or ")}.`
+                : "";
+            const lineSuffix = unseatRule.EndMatchIfTopPositionsGuaranteed
+                ? " Match ends early if top position(s) are guaranteed (except final match). Ties for other positions broken arbitrarily."
+                : "";
+
+            if (conditionsText || lineSuffix) {
                 lines.push(
-                    `<li><b>(IC Only) Unseating:</b> Unseat if ${conditions.join(" or ")}.${unseatRule.EndMatchIfAllNextRoomsGuaranteed ? " Match ends early if all next rooms are guaranteed." : ""}</li>`,
+                    `<li><b>(IC Only) Unseating:</b>${conditionsText}${lineSuffix}</li>`,
                 );
             }
         }
@@ -377,16 +384,16 @@ export class UnseatRule {
      * Initializes a new instance of the UnseatRule class.
      */
     constructor() {
-        this.UnseatIfNextRoomGuaranteed = true;
+        this.UnseatIfNextRoomGuaranteed = false;
         this.UnseatIfCannotAdvance = false;
         this.UnseatIfPositionGuaranteed = false;
-        this.EndMatchIfAllNextRoomsGuaranteed = false;
+        this.EndMatchIfTopPositionsGuaranteed = false;
     }
 
     /**
-     * Value indicating whether the match should end if all the next rooms are guaranteed based on MatchScheduledRoom.RoutedTeamOrQuizzers.
+     * Value indicating whether the match should end if top position(s) are guaranteed (except final). Other ties will be broken arbitrarily.
      */
-    public EndMatchIfAllNextRoomsGuaranteed: boolean;
+    public EndMatchIfTopPositionsGuaranteed: boolean;
 
     /**
      * Value indicating whether to unseat a quizzer if their next room is guaranteed.

--- a/src/types/services/AstroDatabasesService.ts
+++ b/src/types/services/AstroDatabasesService.ts
@@ -227,6 +227,7 @@ export class AstroDatabasesService {
      * @param auth AuthManager to use for authentication.
      * @param eventId Id for the event.
      * @param databaseId Id for the database.
+     * @param isIndividualCompetition Value indicating whether to include team or individual competitions.
      *
      * @returns List of meets that have ranks.
      */
@@ -234,12 +235,16 @@ export class AstroDatabasesService {
         auth: AuthManager,
         eventId: string,
         databaseId: string,
+        isIndividualCompetition: boolean,
     ): Promise<Record<number, string>> {
         return RemoteServiceUtility.executeHttpRequest<Record<number, string>>(
             auth,
             "GET",
             RemoteServiceUrlBase.Registration,
             `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/meetsWithRanks`,
+            RemoteServiceUtility.getFilteredUrlParameters({
+                isIndividualCompetition,
+            }),
         );
     }
 

--- a/src/types/services/AstroMeetsService.ts
+++ b/src/types/services/AstroMeetsService.ts
@@ -182,6 +182,90 @@ export class AstroMeetsService {
             settings,
         );
     }
+
+    /**
+     * Retrieves a bulk seeding template Excel file for the specified source meets.
+     * The template can then be filled out and uploaded via parseBulkSeedTemplate
+     * to create multiple divisions at once.
+     *
+     * @param auth AuthManager to use for authentication.
+     * @param eventId Id for the event.
+     * @param databaseId Id for the database.
+     * @param sourceMeetIds Ids of the source meets to seed from (in priority order).
+     */
+    public static getBulkSeedTemplate(
+        auth: AuthManager,
+        eventId: string,
+        databaseId: string,
+        sourceMeetIds: number[],
+    ): Promise<void> {
+        return RemoteServiceUtility.downloadFromHttpRequest(
+            auth,
+            "POST",
+            RemoteServiceUrlBase.Registration,
+            `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/meets/bulkSeedTemplate`,
+            undefined,
+            undefined,
+            { MeetIds: sourceMeetIds },
+            true,
+        );
+    }
+
+    /**
+     * Parses an uploaded bulk seeding template file into an array of meet settings
+     * that can be edited in memory and then saved using bulkCreateOrUpdateMeets.
+     *
+     * @param auth AuthManager to use for authentication.
+     * @param eventId Id for the event.
+     * @param databaseId Id for the database.
+     * @param form Form contents with "file" set with the bulk seed template file.
+     *
+     * @returns Parsed list of meet settings.
+     */
+    public static parseBulkSeedTemplate(
+        auth: AuthManager,
+        eventId: string,
+        databaseId: string,
+        form: FormData,
+    ): Promise<OnlineMeetSettings[]> {
+        return RemoteServiceUtility.executeHttpRequest<OnlineMeetSettings[]>(
+            auth,
+            "POST",
+            RemoteServiceUrlBase.Registration,
+            `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/meets/bulkSeedTemplate/parse`,
+            undefined,
+            form,
+            true,
+        );
+    }
+
+    /**
+     * Creates or updates multiple meets in a single request.
+     *
+     * @param auth AuthManager to use for authentication.
+     * @param eventId Id for the event.
+     * @param databaseId Id for the database.
+     * @param settings Settings for each meet. Use a null/0 VersionId for new meets.
+     * @param useOptimizer Value indicating whether to use the optimizer when refreshing schedules.
+     *
+     * @returns Updated database summary.
+     */
+    public static bulkCreateOrUpdateMeets(
+        auth: AuthManager,
+        eventId: string,
+        databaseId: string,
+        settings: OnlineMeetSettings[],
+        useOptimizer: boolean = false,
+    ): Promise<OnlineDatabaseSummary> {
+        return RemoteServiceUtility.executeHttpRequest<OnlineDatabaseSummary>(
+            auth,
+            "PUT",
+            RemoteServiceUrlBase.Registration,
+            `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/meets/bulk`,
+            RemoteServiceUtility.getFilteredUrlParameters({ o: useOptimizer }),
+            settings,
+        );
+    }
 }
 
 /**

--- a/src/types/services/AstroMeetsService.ts
+++ b/src/types/services/AstroMeetsService.ts
@@ -44,6 +44,37 @@ export class AstroMeetsService {
     }
 
     /**
+     * Parses a seed report from a file containing multiple divisions.
+     *
+     * @param auth AuthManager to use for authentication.
+     * @param eventId Id for the event.
+     * @param databaseId Id for the database.
+     * @param form Form contents with "file" set with the file.
+     * @param isIndividualCompetition Value indicating whether the report is for an individual competition.
+     *
+     * @returns Parsed ordered list of teams or quizzers.
+     */
+    public static parseSeedReport(
+        auth: AuthManager,
+        eventId: string,
+        databaseId: string,
+        form: FormData,
+        isIndividualCompetition: boolean = false,
+    ): Promise<OnlineMeetSettings[]> {
+        return RemoteServiceUtility.executeHttpRequest<OnlineMeetSettings[]>(
+            auth,
+            "POST",
+            RemoteServiceUrlBase.Registration,
+            `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/meets/0/seedReport`,
+            RemoteServiceUtility.getFilteredUrlParameters({
+                isIndividualCompetition,
+            }),
+            form,
+            true,
+        );
+    }
+
+    /**
      * Retrieves the current custom schedule template as a file for the meet.
      *
      * @param auth AuthManager to use for authentication.
@@ -80,7 +111,6 @@ export class AstroMeetsService {
      * @param databaseId Id for the database.
      * @param meetId Id for the meet. Use 0 or negative for a new meet.
      * @param settings Settings for the meet.
-     * @param useOptimizer Value indicating whether to use the optimizer when refreshing the schedule.
      *
      * @returns Updated database summary.
      */
@@ -90,14 +120,39 @@ export class AstroMeetsService {
         databaseId: string,
         meetId: number,
         settings: OnlineMeetSettings,
-        useOptimizer: boolean = false,
     ): Promise<OnlineDatabaseSummary> {
         return RemoteServiceUtility.executeHttpRequest<OnlineDatabaseSummary>(
             auth,
             "PUT",
             RemoteServiceUrlBase.Registration,
             `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/meets/${meetId}`,
-            RemoteServiceUtility.getFilteredUrlParameters({ o: useOptimizer }),
+            undefined,
+            settings,
+        );
+    }
+
+    /**
+     * Creates multiple meets.
+     *
+     * @param auth AuthManager to use for authentication.
+     * @param eventId Id for the event.
+     * @param databaseId Id for the database.
+     * @param settings Settings for the meets.
+     *
+     * @returns Updated database summary.
+     */
+    public static bulkCreateMeets(
+        auth: AuthManager,
+        eventId: string,
+        databaseId: string,
+        settings: OnlineMeetSettings[],
+    ): Promise<OnlineDatabaseSummary> {
+        return RemoteServiceUtility.executeHttpRequest<OnlineDatabaseSummary>(
+            auth,
+            "PUT",
+            RemoteServiceUrlBase.Registration,
+            `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/meets/0/bulk`,
+            undefined,
             settings,
         );
     }
@@ -179,90 +234,6 @@ export class AstroMeetsService {
             `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/meets/${meetId}/schedule/stats`,
             RemoteServiceUtility.getFilteredUrlParameters({ o: useOptimizer }),
             undefined,
-            settings,
-        );
-    }
-
-    /**
-     * Retrieves a bulk seeding template Excel file for the specified source meets.
-     * The template can then be filled out and uploaded via parseBulkSeedTemplate
-     * to create multiple divisions at once.
-     *
-     * @param auth AuthManager to use for authentication.
-     * @param eventId Id for the event.
-     * @param databaseId Id for the database.
-     * @param sourceMeetIds Ids of the source meets to seed from (in priority order).
-     */
-    public static getBulkSeedTemplate(
-        auth: AuthManager,
-        eventId: string,
-        databaseId: string,
-        sourceMeetIds: number[],
-    ): Promise<void> {
-        return RemoteServiceUtility.downloadFromHttpRequest(
-            auth,
-            "POST",
-            RemoteServiceUrlBase.Registration,
-            `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/meets/bulkSeedTemplate`,
-            undefined,
-            undefined,
-            { MeetIds: sourceMeetIds },
-            true,
-        );
-    }
-
-    /**
-     * Parses an uploaded bulk seeding template file into an array of meet settings
-     * that can be edited in memory and then saved using bulkCreateOrUpdateMeets.
-     *
-     * @param auth AuthManager to use for authentication.
-     * @param eventId Id for the event.
-     * @param databaseId Id for the database.
-     * @param form Form contents with "file" set with the bulk seed template file.
-     *
-     * @returns Parsed list of meet settings.
-     */
-    public static parseBulkSeedTemplate(
-        auth: AuthManager,
-        eventId: string,
-        databaseId: string,
-        form: FormData,
-    ): Promise<OnlineMeetSettings[]> {
-        return RemoteServiceUtility.executeHttpRequest<OnlineMeetSettings[]>(
-            auth,
-            "POST",
-            RemoteServiceUrlBase.Registration,
-            `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/meets/bulkSeedTemplate/parse`,
-            undefined,
-            form,
-            true,
-        );
-    }
-
-    /**
-     * Creates or updates multiple meets in a single request.
-     *
-     * @param auth AuthManager to use for authentication.
-     * @param eventId Id for the event.
-     * @param databaseId Id for the database.
-     * @param settings Settings for each meet. Use a null/0 VersionId for new meets.
-     * @param useOptimizer Value indicating whether to use the optimizer when refreshing schedules.
-     *
-     * @returns Updated database summary.
-     */
-    public static bulkCreateOrUpdateMeets(
-        auth: AuthManager,
-        eventId: string,
-        databaseId: string,
-        settings: OnlineMeetSettings[],
-        useOptimizer: boolean = false,
-    ): Promise<OnlineDatabaseSummary> {
-        return RemoteServiceUtility.executeHttpRequest<OnlineDatabaseSummary>(
-            auth,
-            "PUT",
-            RemoteServiceUrlBase.Registration,
-            `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/meets/bulk`,
-            RemoteServiceUtility.getFilteredUrlParameters({ o: useOptimizer }),
             settings,
         );
     }

--- a/src/types/services/AstroMeetsService.ts
+++ b/src/types/services/AstroMeetsService.ts
@@ -281,12 +281,6 @@ export interface OnlineMeetSettings {
     MatchTimes?: Record<number, string | null> | null;
 
     /**
-     * Value indicating whether this meet is an individual competition. This can only be set when the meet is created. If this is true, AllQuizzers
-     * will be populated. Otherwise, AllTeams will be populated.
-     */
-    IsIndividualCompetition: boolean;
-
-    /**
      * Version id for the meet. This is used to determine if someone else changed the meet since it was last loaded.
      * This can only be null for a new meet.
      */

--- a/src/types/services/AstroTeamsAndQuizzersService.ts
+++ b/src/types/services/AstroTeamsAndQuizzersService.ts
@@ -115,6 +115,36 @@ export class AstroTeamsAndQuizzersService {
     }
 
     /**
+     * Generates a ranked seeding report that can be used to seed a meet.
+     *
+     * @param auth AuthManager to use for authentication.
+     * @param eventId Id for the event.
+     * @param databaseId Id for the database.
+     * @param rankedMeetIds List of ranked meet ids.
+     * @param isIndividualCompetition Value indicating whether the seeding report is for an individual competition.
+     *
+     * @returns Seeding report for the database.
+     */
+    public static getRankedSeedReport(
+        auth: AuthManager,
+        eventId: string,
+        databaseId: string,
+        rankedMeetIds: number[],
+        isIndividualCompetition: boolean,
+    ): Promise<void> {
+        return RemoteServiceUtility.downloadFromHttpRequest(
+            auth,
+            "GET",
+            RemoteServiceUrlBase.Registration,
+            `${URL_ROOT_PATH}/${eventId}/databases/${databaseId}/teamsAndQuizzers/rankedSeedReport`,
+            RemoteServiceUtility.getFilteredUrlParameters({
+                rankedMeetIds: rankedMeetIds.join(","),
+                isIndividualCompetition,
+            }),
+        );
+    }
+
+    /**
      * Parses a seed report from a file.
      *
      * @param auth AuthManager to use for authentication.

--- a/src/types/services/RemoteServiceUtility.ts
+++ b/src/types/services/RemoteServiceUtility.ts
@@ -309,8 +309,7 @@ export class RemoteServiceUtility {
         let baseUrl: string;
         switch (service) {
             case RemoteServiceUrlBase.Registration:
-                // baseUrl = "https://registration.biblequiz.com";
-                baseUrl = "http://localhost:5002";
+                baseUrl = "https://registration.biblequiz.com";
                 break;
             case RemoteServiceUrlBase.Scores:
                 baseUrl = "https://scores.biblequiz.com";

--- a/src/types/services/RemoteServiceUtility.ts
+++ b/src/types/services/RemoteServiceUtility.ts
@@ -309,7 +309,8 @@ export class RemoteServiceUtility {
         let baseUrl: string;
         switch (service) {
             case RemoteServiceUrlBase.Registration:
-                baseUrl = "https://registration.biblequiz.com";
+                // baseUrl = "https://registration.biblequiz.com";
+                baseUrl = "http://localhost:5002";
                 break;
             case RemoteServiceUrlBase.Scores:
                 baseUrl = "https://scores.biblequiz.com";


### PR DESCRIPTION
* **Add Bulk Seed Support**
Introduce a new workflow to enable the bulk seeding of team and individual Divisions from a single seeding report. This will simplify the work required to setup the new event.

* **Improve the Event Lookup**
Removed reports and updated the search in the Event Lookup dialog to improve how it displays. This change also makes the dialog fit on the page.

* **Enable Escape in MatchRulesDialog**
Enabled the `Escape` key to work in `MatchRulesDialog`, even when it is nested.

* **Renamed EndMatchIfAllNextRoomsGuaranteed to EndMatchIfTopPositionsGuaranteed**
Updated the new rule property to match the server naming.