### PR TITLE
Add National and Master Memorization Award pages

### DIFF
--- a/src/content/docs/tbq/Seasons/2027/discipleship.mdx
+++ b/src/content/docs/tbq/Seasons/2027/discipleship.mdx
@@ -7,9 +7,9 @@ sidebar:
         icon: fas faBookOpenReader
 ---
 
-## Discipleship Requirements
+## Requirements
 
-_2026-2027 BQ Season_
+_The following guidelines are for the 2026-2027 Teen Bible Quiz season over the Gospel of Mark._
 
 1. Read the entire Study Guide over all of the Gospel of Mark.
 
@@ -28,6 +28,10 @@ _2026-2027 BQ Season_
     Read the book **_Radical Obedience_** by Dr. Paul and Carol Alexander, Westbow Press, 2025. The book is a thought provoking and inspiring narrative of two global pilgrims who dared to risk everything to follow Jesus in "radical obedience." Write a 200-word report on the book.
 
     Send the report to your District Bible Quiz Coordinator (DBQC).
+
+## Submission
+
+Each quizzer applying for this award must complete a submission form. The form opens November 1, 2026, and closes May 10, 2027, at 10:00 PM Eastern Time. Your District Bible Quiz Coordinator (DBQC) must certify that you completed the award.
 
 ## Discussion Questions
 

--- a/src/content/docs/tbq/Seasons/2027/master-memorization.mdx
+++ b/src/content/docs/tbq/Seasons/2027/master-memorization.mdx
@@ -1,0 +1,28 @@
+---
+title: "Master Memorization Award"
+sidebar:
+    label: Master Memorization Award
+    order: -7.5
+    attrs:
+        icon: fas faStar
+---
+
+_The following guidelines are for the 2026-2027 Teen Bible Quiz season over the Gospel of Mark._
+
+1. The 2026-2027 "Master Memorization Award" is available to quizzers, grades 6-12, and to all Bible Quiz coaches and officials. The Master Memorization Award rules and guidelines apply to all participants (quizzers, coaches, and officials) who are working on their 2026-2027 Master Memorization Award.
+
+2. The coach or official to whom the quizzer quotes must not be a parent or family member. If the coach or official is a parent or family member of the quizzer, the quizzer must quote to another coach or official in the church. In the event that the parent or family member is the only Bible Quiz coach or official in the church, the quizzer may quote to their youth pastor, youth sponsor, senior pastor, league coordinator, district coordinator, or another adult who has a firm understanding of the quoting rules.
+
+3. All of the Gospel of Mark must be quoted consecutively, in one sitting, within a 80-minute time limit, beginning with Mark chapter one, verse one, and continuing through Mark chapter 16 verse 20. Quoting must be done with each verse, section, and chapter in chronological order, in one sitting, to a Bible Quiz coach or official (or one of the above-named persons) clearly and distinctly so that each word is understood. Participants may not quote verses, sections, or chapters out of order or backwards.
+
+4. The quizzer is permitted 14 mistakes for the entirety of the material when quoting all of the Gospel of Mark. Each word that is omitted, repeated, added, or changed counts as one mistake. If a quizzer corrects himself or herself, the correction still counts as a mistake.
+
+5. If at the end of quoting the entire Gospel of Mark the quizzer has 15 mistakes or more the Gospel of Mark must again be quoted in a 80-minute time limit to obtain the Master Memorization Award.
+
+6. All Contender or XP5 quizzers are eligible for the Master Memorization Award. However, these quizzers must quote the entire Gospel of Mark in its entirety (all 16 chapters), in accordance with the above guidelines, in order to receive the Master Memorization Award.
+
+7. All other National Memorization Award guidelines remain in effect for this award.
+
+## Submission
+
+Each quizzer applying for this award must complete a submission form. The form opens November 1, 2026, and closes May 10, 2027, at 10:00 PM Eastern Time. Your District Bible Quiz Coordinator (DBQC) must certify that you completed the award.

--- a/src/content/docs/tbq/Seasons/2027/national-memorization.mdx
+++ b/src/content/docs/tbq/Seasons/2027/national-memorization.mdx
@@ -1,0 +1,30 @@
+---
+title: "National Memorization Award"
+sidebar:
+    label: National Memorization Award
+    order: -8
+    attrs:
+        icon: fas faCertificate
+---
+
+_The following guidelines are for the 2026-2027 Teen Bible Quiz season over the Gospel of Mark._
+
+1. The Memorization Award is available to quizzers, grades 6-12, and to all Bible Quiz coaches and officials. The Memorization Award rules and guidelines apply to all participants (quizzers, coaches, and officials) who are working on their 2026-2027 National Memorization Award.
+
+2. The coach or official to whom the quizzer quotes must not be a parent or family member. If the coach or official is a parent or family member of the quizzer, the quizzer must quote to another coach or official in the church. In the event that the parent or family member is the only Bible Quiz coach or official in the church, the quizzer may quote to their youth pastor, youth sponsor, senior pastor, league coordinator, district coordinator, or another adult who has a firm understanding of the quoting rules.
+
+3. All quizzers must quote an entire chapter at one sitting, starting at the first verse quoting each verse in order to the end of the chapter, to a Bible Quiz coach or official.
+
+4. The quizzer is permitted four mistakes per chapter. Each word that is omitted, repeated, added, or changed counts as one mistake. If a quizzer corrects themselves, the correction still counts as a mistake.
+
+5. The quizzer may quote the entire chapter as many times as necessary by May 10, 2027, to quote within the four-mistake limit.
+
+6. Each quizzer must quote at least one entire chapter during a Sunday morning, Sunday evening, or Wednesday evening service, small groups, etc. in their local church. The chapter may have been previously quoted to a coach (youth pastor, etc) so that the number of mistakes in the pulpit (public setting) will not hinder their award. Coaches should set the service date with the senior pastor on the church calendar early in 2026-2027 quiz season.
+
+7. Quizzers who compete in the "Championship" division during the 2026-2027 quiz season must quote the entirety of the Gospel of Mark. Quizzers who compete in the "Contender" division are required to quote Mark Chapters 1-8. Quizzers who are competing in the "XP5" division are only required to quote Mark chapters 1, 5, 6, and 8. However, "Contender", and "XP5" quizzers may also quote the entire "Championship" material if they so desire.
+
+8. Only students who complete the "Championship" material, covering all of the Gospel of Mark, will be eligible for any Bible Quiz Memorization Award scholarships offered through many colleges and universities. Students who earn the "Contender", or the "XP5" Memorization Award will NOT be eligible for scholarships from the district/network office, national office or from any colleges or universities (unless specified by that college or university).
+
+## Submission
+
+Each quizzer applying for this award must complete a submission form. The form opens November 1, 2026, and closes May 10, 2027, at 10:00 PM Eastern Time. Your District Bible Quiz Coordinator (DBQC) must certify that you completed the award.


### PR DESCRIPTION
## Summary
- Add National Memorization Award and Master Memorization Award pages for the 2026-2027 (Teen Bible Quiz) season, converted from source Word guideline docs, placed in the sidebar before Discipleship Award
- Add a shared "Submission" section (form window, DBQC certification) to all three award pages
- Rename Discipleship Award's "Discipleship Requirements" heading to "Requirements" and align its intro line with the other two award pages

## Test plan
- [ ] Review rendered pages in Starlight dev preview for correct sidebar ordering, icons, and content